### PR TITLE
Add "flex", "flexGrow", and "flexShrink" rules.

### DIFF
--- a/integration-test/Css.ts
+++ b/integration-test/Css.ts
@@ -76,6 +76,9 @@ class CssBuilder<T extends Properties1> {
   get dtColumn() { return this.add("display", "tableColumn"); }
   get dtColumnGroup() { return this.add("display", "tableColumnGroup"); }
   get dg() { return this.add("display", "grid"); }
+  get df() { return this.add("display", "flex"); }
+  get dif() { return this.add("display", "inline-flex"); }
+  display(value: Properties["display"]) { return this.add("display", value); }
 
   // flexboxRules
   get justifyStart() { return this.add("justifyContent", "flex-start"); }
@@ -84,10 +87,6 @@ class CssBuilder<T extends Properties1> {
   get justifyBetween() { return this.add("justifyContent", "space-between"); }
   get justifyAround() { return this.add("justifyContent", "space-around"); }
   justify(value: Properties["justifyContent"]) { return this.add("justifyContent", value); }
-  get flex() { return this.add("display", "flex"); }
-  get inlineFlex() { return this.add("display", "inline-flex"); }
-  get flexNone() { return this.add("display", "none"); }
-  display(value: Properties["display"]) { return this.add("display", value); }
   get selfStart() { return this.add("alignSelf", "flex-start"); }
   get selfEnd() { return this.add("alignSelf", "flex-end"); }
   get selfCenter() { return this.add("alignSelf", "center"); }
@@ -109,6 +108,15 @@ class CssBuilder<T extends Properties1> {
   get fb7() { return this.add("flexBasis", "14.285714%"); }
   get fb0() { return this.add("flexBasis", "12.5%"); }
   fb(value: Properties["flexBasis"]) { return this.add("flexBasis", value); }
+  get flexAuto() { return this.add("flex", "auto"); }
+  get flexNone() { return this.add("flex", "none"); }
+  flex(value: Properties["flex"]) { return this.add("flex", value); }
+  get fg0() { return this.add("flexGrow", 0); }
+  get fg1() { return this.add("flexGrow", 1); }
+  flexGrow(value: Properties["flexGrow"]) { return this.add("flexGrow", value); }
+  get fs0() { return this.add("flexShrink", 0); }
+  get fs1() { return this.add("flexShrink", 1); }
+  flexShrink(value: Properties["flexShrink"]) { return this.add("flexShrink", value); }
 
   // heightRules
   get h25() { return this.add("height", "25%"); }

--- a/src/rules/display.ts
+++ b/src/rules/display.ts
@@ -3,16 +3,21 @@ import { makeRules } from "../utils";
 
 // https://github.com/tachyons-css/tachyons/blob/master/src/_display.css
 export const displayRules: RuleFn = () =>
-  makeRules("display", {
-    dn: "none",
-    db: "block",
-    dib: "inlineBlock",
-    dit: "inlineTable",
-    dt: "table",
-    dtc: "tableCell",
-    dtRow: "tableRow",
-    dtColumn: "tableColumn",
-    dtColumnGroup: "tableColumnGroup",
-    // added
-    dg: "grid",
-  });
+  makeRules("display",
+    {
+      dn: "none",
+      db: "block",
+      dib: "inlineBlock",
+      dit: "inlineTable",
+      dt: "table",
+      dtc: "tableCell",
+      dtRow: "tableRow",
+      dtColumn: "tableColumn",
+      dtColumnGroup: "tableColumnGroup",
+      // added
+      dg: "grid",
+      df: "flex",
+      dif: "inline-flex",
+    },
+    "display"
+  );

--- a/src/rules/flexbox.ts
+++ b/src/rules/flexbox.ts
@@ -15,16 +15,6 @@ export const flexboxRules: RuleFn = (config) => [
   ),
 
   ...makeRules(
-    "display",
-    {
-      flex: "flex",
-      inlineFlex: "inline-flex",
-      flexNone: "none",
-    },
-    "display"
-  ),
-
-  ...makeRules(
     "alignSelf",
     {
       selfStart: "flex-start",
@@ -62,5 +52,12 @@ export const flexboxRules: RuleFn = (config) => [
       fb0: "12.5%",
     },
     "fb",
-  )
+  ),
+
+  // https://github.com/tachyons-css/tachyons/blob/master/src/_flexbox.css#L17
+  ...makeRules("flex", { flexAuto: "auto", flexNone: "none" }, "flex"),
+
+  // https://github.com/tachyons-css/tachyons/blob/master/src/_flexbox.css#L69
+  ...makeRules("flexGrow", { fg0: 0, fg1: 1 }, "flexGrow"),
+  ...makeRules("flexShrink", { fs0: 0, fs1: 1 }, "flexShrink"),
 ];


### PR DESCRIPTION
Defines some preset "flex", "flexGrow" and "flexShrink" rules and the ability to customize.
Replaces "flexNone" which was outputting "display: none", to output the short hand "flex: none;". "flexAuto" outputs the shorthand of "flex: auto;"

Adds in shorthands version of flex-grow: 0 | 1; and flex-shring: 0 | 1; These are the most widely used values for this property, however there are times where we may use a number greater than 1 in order to maintain ratios, so adding the ability to customize "flexGrow" and "flexShrink".

Moves "flex" and "inlineFlex" to be under the "display" rules, which I think makes more sense. Renames them from "flex" to "df" and "inlineFlex" to "dif". Will need to update consuming repos when pull in the latest version of truss.