### PR TITLE
let flexBasis accept a value

### DIFF
--- a/integration-test/Css.ts
+++ b/integration-test/Css.ts
@@ -108,6 +108,7 @@ class CssBuilder<T extends Properties1> {
   get fb6() { return this.add("flexBasis", "16.666666%"); }
   get fb7() { return this.add("flexBasis", "14.285714%"); }
   get fb0() { return this.add("flexBasis", "12.5%"); }
+  fb(value: Properties["flexBasis"]) { return this.add("flexBasis", value); }
 
   // heightRules
   get h25() { return this.add("height", "25%"); }

--- a/src/rules/flexbox.ts
+++ b/src/rules/flexbox.ts
@@ -60,6 +60,7 @@ export const flexboxRules: RuleFn = (config) => [
       fb6: "16.666666%",
       fb7: "14.285714%",
       fb0: "12.5%",
-    }
+    },
+    "fb",
   )
 ];


### PR DESCRIPTION
Quick patch to let `flexBasis` accept a value (currently using `Css.add` in place of this)