### PR TITLE
Support cursor not-allowed and basic grid properties

### DIFF
--- a/integration-test/Css.ts
+++ b/integration-test/Css.ts
@@ -178,7 +178,13 @@ class CssBuilder<T extends Properties1> {
   // grid
   gtc(value: Properties["gridTemplateColumns"]) { return this.add("gridTemplateColumns", value); }
   gtr(value: Properties["gridTemplateRows"]) { return this.add("gridTemplateRows", value); }
-  gap(value: Properties["gap"]) { return this.add("gap", value); }
+  get gap0() { return this.gap(0); }
+  get gap1() { return this.gap(1); }
+  get gap2() { return this.gap(2); }
+  get gap3() { return this.gap(3); }
+  get gap4() { return this.gap(4); }
+  gap(inc: number | string) { return this.add("gap", maybeInc(inc)); }
+  gapPx(px: number) { return this.add("gap", `${px}px`); }
 
   // height
   get h0() { return this.h(0); }

--- a/integration-test/Css.ts
+++ b/integration-test/Css.ts
@@ -25,6 +25,14 @@ class CssBuilder<T extends Properties1> {
     return new CssBuilder({ ...this.opts, ...opts });
   }
 
+  // border
+  get ba() { return this.add("borderStyle", "solid").add("borderWidth", "1px"); }
+  get bt() { return this.add("borderTopStyle", "solid").add("borderTopWidth", "1px"); }
+  get br() { return this.add("borderRightStyle", "solid").add("borderRightWidth", "1px"); }
+  get bb() { return this.add("borderBottomStyle", "solid").add("borderBottomWidth", "1px"); }
+  get bl() { return this.add("borderLeftStyle", "solid").add("borderLeftWidth", "1px"); }
+  get bn() { return this.add("borderStyle", "none").add("borderWidth", "0"); }
+
   // borderColor
   get bBlack() { return this.add("borderColor", "#353535"); }
   get bMidGray() { return this.add("borderColor", "#888888"); }
@@ -41,14 +49,6 @@ class CssBuilder<T extends Properties1> {
   get br4() { return this.add("borderRadius", "1rem"); }
   get br100() { return this.add("borderRadius", "100%"); }
   get brPill() { return this.add("borderRadius", "9999px"); }
-
-  // border
-  get ba() { return this.add("borderStyle", "solid").add("borderWidth", "1px"); }
-  get bt() { return this.add("borderTopStyle", "solid").add("borderTopWidth", "1px"); }
-  get br() { return this.add("borderRightStyle", "solid").add("borderRightWidth", "1px"); }
-  get bb() { return this.add("borderBottomStyle", "solid").add("borderBottomWidth", "1px"); }
-  get bl() { return this.add("borderLeftStyle", "solid").add("borderLeftWidth", "1px"); }
-  get bn() { return this.add("borderStyle", "none").add("borderWidth", "0"); }
 
   // borderStyle
   get bsDashed() { return this.add("borderStyle", "dashed"); }
@@ -96,6 +96,7 @@ class CssBuilder<T extends Properties1> {
 
   // cursor
   get cursorPointer() { return this.add("cursor", "pointer"); }
+  get cursorNotAllowed() { return this.add("cursor", "not-allowed"); }
 
   // display
   get dn() { return this.add("display", "none"); }
@@ -174,6 +175,11 @@ class CssBuilder<T extends Properties1> {
   get fw8() { return this.add("fontWeight", 800); }
   get fw9() { return this.add("fontWeight", 900); }
 
+  // grid
+  gtc(value: Properties["gridTemplateColumns"]) { return this.add("gridTemplateColumns", value); }
+  gtr(value: Properties["gridTemplateRows"]) { return this.add("gridTemplateRows", value); }
+  gap(value: Properties["gap"]) { return this.add("gap", value); }
+
   // height
   get h0() { return this.h(0); }
   get h1() { return this.h(1); }
@@ -204,11 +210,6 @@ class CssBuilder<T extends Properties1> {
   get maxh100() { return this.add("maxHeight", "100%"); }
   maxh(value: Properties["maxHeight"]) { return this.add("maxHeight", value); }
 
-  // outline
-  get outline() { return this.add("outline", "1px solid"); }
-  get outlineTransparent() { return this.add("outline", "1px solid transparent"); }
-  get outline0() { return this.add("outline", "0"); }
-
   // objectFit
   get objectContain() { return this.add("objectFit", "contain"); }
   get objectCover() { return this.add("objectFit", "cover"); }
@@ -216,6 +217,11 @@ class CssBuilder<T extends Properties1> {
   get objectNone() { return this.add("objectFit", "none"); }
   get objectScaleDown() { return this.add("objectFit", "scale-down"); }
   objectFit(value: Properties["objectFit"]) { return this.add("objectFit", value); }
+
+  // outline
+  get outline() { return this.add("outline", "1px solid"); }
+  get outlineTransparent() { return this.add("outline", "1px solid transparent"); }
+  get outline0() { return this.add("outline", "0"); }
 
   // overflow
   get overflowVisible() { return this.add("overflow", "visible"); }

--- a/src/sections/cursor.ts
+++ b/src/sections/cursor.ts
@@ -1,6 +1,9 @@
-import { newMethod } from "../methods";
+import { newMethod, newMethodsForProp } from "../methods";
 import { MethodFn } from "../config";
 
 export const cursor: MethodFn = () => [
-  newMethod("cursorPointer", { cursor: "pointer" }),
+  ...newMethodsForProp("cursor", {
+    cursorPointer: "pointer",
+    cursorNotAllowed: "not-allowed",
+  }),
 ];

--- a/src/sections/grid.ts
+++ b/src/sections/grid.ts
@@ -1,0 +1,8 @@
+import { MethodFn } from "../config";
+import { newMethodsForProp, newParamMethod } from "../methods";
+
+export const grid: MethodFn = () => [
+  newParamMethod("gtc", "gridTemplateColumns"),
+  newParamMethod("gtr", "gridTemplateRows"),
+  newParamMethod("gap", "gap"),
+];

--- a/src/sections/grid.ts
+++ b/src/sections/grid.ts
@@ -1,8 +1,12 @@
 import { MethodFn } from "../config";
-import { newMethodsForProp, newParamMethod } from "../methods";
+import {
+  newIncrementMethods,
+  newMethodsForProp,
+  newParamMethod,
+} from "../methods";
 
-export const grid: MethodFn = () => [
+export const grid: MethodFn = (config) => [
   newParamMethod("gtc", "gridTemplateColumns"),
   newParamMethod("gtr", "gridTemplateRows"),
-  newParamMethod("gap", "gap"),
+  ...newIncrementMethods(config, "gap", "gap"),
 ];

--- a/src/sections/index.ts
+++ b/src/sections/index.ts
@@ -1,6 +1,6 @@
+import { border } from "./border";
 import { borderColor } from "./borderColors";
 import { borderRadius } from "./borderRadius";
-import { border } from "./border";
 import { borderStyle } from "./borderStyles";
 import { borderWidth } from "./borderWidths";
 import { boxShadow } from "./boxShadow";
@@ -10,6 +10,7 @@ import { display } from "./display";
 import { flexbox } from "./flexbox";
 import { float } from "./floats";
 import { fontWeight } from "./fontWeight";
+import { grid } from "./grid";
 import { height } from "./heights";
 import { objectFit } from "./objectFit";
 import { outline } from "./outlines";
@@ -30,9 +31,9 @@ import { width } from "./widths";
 import { zIndex } from "./zIndex";
 
 export const defaultSections = {
+  border,
   borderColor,
   borderRadius,
-  border,
   borderStyle,
   borderWidth,
   boxShadow,
@@ -42,9 +43,10 @@ export const defaultSections = {
   flexbox,
   float,
   fontWeight,
+  grid,
   height,
-  outline,
   objectFit,
+  outline,
   overflow,
   position,
   skins,


### PR DESCRIPTION
Add general support for:
- `cursor: "not-allowed"`
- `grid-template-columns`
- `grid-template-rows`
- `gap`