### PR TITLE
Show fela usage

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,13 +1,12 @@
-
 <p style="padding: 100px">
   <img src="https://github.com/homebound-team/truss/blob/main/logo.svg?raw=true" width="400" />
 </p>
 
 Truss is a mini-framework for generating a Tachyons-ish TypeScript DSL for writing framework-agnostic CSS-in-JS (i.e. the truss DSL can be used in emotion, MUI, fela, etc.) that achieves utility-class brevity while critical-css/incremental delivery.
- 
+
 See the "Why This Approach?" section for more rationale.
- 
-(Disclaimer, Truss was written for/and currently used day-to-day with Emotion, but in theory it should work well with other CSS-in-JS frameworks.)
+
+Truss should generally support any CSS-in-JS framework without any customizations; currently the same `Css.ts`-generated DSL is verified to work all three of Material UI, Emotion, and Fela with no changes (see the integration-test directory for examples).
 
 ## Quick Intro
 
@@ -111,7 +110,7 @@ This leveraging of the existing framework's selector support makes Truss's DSL s
 Truss liberally borrows the idea of type-checked "extension" CSS from the currently-unreleased Facebook XStyles library (at least in theory; I've only seen one or two slides for this feature of XStyles, but I'm pretty sure Truss is faithful re-implementation of it).
 
 As context, when developing components, you often end up with "properties that are okay for the caller to set" (i.e. that you as the component developer support the caller setting) and "properties that are _not_ okay for the caller to set" (i.e. because the component controls them).
- 
+
 Basically, you want to allow the caller to customize _some_ styles of the component, typically things like color or margin or font size, but not give them blanket control of "here is a `className` prop, do whatever you want to my root element", which risks "radical"/open-ended customization that then you, as the component developer, don't know if you will/will not unintentionally break going forward.
 
 (I.e. see [Layout isolated components](https://visly.app/blog/layout-isolated-components) for a great write up of "parents control margin, components control padding".)
@@ -131,12 +130,12 @@ export interface DatePickerProps<X> {
 }
 
 // Use the `Only` type to ensure `xss` prop is a subset of DatePickerXss
-export function DatePicker<X extends Only<DatePickerXss, X>>(props: DatePickerProps<X>) {
+export function DatePicker<X extends Only<DatePickerXss, X>>(
+  props: DatePickerProps<X>
+) {
   const { date, xss } = props;
   // The component controls marginTop/marginBottom, and defers to the caller for marginLeft/marginRight
-  return (
-    <div css={{...Css.my2.$, ...xss }}>{date}</div>
-  );
+  return <div css={{ ...Css.my2.$, ...xss }}>{date}</div>;
 }
 ```
 
@@ -232,15 +231,15 @@ Where `"spacing"` matches the name of the file that declared these rules in Trus
 ### Forking
 
 At the end of the day, Truss is small and hackable such that forking it to make the abbreviations "strict Tachyons" or "strict Tailwinds" or "whatever best fits your project/conventions/styles" should be easy and is kosher/encouraged.
- 
+
 The core Truss feature of "make a TypeScript DSL with a bunch of abbreviations" is also basically done, so it's unlikely you will miss out on some future/forthcoming amazing features by forking.
 
 And, even if so, the coupling between Truss and your application code is limited to the `Css.abbreviations.$` lines that should be extremely stable even if/as the core of Truss evolves.
 
 ## Why This Approach?
 
-Truss's  approach is "Tachyons-ish" (or Tailwinds-ish), insofar as having short/cute utility class definitions.
- 
+Truss's approach is "Tachyons-ish" (or Tailwinds-ish), insofar as having short/cute utility class definitions.
+
 However, the abbreviations are runtime resolved to object-style CSS-in-JS rules that are then output by Emotion (or your CSS-in-JS framework of choice), as if the rules had originally been written long-form.
 
 The benefits of this approach are:
@@ -254,11 +253,11 @@ The benefits of this approach are:
 - Psuedo-selectors/breakpoints go through Emotion/the CSS-in-JS framework, which is simpler, more powerful, and reduces method/abbreviation bloat.
 
   I.e. we don't need to suffix `-nl` for "not large" onto every single abbreviation.
-  
+
 - "Regular Emotion/CSS-in-JS" is easily/inherently available as an escape hatch for places where utility classes don't make sense.
 
   It's very likely you'll need "not utility" styles at some point in your project, and because Truss's DSL is already going through Emotion/CSS-in-JS anyway, it means your one-off "not utility" rules will use the same/consistent CSS-in-JS output/generation pipeline.
-  
+
   This means you don't end up with mixed idioms of `className="mx2 black"` for 90% of your styles, but then "something different" like `css={...}` for the last 10%.
 
 - Projects can easily tweak their preferred styles/abbreviations.
@@ -279,9 +278,8 @@ Several libraries influenced Truss, specifically:
 
 ## Todo
 
-* Support `number[]` increments as config
-* Upstream optional per-font size letter spacing/line height support
-* Babel plugin that evaluates `Css...$` expressions at build-time
+- Support `number[]` increments as config
+- Upstream optional per-font size letter spacing/line height support
+- Babel plugin that evaluates `Css...$` expressions at build-time
   - I.e. see babel-plugin-tailwind-components and [typed.tw's implementation](https://github.com/dvkndn/typed.tw/tree/master/webpack-loader)
-* Fela support, ideally via an Emotion-esque `css` prop?
-* Server-side generation; in theory this should just work?
+- Server-side generation; in theory this should just work?

--- a/integration-test/Css.emotion.test.tsx
+++ b/integration-test/Css.emotion.test.tsx
@@ -1,0 +1,114 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+import { render } from "@testing-library/react";
+import { Css, Only, Properties, sm } from "./Css";
+
+describe("Css.emotion", () => {
+  it("works with emotion", () => {
+    // We use p3 (all padding) then pb2 after that, so pb2 should always win.
+    // And we can move mb1 either to the front or the end, and it'll be the same output.
+    const r = render(
+      <div css={Css.mb1.p3.pb2.$}>
+        <span css={Css.p3.pb2.mb1.$} />
+      </div>
+    );
+    expect(r.container).toMatchInlineSnapshot(`
+      .emotion-0 {
+        margin-bottom: 8px;
+        padding-bottom: 16px;
+        padding-left: 24px;
+        padding-right: 24px;
+        padding-top: 24px;
+      }
+
+      <div>
+        <div
+          class="emotion-0"
+        >
+          <span
+            class="emotion-0"
+          />
+        </div>
+      </div>
+    `);
+  });
+
+  it("can be combined with other rules", () => {
+    const phoneOnly = `@media (max-width:500px)`;
+    const r = render(
+      <div
+        css={{
+          ...Css.mb1.pb2.$,
+          "&:hover": { marginBottom: "16px", ...Css.pb3.$ },
+          "&:focus": Css.pb4.$,
+          [phoneOnly]: Css.pb3.$,
+        }}
+      />
+    );
+    expect(r.container).toMatchInlineSnapshot(`
+      .emotion-0 {
+        margin-bottom: 8px;
+        padding-bottom: 16px;
+      }
+
+      .emotion-0:hover {
+        margin-bottom: 16px;
+        padding-bottom: 24px;
+      }
+
+      .emotion-0:focus {
+        padding-bottom: 32px;
+      }
+
+      @media (max-width:500px) {
+        .emotion-0 {
+          padding-bottom: 24px;
+        }
+      }
+
+      <div>
+        <div
+          class="emotion-0"
+        />
+      </div>
+    `);
+  });
+
+  it("can use generated breakpoints", () => {
+    const r = render(<div css={{ ...Css.mb1.pb2.$, [sm]: Css.pb3.$ }} />);
+    expect(r.container).toMatchInlineSnapshot(`
+      .emotion-0 {
+        margin-bottom: 8px;
+        padding-bottom: 16px;
+      }
+
+      @media screen and (max-width:599px) {
+        .emotion-0 {
+          padding-bottom: 24px;
+        }
+      }
+
+      <div>
+        <div
+          class="emotion-0"
+        />
+      </div>
+    `);
+  });
+});
+
+type Margins =
+  | "margin"
+  | "marginTop"
+  | "marginLeft"
+  | "marginBottom"
+  | "marginRight";
+
+type FooXss = Pick<Properties, Margins>;
+
+type FooProps<X extends FooXss> = { name: string; xss?: X };
+
+/** This component styles it's own padding but lets the caller define margin. */
+function FooComponent<X extends Only<FooXss, X>>(props: FooProps<X>) {
+  return <span css={{ ...Css.pb1.$, ...props.xss }}>{props.name}</span>;
+}

--- a/integration-test/Css.fela.test.tsx
+++ b/integration-test/Css.fela.test.tsx
@@ -1,0 +1,67 @@
+/* @jsx fe */
+import { createSnapshot } from "jest-react-fela";
+import { fe, useFela } from "react-fela";
+import { Css } from "./Css";
+
+describe("Css.fela", () => {
+  it("supports css prop", () => {
+    const r = createSnapshot(<span css={Css.mt1.$} />);
+    expect(r).toMatchInlineSnapshot(`
+      ".a {
+        margin-top: 8px;
+      }
+
+
+      <span className=a />;
+      "
+    `);
+  });
+
+  it("supports useFela", () => {
+    function FooComponent(props: { name: string }) {
+      const { css } = useFela();
+      return (
+        <span className={css(Css.pb1.white.$)}>
+          <span className={css(Css.pb1.black.$)}>{props.name}</span>
+        </span>
+      );
+    }
+
+    const r = createSnapshot(<FooComponent name="foo" />);
+    expect(r).toMatchInlineSnapshot(`
+      ".a {
+        color: #fcfcfa;
+      }
+      .b {
+        padding-bottom: 8px;
+      }
+      .c {
+        color: #353535;
+      }
+
+
+      <span className=a b>
+        <span className=c b>foo</span>
+      </span>;
+      "
+    `);
+  });
+
+  it("supports selectors", () => {
+    const r = createSnapshot(
+      <span css={{ ...Css.mt1.$, ":hover": Css.mt2.$ }} />
+    );
+    expect(r).toMatchInlineSnapshot(`
+      ".a {
+        margin-top: 8px;
+      }
+      .b:hover {
+        margin-top: 16px;
+      }
+
+
+      <span className=a b />;
+      "
+    `);
+  });
+});

--- a/integration-test/Css.mui.test.tsx
+++ b/integration-test/Css.mui.test.tsx
@@ -1,0 +1,56 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+import { Button } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import { render } from "@testing-library/react";
+import { Css } from "./Css";
+
+const useStyles = makeStyles({
+  root: Css.black.$,
+});
+
+describe("Css.mui", () => {
+  it("works via makeStyles", () => {
+    function FooComponent() {
+      const styles = useStyles();
+      return <div className={styles.root}>root</div>;
+    }
+
+    const r = render(<FooComponent />);
+    expect(r.container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="makeStyles-root-1"
+        >
+          root
+        </div>
+      </div>
+    `);
+  });
+
+  it("works via emotion's prop", () => {
+    const r = render(<Button css={Css.mb1.$}>Click</Button>);
+    expect(r.container).toMatchInlineSnapshot(`
+      .emotion-0 {
+        margin-bottom: 8px;
+      }
+
+      <div>
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text emotion-0"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-label"
+          >
+            Click
+          </span>
+          <span
+            class="MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    `);
+  });
+});

--- a/integration-test/Css.test.tsx
+++ b/integration-test/Css.test.tsx
@@ -56,7 +56,7 @@ describe("Css", () => {
   });
 
   it("works on components as xstyle", () => {
-    const r = render(<FooComponent name="foo" xstyle={Css.mb1.$} />);
+    const r = render(<FooComponent name="foo" xss={Css.mb1.$} />);
     expect(r.container).toMatchInlineSnapshot(`
       .emotion-0 {
         padding-bottom: 8px;
@@ -141,7 +141,7 @@ describe("Css", () => {
     style(c);
 
     // @ts-expect-error
-    const d = <FooComponent xstyle={Css.mb1.pb1.$} name="foo" />;
+    const d = <FooComponent xss={Css.mb1.pb1.$} name="foo" />;
     expect(d).toBeDefined();
   });
 
@@ -275,7 +275,6 @@ describe("Css", () => {
       }
     `);
   });
-
 });
 
 type Margins =
@@ -285,11 +284,11 @@ type Margins =
   | "marginBottom"
   | "marginRight";
 
-type FooXStyle = Pick<Properties, Margins>;
+type FooXss = Pick<Properties, Margins>;
 
-type FooProps<X extends FooXStyle> = { name: string; xstyle: X };
+type FooProps<X extends FooXss> = { name: string; xss?: X };
 
 /** This component styles it's own padding but lets the caller define margin. */
-function FooComponent<X extends Only<FooXStyle, X>>(props: FooProps<X>) {
-  return <span css={{ ...Css.pb1.$, ...props.xstyle }}>{props.name}</span>;
+function FooComponent<X extends Only<FooXss, X>>(props: FooProps<X>) {
+  return <span css={{ ...Css.pb1.$, ...props.xss }}>{props.name}</span>;
 }

--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@homebound/truss-integration-tests",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "license": "ISC",
+  "jest": {
+    "preset": "ts-jest",
+    "snapshotSerializers": [
+      "jest-emotion"
+    ]
+  }
+}

--- a/integration-test/tsconfig.json
+++ b/integration-test/tsconfig.json
@@ -11,10 +11,11 @@
     "sourceMap": true,
     "strict": true,
     "downlevelIteration": true,
-    "noEmit": false,
-    "baseUrl": "src/",
-    "outDir": "build/",
-    "types": ["jest", "node"]
+    "noEmit": true,
+    "baseUrl": "./",
+    "types": ["jest", "node"],
+    "typeRoots": ["./typings", "../node_modules/@types"],
+    "jsx": "react"
   },
-  "include": ["src/"]
+  "include": ["./"]
 }

--- a/integration-test/typings/react-fela.d.ts
+++ b/integration-test/typings/react-fela.d.ts
@@ -1,0 +1,5 @@
+declare module "react-fela" {
+  export const fe: any;
+}
+
+declare module "jest-react-fela";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1219,6 +1219,12 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -1470,6 +1476,12 @@
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true
     },
+    "browser-request": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
+      "integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc=",
+      "dev": true
+    },
     "bs-logger": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
@@ -1606,6 +1618,12 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
     "collect-v8-coverage": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
@@ -1673,6 +1691,12 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+      "dev": true
+    },
     "core-js-pure": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
@@ -1738,6 +1762,15 @@
         "source-map": "^0.6.1",
         "source-map-resolve": "^0.5.2",
         "urix": "^0.1.0"
+      }
+    },
+    "css-in-js-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.0.4.tgz",
+      "integrity": "sha512-4RKm4RXq+TnX3rVRl85cabEc+VtR0yuU8zT9QpZqa9lLlJzw7Ma6Yyg2N9Gm6l9W+TP0IsWF0wvh3Is4Oifr7g==",
+      "dev": true,
+      "requires": {
+        "hyphenate-style-name": "^1.0.3"
       }
     },
     "css-vendor": {
@@ -1918,6 +1951,36 @@
         "csstype": "^2.6.7"
       }
     },
+    "dom-serializer": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+          "dev": true
+        },
+        "entities": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "dev": true
+    },
     "domexception": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
@@ -1933,6 +1996,25 @@
           "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
           "dev": true
         }
+      }
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "ecc-jsbn": {
@@ -1951,6 +2033,15 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -1959,6 +2050,12 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -2213,6 +2310,12 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-loops": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-loops/-/fast-loops-1.1.2.tgz",
+      "integrity": "sha512-ql8BgnHFryLogmmzR5O3uobe+3Zzaq6h6MWn/VtAyL9OXb51r5PSTbCm9f56fvEvMWWGjbdkr4xyhT0/vLJkKw==",
+      "dev": true
+    },
     "fb-watchman": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
@@ -2220,6 +2323,81 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
+      }
+    },
+    "fbjs": {
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "dev": true,
+      "requires": {
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
+      }
+    },
+    "fela": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fela/-/fela-11.3.0.tgz",
+      "integrity": "sha512-XdtQhmKnE21FftDAG1NZXj/tFF7Rrl1e5uVM3hrqEAZhYhP3N9mqjYXyI8x1nv+EEpsT4CkyzkaXNzHcc07cdQ==",
+      "dev": true,
+      "requires": {
+        "css-in-js-utils": "^3.0.0",
+        "csstype": "^2.5.5",
+        "fast-loops": "^1.0.0",
+        "fela-utils": "^11.3.0",
+        "isobject": "^3.0.1"
+      }
+    },
+    "fela-bindings": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fela-bindings/-/fela-bindings-11.3.0.tgz",
+      "integrity": "sha512-XspvfmaKcs/M3cuduR//NERm2ajBto0VIPboqpxfaFwxryw4RtVe7TZ+SXJVXAMaZa6RwtI48JDCS8uuA4RmFA==",
+      "dev": true,
+      "requires": {
+        "fast-loops": "^1.0.0",
+        "fela-dom": "^11.3.0",
+        "fela-tools": "^11.3.0",
+        "react-addons-shallow-compare": "^15.6.2",
+        "shallow-equal": "^1.0.0"
+      }
+    },
+    "fela-dom": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fela-dom/-/fela-dom-11.3.0.tgz",
+      "integrity": "sha512-RGXNtRMcuorOjSsPRwbOP65vfvuquDKzIUZ2I3MAIoLVhdczr/VVyJ0RYL2wHaqZkK3djkCpHmoWByx84dD+qA==",
+      "dev": true,
+      "requires": {
+        "css-in-js-utils": "^3.0.0",
+        "fast-loops": "^1.0.1",
+        "fela-utils": "^11.3.0",
+        "sort-css-media-queries": "^1.4.3"
+      }
+    },
+    "fela-tools": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fela-tools/-/fela-tools-11.3.0.tgz",
+      "integrity": "sha512-kxwjZd1BF6w+pHeX2bxD6TwbnecrUSk4JhaSbW7Bjt+349y15pqnzMgCK1d9ejIiWfwWL/jyggTdoW4SREZctw==",
+      "dev": true,
+      "requires": {
+        "css-in-js-utils": "^3.0.0",
+        "fast-loops": "^1.0.0",
+        "fela": "^11.3.0",
+        "fela-utils": "^11.3.0"
+      }
+    },
+    "fela-utils": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fela-utils/-/fela-utils-11.3.0.tgz",
+      "integrity": "sha512-LUvlFPIMvtE0zrdGcxIPhHzuN+GTonqpTGRtTdC9EdP33GfyCIqLnaVU7I7PnXzhiaFpc1ShQGE69m+sWLwAyQ==",
+      "dev": true,
+      "requires": {
+        "css-in-js-utils": "^3.0.0",
+        "fast-loops": "^1.0.0"
       }
     },
     "fill-range": {
@@ -2471,6 +2649,219 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      }
+    },
+    "htmltojsx": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/htmltojsx/-/htmltojsx-0.3.0.tgz",
+      "integrity": "sha1-ZIfEUE1mAFHkn3OhJ7RV12PfgmY=",
+      "dev": true,
+      "requires": {
+        "jsdom-no-contextify": "~3.1.0",
+        "react": "~15.4.1",
+        "react-dom": "~15.4.1",
+        "yargs": "~4.6.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "react": {
+          "version": "15.4.2",
+          "resolved": "https://registry.npmjs.org/react/-/react-15.4.2.tgz",
+          "integrity": "sha1-QfeZGyYYU5K6m66WyIiefgGDl+8=",
+          "dev": true,
+          "requires": {
+            "fbjs": "^0.8.4",
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "react-dom": {
+          "version": "15.4.2",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.4.2.tgz",
+          "integrity": "sha1-AVNj8FsKH9Uq6e/dOgBg2QaVII8=",
+          "dev": true,
+          "requires": {
+            "fbjs": "^0.8.1",
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.6.0.tgz",
+          "integrity": "sha1-y0BQwBWb+2u2ScD0r1UFJqhGGdw=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^2.0.1",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "lodash.assign": "^4.0.3",
+            "os-locale": "^1.4.0",
+            "pkg-conf": "^1.1.2",
+            "read-pkg-up": "^1.0.1",
+            "require-main-filename": "^1.0.1",
+            "string-width": "^1.0.1",
+            "window-size": "^0.2.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^2.4.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+          "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0",
+            "lodash.assign": "^4.0.6"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -2551,6 +2942,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
     "ip-regex": {
@@ -2703,6 +3100,12 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -2736,6 +3139,16 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -3070,6 +3483,16 @@
         "jest-util": "^26.0.1"
       }
     },
+    "jest-fela-bindings": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/jest-fela-bindings/-/jest-fela-bindings-11.3.0.tgz",
+      "integrity": "sha512-uZS+edCBvesbNLoukvyMrV8bv779F7643FEZB75yu7WrCFj9OgfJv42otA5gz+rMcj4KLUTrb38sV74MXND2oQ==",
+      "dev": true,
+      "requires": {
+        "fela-tools": "^11.3.0",
+        "htmltojsx": "^0.3.0"
+      }
+    },
     "jest-get-type": {
       "version": "26.0.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
@@ -3174,6 +3597,15 @@
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
       "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
       "dev": true
+    },
+    "jest-react-fela": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/jest-react-fela/-/jest-react-fela-11.3.0.tgz",
+      "integrity": "sha512-ikiPVnIrsXC0/KeUh7v7FxzglaC10LUscSOTAoQnJS+KDRtux2wtbNtWBT+gm/35lhzSneaOMCCh1yQLHNsfsA==",
+      "dev": true,
+      "requires": {
+        "jest-fela-bindings": "^11.3.0"
+      }
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -3430,6 +3862,52 @@
         "xml-name-validator": "^3.0.0"
       }
     },
+    "jsdom-no-contextify": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom-no-contextify/-/jsdom-no-contextify-3.1.0.tgz",
+      "integrity": "sha1-DYvq9hDC/yOJT1Tfp/id0i/Q96s=",
+      "dev": true,
+      "requires": {
+        "browser-request": ">= 0.3.1 < 0.4.0",
+        "cssom": ">= 0.3.0 < 0.4.0",
+        "cssstyle": ">= 0.2.21 < 0.3.0",
+        "htmlparser2": ">= 3.7.3 < 4.0.0",
+        "nwmatcher": ">= 1.3.4 < 2.0.0",
+        "parse5": ">= 1.3.1 < 2.0.0",
+        "request": ">= 2.44.0 < 3.0.0",
+        "xml-name-validator": "^1.0.0",
+        "xmlhttprequest": ">= 1.6.0 < 2.0.0"
+      },
+      "dependencies": {
+        "cssom": {
+          "version": "0.3.8",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+          "dev": true
+        },
+        "cssstyle": {
+          "version": "0.2.37",
+          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+          "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+          "dev": true,
+          "requires": {
+            "cssom": "0.3.x"
+          }
+        },
+        "parse5": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+          "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+          "dev": true
+        },
+        "xml-name-validator": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-1.0.0.tgz",
+          "integrity": "sha1-3Pgu4JIyKVHvjMG6WWycv9FKg/E=",
+          "dev": true
+        }
+      }
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -3579,6 +4057,15 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^1.0.0"
+      }
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -3601,6 +4088,39 @@
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        }
+      }
+    },
     "locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -3614,6 +4134,12 @@
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -3791,6 +4317,16 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -3861,6 +4397,18 @@
       "requires": {
         "path-key": "^2.0.0"
       }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "nwmatcher": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
+      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
+      "dev": true
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -3959,6 +4507,15 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
         "word-wrap": "~1.2.3"
+      }
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
+      "requires": {
+        "lcid": "^1.0.0"
       }
     },
     "p-each-series": {
@@ -4072,6 +4629,27 @@
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
     "pirates": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
@@ -4079,6 +4657,39 @@
       "dev": true,
       "requires": {
         "node-modules-regexp": "^1.0.0"
+      }
+    },
+    "pkg-conf": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
+      "integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0",
+        "load-json-file": "^1.1.0",
+        "object-assign": "^4.0.1",
+        "symbol": "^0.2.1"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        }
       }
     },
     "pkg-dir": {
@@ -4123,6 +4734,15 @@
         "ansi-regex": "^5.0.0",
         "ansi-styles": "^4.0.0",
         "react-is": "^16.12.0"
+      }
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "requires": {
+        "asap": "~2.0.3"
       }
     },
     "prompts": {
@@ -4185,6 +4805,16 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-addons-shallow-compare": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.2.tgz",
+      "integrity": "sha1-GYoAuR/DdiPbZKKP0XtZa6NicC8=",
+      "dev": true,
+      "requires": {
+        "fbjs": "^0.8.4",
+        "object-assign": "^4.1.0"
+      }
+    },
     "react-dom": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
@@ -4195,6 +4825,17 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.19.1"
+      }
+    },
+    "react-fela": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/react-fela/-/react-fela-11.3.0.tgz",
+      "integrity": "sha512-J15sKZ73KA59oqPTzU3ZgjRAOuxm5Xh/bTydjD6wSDBYg4rFz9XhWRTKqFVFxMk5CgTlCA7FMDSXbFJcEyXlIQ==",
+      "dev": true,
+      "requires": {
+        "fela-bindings": "^11.3.0",
+        "fela-dom": "^11.3.0",
+        "prop-types": "^15.5.8"
       }
     },
     "react-is": {
@@ -4244,6 +4885,17 @@
         "find-up": "^4.1.0",
         "read-pkg": "^5.2.0",
         "type-fest": "^0.8.1"
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "regenerator-runtime": {
@@ -4637,6 +5289,18 @@
         }
       }
     },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
+    },
+    "shallow-equal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==",
+      "dev": true
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -4805,6 +5469,12 @@
         }
       }
     },
+    "sort-css-media-queries": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sort-css-media-queries/-/sort-css-media-queries-1.5.0.tgz",
+      "integrity": "sha512-QofNE7CEVH1AKdhS7L9IPbV9UtyQYNXyw++8lC+xG6iOLlpzsmncZRiKbihTAESvZ8wOhwnPoesHbMrehrQyyw==",
+      "dev": true
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4969,6 +5639,23 @@
         "strip-ansi": "^6.0.0"
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
+      }
+    },
     "strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -5014,6 +5701,12 @@
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
       }
+    },
+    "symbol": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz",
+      "integrity": "sha1-O5hzuKkB5Hxu/iFSajrDcu8ou8c=",
+      "dev": true
     },
     "symbol-tree": {
       "version": "3.2.4",
@@ -5227,6 +5920,12 @@
       "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
       "dev": true
     },
+    "ua-parser-js": {
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
+      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
+      "dev": true
+    },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -5298,6 +5997,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "uuid": {
@@ -5389,6 +6094,12 @@
         "iconv-lite": "0.4.24"
       }
     },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+      "dev": true
+    },
     "whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -5427,6 +6138,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "window-size": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
       "dev": true
     },
     "word-wrap": {
@@ -5480,6 +6197,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
       "dev": true
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc",
     "generate": "ts-node ./integration-test/index.ts",
-    "test": "jest"
+    "test": "jest && (cd integration-test; npm test)"
   },
   "license": "ISC",
   "dependencies": {
@@ -14,22 +14,24 @@
     "ts-poet": "^3.2.2"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.0",
     "@emotion/core": "^10.0.28",
     "@material-ui/core": "^4.10.2",
     "@testing-library/react": "^10.3.0",
+    "@types/jest": "^26.0.0",
     "jest": "^26.0.1",
     "jest-emotion": "^10.0.32",
+    "jest-react-fela": "^11.3.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-fela": "^11.3.0",
     "ts-jest": "^26.1.0",
     "ts-node": "^8.10.2",
     "typescript": "^3.9.5"
   },
   "jest": {
     "preset": "ts-jest",
-    "snapshotSerializers": [
-      "jest-emotion"
+    "testMatch": [
+      "<rootDir>/src/*.test.(ts|tsx)"
     ]
   }
 }


### PR DESCRIPTION
I was pleasantly surprised to learn that Fela already supports a `css`-prop style API.

Unfortunately I had to add some custom typings to get it to work; currently being a little hacky and just using anys in the custom `react-fela.d.ts`.

Otherwise fela is pretty neat, you can see how it's making per-property class names and then reusing them across elements.