### PR TITLE
Add better breakpoint support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
           steps:
             - run: npm install
       - run: npm run build
+      - run: npm run test
       - when:
           condition: <<parameters.publish>>
           steps:

--- a/README.markdown
+++ b/README.markdown
@@ -103,8 +103,6 @@ function MyReactComponent(props: ...) {
 
 This leveraging of the existing framework's selector support makes Truss's DSL shorter and simpler than Tachyons/Tailwinds, which have to repetively/pre-emptively mixin hover/media variations for each size into each abbreviation.
 
-(Note that Truss could probably learn a syntax like `Css.mx2.black.if(sm).mx1.$` but that is not implemented yet.)
-
 ## XStyles / Xss Extension Contracts
 
 Truss liberally borrows the idea of type-checked "extension" CSS from the currently-unreleased Facebook XStyles library (at least in theory; I've only seen one or two slides for this feature of XStyles, but I'm pretty sure Truss is faithful re-implementation of it).
@@ -189,6 +187,8 @@ const fonts = {
   f12: "12px",
   f10: "10px",
 };
+
+const breakpoints = { sm: 0, md: 600, lg: 960 };
 
 // ...rest of the config file...
 ```

--- a/integration-test/Css.test.tsx
+++ b/integration-test/Css.test.tsx
@@ -2,7 +2,7 @@
 import { Button } from "@material-ui/core";
 import { jsx } from "@emotion/core";
 import { render } from "@testing-library/react";
-import { Css, Only, Properties } from "./Css";
+import { Css, Only, Properties, sm } from "./Css";
 
 describe("Css", () => {
   it("can add mb", () => {
@@ -220,6 +220,52 @@ describe("Css", () => {
         "marginBottom": "8px !important",
       }
     `);
+  });
+
+  it("can use generated breakpoints with emotion", () => {
+    const r = render(<div css={{ ...Css.mb1.pb2.$, [sm]: Css.pb3.$ }} />);
+    expect(r.container).toMatchInlineSnapshot(`
+      .emotion-0 {
+        margin-bottom: 8px;
+        padding-bottom: 16px;
+      }
+
+      @media screen and (max-width:599px) {
+        .emotion-0 {
+          padding-bottom: 24px;
+        }
+      }
+
+      <div>
+        <div
+          class="emotion-0"
+        />
+      </div>
+    `);
+  });
+
+  it("can use generated breakpoints with if dsl", () => {
+    expect(Css.pb2.white.if(sm).pb3.black.$).toMatchInlineSnapshot(`
+      Object {
+        "@media screen and (max-width:599px)": Object {
+          "color": "#353535",
+          "paddingBottom": "24px",
+        },
+        "color": "#fcfcfa",
+        "paddingBottom": "16px",
+      }
+    `);
+  });
+
+  it("will not accept just random strings to if", () => {
+    // @ts-expect-error
+    Css.black.if("rawstring").$;
+  });
+
+  it("cannot 'else' when using `if(bp)`", () => {
+    expect(() => Css.if(sm).black.else.white.$).toThrow(
+      "else is not supported"
+    );
   });
 });
 

--- a/integration-test/index.ts
+++ b/integration-test/index.ts
@@ -20,6 +20,8 @@ const fonts = {
   f10: "10px",
 };
 
+const breakpoints = { sm: 0, md: 600, lg: 960 };
+
 const methods = generateRules({ palette, fonts, numberOfIncrements });
 
 // Add/remove application-specific/one-off rules as needed.
@@ -39,6 +41,7 @@ generate({
   increment,
   aliases,
   extras,
+  breakpoints,
 }).then(
   () => console.log("done"),
   (err) => console.error(err)

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { RuleConfig } from "./rules";
-import { makeIncRules } from "./utils";
+import { makeBreakpoints, makeIncRules } from "./utils";
 
 describe("utils", () => {
   const config: RuleConfig = { numberOfIncrements: 3, fonts: {}, palette: {} };
@@ -40,6 +40,51 @@ describe("utils", () => {
           "m(inc: number | string) { return this.mt(inc).mr(inc).mb(inc).ml(inc); }",
         ]
       `);
+    });
+  });
+
+  describe("makeBreakpoints", () => {
+    it("works with one breakpoint", () => {
+      // this doesn't really make sense, but just make sure it doesn't blow up
+      expect(makeBreakpoints({ sm: 0 })).toEqual({
+        sm: "@media screen and (max-width:0)",
+      });
+    });
+
+    it("works with two breakpoints", () => {
+      expect(makeBreakpoints({ sm: 0, lg: 600 })).toEqual({
+        sm: "@media screen and (max-width:599px)",
+        lg: "@media screen and (min-width:600px)",
+        smOrLg: "@media screen",
+      });
+    });
+
+    it("works with three breakpoints", () => {
+      expect(makeBreakpoints({ sm: 0, md: 600, lg: 960 })).toEqual({
+        sm: "@media screen and (max-width:599px)",
+        md: "@media screen and (min-width:600px) and (max-width:959px)",
+        lg: "@media screen and (min-width:960px)",
+        smOrMd: "@media screen and (max-width:959px)",
+        mdOrLg: "@media screen and (min-width:600px)",
+        mdAndUp: "@media screen and (min-width:600px)",
+        mdAndDown: "@media screen and (max-width:959px)",
+      });
+    });
+
+    it("works with four breakpoints", () => {
+      expect(makeBreakpoints({ sm: 0, md: 600, lg: 960, xl: 1200 })).toEqual({
+        sm: "@media screen and (max-width:599px)",
+        md: "@media screen and (min-width:600px) and (max-width:959px)",
+        lg: "@media screen and (min-width:960px) and (max-width:1199px)",
+        xl: "@media screen and (min-width:1200px)",
+        smOrMd: "@media screen and (max-width:959px)",
+        mdOrLg: "@media screen and (min-width:600px) and (max-width:1199px)",
+        lgOrXl: "@media screen and (min-width:960px)",
+        mdAndUp: "@media screen and (min-width:600px)",
+        mdAndDown: "@media screen and (max-width:959px)",
+        lgAndUp: "@media screen and (min-width:960px)",
+        lgAndDown: "@media screen and (max-width:1199px)",
+      });
     });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,7 +72,63 @@ export function makeIncRules(
   }
 }
 
+/** Turns a high-level `{ sm: 0, md: 200 }` breakpoint config into a useful set of multiple media queries. */
+export function makeBreakpoints(
+  breakpoints: Record<string, number>
+): Record<string, string> {
+  const r: Record<string, string> = {};
+  const bps = Object.keys(breakpoints);
+  Object.entries(breakpoints).forEach(([bp, px], i) => {
+    const isFirst = i === 0;
+    const isLast = i === bps.length - 1;
+    // Calc this breakpoint's min/max, which is its px --> the next bp's px - 1
+    const min = !isFirst ? `${px}px` : "0";
+    const max = !isLast ? `${breakpoints[bps[i + 1]] - 1}px` : "0";
+
+    // Make a rule for exactly this breakpoint, i.e. "just sm" or "just md".
+    if (isFirst) {
+      // Don't bother with min-width on the smallest bp
+      r[bp] = `@media screen and (max-width:${max})`;
+    } else if (isLast) {
+      // Don't bother with max-width on the largest bp
+      r[bp] = `@media screen and (min-width:${min})`;
+    } else {
+      r[bp] = `@media screen and (min-width:${min}) and (max-width:${max})`;
+    }
+
+    // Make combinations of neighbors, i.e. smOrMd or mdOrLg. We could go further, like smOrMdOrLg, but that seems excessive.
+    if (!isFirst) {
+      const isSecond = i === 1;
+      const prevBp = bps[i - 1];
+      const name = `${prevBp}Or${capitalize(bp)}`;
+      let rule = "@media screen";
+      // If we're the `firstOrSecond` combination, we can skip min-width.
+      if (!isSecond) {
+        const prevMin = breakpoints[bps[i - 1]];
+        rule += ` and (min-width:${prevMin}px)`;
+      }
+      // If we're the `secondToLastOrLast` combination, we can skip max-width.
+      if (!isLast) {
+        rule += ` and (max-width:${max})`;
+      }
+      r[name] = rule;
+    }
+
+    // Make up/down variants for any "middle" breakpoints, i.e. `smUp` is "everything" and
+    // `smDown` is "just sm", so skip both of those, and same for largest `lgUp`/`lgDown` bp.
+    if (!isFirst && !isLast) {
+      r[`${bp}AndUp`] = `@media screen and (min-width:${min})`;
+      r[`${bp}AndDown`] = `@media screen and (max-width:${max})`;
+    }
+  });
+  return r;
+}
+
 /** Keeps numbers as literals, and wraps anything else with double quotes. */
 function maybeWrap(value: unknown): string {
   return typeof value === "number" ? String(value) : `"${value}"`;
+}
+
+function capitalize(s: string): string {
+  return `${s[0].toUpperCase()}${s.substring(1)}`;
 }


### PR DESCRIPTION
Each truss application's `index.ts` can define the pixel-based breakpoints, and then we generate various `sm` / `md` / `lg` / `mdAndUp` / `smOrMd` / etc. media queries from that initial declaration.

Also `Css.foo.if(sm).bar.$` works now, and uses a branded `Breakpoint` type to make sure you can't call it with random strings (even though the `const sm = ...` are still strings so can also be used in the emotion `[sm]: ...` syntax).