### PR TITLE
Ranch 305 add flex and width rules

### DIFF
--- a/integration-test/Css.ts
+++ b/integration-test/Css.ts
@@ -100,12 +100,14 @@ class CssBuilder<T extends Properties1> {
   get itemsBaseline() { return this.add("alignItems", "baseline"); }
   get itemsStretch() { return this.add("alignItems", "stretch"); }
   items(value: Properties["alignItems"]) { return this.add("alignItems", value); }
-  get fb0() { return this.fb(0); }
-  get fb1() { return this.fb(1); }
-  get fb2() { return this.fb(2); }
-  get fb3() { return this.fb(3); }
-  get fb4() { return this.fb(4); }
-  fb(inc: number | string) { return this.add("flexBasis", px(inc)); }
+  get fb1() { return this.add("flexBasis", "100%"); }
+  get fb2() { return this.add("flexBasis", "50%"); }
+  get fb3() { return this.add("flexBasis", "33.333333%"); }
+  get fb4() { return this.add("flexBasis", "25%"); }
+  get fb5() { return this.add("flexBasis", "20%"); }
+  get fb6() { return this.add("flexBasis", "16.666666%"); }
+  get fb7() { return this.add("flexBasis", "14.285714%"); }
+  get fb0() { return this.add("flexBasis", "12.5%"); }
 
   // heightRules
   get h25() { return this.add("height", "25%"); }
@@ -260,18 +262,15 @@ class CssBuilder<T extends Properties1> {
   get w50() { return this.add("width", "50%"); }
   get w75() { return this.add("width", "75%"); }
   get w100() { return this.add("width", "100%"); }
+  get mw0() { return this.add("minWidth", 0); }
+  get mw100() { return this.add("minWidth", "100%"); }
+  mw(value: Properties["minWidth"]) { return this.add("minWidth", value); }
   get w0() { return this.w(0); }
   get w1() { return this.w(1); }
   get w2() { return this.w(2); }
   get w3() { return this.w(3); }
   get w4() { return this.w(4); }
   w(inc: number | string) { return this.add("width", px(inc)); }
-  get mw0() { return this.mw(0); }
-  get mw1() { return this.mw(1); }
-  get mw2() { return this.mw(2); }
-  get mw3() { return this.mw(3); }
-  get mw4() { return this.mw(4); }
-  mw(inc: number | string) { return this.add("minWidth", px(inc)); }
 
   // visibilityRules
   get visible() { return this.add("visibility", "visible"); }

--- a/src/rules/flexbox.ts
+++ b/src/rules/flexbox.ts
@@ -48,5 +48,18 @@ export const flexboxRules: RuleFn = (config) => [
     "items"
   ),
 
-  ...makeIncRules(config, "fb", "flexBasis")
+  ...makeRules(
+    "flexBasis",
+    // https://github.com/tack-hammer/tailwind-plugin-flex-basis#usage
+    {
+      fb1: "100%",
+      fb2: "50%",
+      fb3: "33.333333%",
+      fb4: "25%",
+      fb5: "20%",
+      fb6: "16.666666%",
+      fb7: "14.285714%",
+      fb0: "12.5%",
+    }
+  )
 ];

--- a/src/rules/widths.ts
+++ b/src/rules/widths.ts
@@ -2,12 +2,24 @@ import { makeIncRules, makeRules } from "../utils";
 import { RuleFn } from "./RuleConfig";
 
 export const widthRules: RuleFn = (config) => [
-  ...makeRules("width", {
-    w25: "25%",
-    w50: "50%",
-    w75: "75%",
-    w100: "100%",
-  }),
+  ...makeRules(
+    "width", 
+    {
+      w25: "25%",
+      w50: "50%",
+      w75: "75%",
+      w100: "100%",
+    },
+  ),
+
+  ...makeRules(
+    "minWidth", 
+    { 
+      mw0: 0, 
+      mw100: "100%" 
+    },
+    "mw",
+  ),
+
   ...makeIncRules(config, "w", "width"),
-  ...makeIncRules(config, "mw", "minWidth"),
 ];


### PR DESCRIPTION
Adds inc rules for `flexBasis` and `minWidth` needed for RANCH-305 originally committed to internal-frontend (https://github.com/homebound-team/internal-frontend/commit/c737ab54504dd77279e5a376f307dfbb3ff10830)