### PR TITLE
Add fill and Palette.

### DIFF
--- a/integration-test/Css.test.tsx
+++ b/integration-test/Css.test.tsx
@@ -2,7 +2,7 @@
 import { Button } from "@material-ui/core";
 import { jsx } from "@emotion/core";
 import { render } from "@testing-library/react";
-import { Css, Only, Properties, sm, px } from "./Css";
+import { Css, Only, Properties, sm, px, Palette } from "./Css";
 
 describe("Css", () => {
   it("can add mb", () => {
@@ -285,6 +285,14 @@ describe("Css", () => {
     expect(Css.var.$).toMatchInlineSnapshot(`
       Object {
         "color": "var(--primary)",
+      }
+    `);
+  });
+
+  it("has the palette", () => {
+    expect(Css.fill(Palette.Black).$).toMatchInlineSnapshot(`
+      Object {
+        "fill": "#353535",
       }
     `);
   });

--- a/integration-test/Css.ts
+++ b/integration-test/Css.ts
@@ -170,6 +170,7 @@ class CssBuilder<T extends Properties1> {
   get bgBlue() { return this.add("backgroundColor", "#526675"); }
   get bgPrimary() { return this.add("backgroundColor", "var(--primary)"); }
   bgColor(value: string) { return this.add("backgroundColor", value); }
+  fill(value: string) { return this.add("fill", value); }
 
   // spacingRules
   get mt0() { return this.mt(0); }
@@ -395,6 +396,15 @@ export function increment(inc: number): number {
 export function px(pixels: number): string {
   return `${pixels}px`;
 }
+
+export const Palette = {
+  Black: "#353535",
+  MidGray: "#888888",
+  LightGray: "#cecece",
+  White: "#fcfcfa",
+  Blue: "#526675",
+  Primary: "var(--primary)",
+};
 
 /** An entry point for Css expressions. CssBuilder is immutable so this is safe to share. */
 export const Css = new CssBuilder({}, true, false, undefined);

--- a/integration-test/index.ts
+++ b/integration-test/index.ts
@@ -50,6 +50,7 @@ const extras = [`export type CustomType = number;`];
 generate({
   outputPath: "./integration-test/Css.ts",
   methods,
+  palette,
   increment,
   aliases,
   extras,

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -15,6 +15,9 @@ export type GenerateOpts = {
   /** The map of "section" to list of getters/methods, i.e. "border-colors" -> `get ml1() { ... }`. */
   methods: Record<string, string[]>;
 
+  /** The app's palette, i.e. logical color name to hex. */
+  palette: Record<string, string>;
+
   /** Your theme's increment, i.e. 6 or 8. */
   increment: number;
 
@@ -73,6 +76,7 @@ export function generateCssBuilder(opts: GenerateOpts): Code {
     extras,
     typeAliases,
     breakpoints,
+    palette,
   } = opts;
 
   const Properties = imp("Properties@csstype");
@@ -187,6 +191,12 @@ export function increment(inc: number): number {
 /** Convert \`pixels\` to a \`px\` units string so it's not ambiguous. */
 export function px(pixels: number): string {
   return \`\${pixels}px\`;
+}
+
+export const Palette = {
+  ${Object.entries(palette).map(([name, value]) => {
+    return `${name}: "${value}",`;
+  })}
 }
 
 /** An entry point for Css expressions. CssBuilder is immutable so this is safe to share. */

--- a/src/rules/skins.ts
+++ b/src/rules/skins.ts
@@ -26,5 +26,6 @@ export const skinRules: RuleFn = (config) => {
     `color(value: string) { return this.add("color", value); }`,
     ...backgroundColors,
     `bgColor(value: string) { return this.add("backgroundColor", value); }`,
+    `fill(value: string) { return this.add("fill", value); }`,
   ];
 };


### PR DESCRIPTION
I've seen `.fill` used a few times for svg things. Initially I thought of adding `.fillBlack`, `.fillBlue`, etc. just like we do for `color` and `background-color`, but `fill` seems a little more special-case-y not super-common, so maybe a compromise is to have a single `fill` method that you always pass the color too.

But then need to easily get the palette values, which had only been in the config before; this adds a `export const Palette` to the generated `Css.ts` file so that the app can use it.