### PR TITLE
Use shorter abbreviations for flex.

### DIFF
--- a/integration-test/Css.ts
+++ b/integration-test/Css.ts
@@ -119,25 +119,25 @@ class CssBuilder<T extends Properties1> {
   display(value: Properties["display"]) { return this.add("display", value); }
 
   // flexbox
-  get justifyStart() { return this.add("justifyContent", "flex-start"); }
-  get justifyEnd() { return this.add("justifyContent", "flex-end"); }
-  get justifyCenter() { return this.add("justifyContent", "center"); }
-  get justifyBetween() { return this.add("justifyContent", "space-between"); }
-  get justifyAround() { return this.add("justifyContent", "space-around"); }
-  get justifyEvenly() { return this.add("justifyContent", "space-evenly"); }
-  justify(value: Properties["justifyContent"]) { return this.add("justifyContent", value); }
-  get selfStart() { return this.add("alignSelf", "flex-start"); }
-  get selfEnd() { return this.add("alignSelf", "flex-end"); }
-  get selfCenter() { return this.add("alignSelf", "center"); }
-  get selfBaseline() { return this.add("alignSelf", "baseline"); }
-  get selfStretch() { return this.add("alignSelf", "stretch"); }
-  self(value: Properties["alignSelf"]) { return this.add("alignSelf", value); }
-  get itemsStart() { return this.add("alignItems", "flex-start"); }
-  get itemsEnd() { return this.add("alignItems", "flex-end"); }
-  get itemsCenter() { return this.add("alignItems", "center"); }
-  get itemsBaseline() { return this.add("alignItems", "baseline"); }
-  get itemsStretch() { return this.add("alignItems", "stretch"); }
-  items(value: Properties["alignItems"]) { return this.add("alignItems", value); }
+  get js() { return this.add("justifyContent", "flex-start"); }
+  get je() { return this.add("justifyContent", "flex-end"); }
+  get jc() { return this.add("justifyContent", "center"); }
+  get jb() { return this.add("justifyContent", "space-between"); }
+  get ja() { return this.add("justifyContent", "space-around"); }
+  get jEvenly() { return this.add("justifyContent", "space-evenly"); }
+  j(value: Properties["justifyContent"]) { return this.add("justifyContent", value); }
+  get asStart() { return this.add("alignSelf", "flex-start"); }
+  get ase() { return this.add("alignSelf", "flex-end"); }
+  get asc() { return this.add("alignSelf", "center"); }
+  get asb() { return this.add("alignSelf", "baseline"); }
+  get asStretch() { return this.add("alignSelf", "stretch"); }
+  as(value: Properties["alignSelf"]) { return this.add("alignSelf", value); }
+  get ais() { return this.add("alignItems", "flex-start"); }
+  get aie() { return this.add("alignItems", "flex-end"); }
+  get aic() { return this.add("alignItems", "center"); }
+  get aib() { return this.add("alignItems", "baseline"); }
+  get aiStretch() { return this.add("alignItems", "stretch"); }
+  ai(value: Properties["alignItems"]) { return this.add("alignItems", value); }
   get fb1() { return this.add("flexBasis", "100%"); }
   get fb2() { return this.add("flexBasis", "50%"); }
   get fb3() { return this.add("flexBasis", "33.333333%"); }
@@ -156,10 +156,10 @@ class CssBuilder<T extends Properties1> {
   get fs0() { return this.add("flexShrink", 0); }
   get fs1() { return this.add("flexShrink", 1); }
   flexShrink(value: Properties["flexShrink"]) { return this.add("flexShrink", value); }
-  get flexRow() { return this.add("flexDirection", "row"); }
-  get flexRowReverse() { return this.add("flexDirection", "row-reverse"); }
-  get flexColumn() { return this.add("flexDirection", "column"); }
-  get flexColumnReverse() { return this.add("flexDirection", "column-reverse"); }
+  get fdRow() { return this.add("flexDirection", "row"); }
+  get fdRowReverse() { return this.add("flexDirection", "row-reverse"); }
+  get fdColumn() { return this.add("flexDirection", "column"); }
+  get fdColumnReverse() { return this.add("flexDirection", "column-reverse"); }
   flexDirection(value: Properties["flexDirection"]) { return this.add("flexDirection", value); }
 
   // float

--- a/integration-test/Css.ts
+++ b/integration-test/Css.ts
@@ -119,24 +119,24 @@ class CssBuilder<T extends Properties1> {
   display(value: Properties["display"]) { return this.add("display", value); }
 
   // flexbox
-  get js() { return this.add("justifyContent", "flex-start"); }
-  get je() { return this.add("justifyContent", "flex-end"); }
-  get jc() { return this.add("justifyContent", "center"); }
-  get jb() { return this.add("justifyContent", "space-between"); }
-  get ja() { return this.add("justifyContent", "space-around"); }
-  get jEvenly() { return this.add("justifyContent", "space-evenly"); }
-  j(value: Properties["justifyContent"]) { return this.add("justifyContent", value); }
-  get asStart() { return this.add("alignSelf", "flex-start"); }
-  get ase() { return this.add("alignSelf", "flex-end"); }
+  get jcfs() { return this.add("justifyContent", "flex-start"); }
+  get jcfe() { return this.add("justifyContent", "flex-end"); }
+  get jcc() { return this.add("justifyContent", "center"); }
+  get jcsb() { return this.add("justifyContent", "space-between"); }
+  get jcsa() { return this.add("justifyContent", "space-around"); }
+  get jce() { return this.add("justifyContent", "space-evenly"); }
+  jc(value: Properties["justifyContent"]) { return this.add("justifyContent", value); }
+  get asfs() { return this.add("alignSelf", "flex-start"); }
+  get asfe() { return this.add("alignSelf", "flex-end"); }
   get asc() { return this.add("alignSelf", "center"); }
   get asb() { return this.add("alignSelf", "baseline"); }
   get asStretch() { return this.add("alignSelf", "stretch"); }
   as(value: Properties["alignSelf"]) { return this.add("alignSelf", value); }
-  get ais() { return this.add("alignItems", "flex-start"); }
-  get aie() { return this.add("alignItems", "flex-end"); }
+  get aifs() { return this.add("alignItems", "flex-start"); }
+  get aife() { return this.add("alignItems", "flex-end"); }
   get aic() { return this.add("alignItems", "center"); }
   get aib() { return this.add("alignItems", "baseline"); }
-  get aiStretch() { return this.add("alignItems", "stretch"); }
+  get ais() { return this.add("alignItems", "stretch"); }
   ai(value: Properties["alignItems"]) { return this.add("alignItems", value); }
   get fb1() { return this.add("flexBasis", "100%"); }
   get fb2() { return this.add("flexBasis", "50%"); }
@@ -156,11 +156,11 @@ class CssBuilder<T extends Properties1> {
   get fs0() { return this.add("flexShrink", 0); }
   get fs1() { return this.add("flexShrink", 1); }
   flexShrink(value: Properties["flexShrink"]) { return this.add("flexShrink", value); }
-  get fdRow() { return this.add("flexDirection", "row"); }
-  get fdRowReverse() { return this.add("flexDirection", "row-reverse"); }
-  get fdColumn() { return this.add("flexDirection", "column"); }
-  get fdColumnReverse() { return this.add("flexDirection", "column-reverse"); }
-  flexDirection(value: Properties["flexDirection"]) { return this.add("flexDirection", value); }
+  get fdr() { return this.add("flexDirection", "row"); }
+  get fdrr() { return this.add("flexDirection", "row-reverse"); }
+  get fdc() { return this.add("flexDirection", "column"); }
+  get fdcr() { return this.add("flexDirection", "column-reverse"); }
+  fd(value: Properties["flexDirection"]) { return this.add("flexDirection", value); }
 
   // float
   get fl() { return this.add("float", "left"); }

--- a/integration-test/Css.ts
+++ b/integration-test/Css.ts
@@ -124,7 +124,7 @@ class CssBuilder<T extends Properties1> {
   get jcc() { return this.add("justifyContent", "center"); }
   get jcsb() { return this.add("justifyContent", "space-between"); }
   get jcsa() { return this.add("justifyContent", "space-around"); }
-  get jce() { return this.add("justifyContent", "space-evenly"); }
+  get jcse() { return this.add("justifyContent", "space-evenly"); }
   jc(value: Properties["justifyContent"]) { return this.add("justifyContent", value); }
   get asfs() { return this.add("alignSelf", "flex-start"); }
   get asfe() { return this.add("alignSelf", "flex-end"); }

--- a/src/sections/flexbox.ts
+++ b/src/sections/flexbox.ts
@@ -5,38 +5,38 @@ export const flexbox: MethodFn = () => [
   ...newMethodsForProp(
     "justifyContent",
     {
-      justifyStart: "flex-start",
-      justifyEnd: "flex-end",
-      justifyCenter: "center",
-      justifyBetween: "space-between",
-      justifyAround: "space-around",
-      justifyEvenly: "space-evenly",
+      js: "flex-start",
+      je: "flex-end",
+      jc: "center",
+      jb: "space-between",
+      ja: "space-around",
+      jEvenly: "space-evenly",
     },
-    "justify"
+    "j"
   ),
 
   ...newMethodsForProp(
     "alignSelf",
     {
-      selfStart: "flex-start",
-      selfEnd: "flex-end",
-      selfCenter: "center",
-      selfBaseline: "baseline",
-      selfStretch: "stretch",
+      asStart: "flex-start",
+      ase: "flex-end",
+      asc: "center",
+      asb: "baseline",
+      asStretch: "stretch",
     },
-    "self"
+    "as"
   ),
 
   ...newMethodsForProp(
     "alignItems",
     {
-      itemsStart: "flex-start",
-      itemsEnd: "flex-end",
-      itemsCenter: "center",
-      itemsBaseline: "baseline",
-      itemsStretch: "stretch",
+      ais: "flex-start",
+      aie: "flex-end",
+      aic: "center",
+      aib: "baseline",
+      aiStretch: "stretch",
     },
-    "items"
+    "ai"
   ),
 
   ...newMethodsForProp(
@@ -64,9 +64,9 @@ export const flexbox: MethodFn = () => [
 
   // https://github.com/tachyons-css/tachyons/blob/master/src/_flexbox.css#L25
   ...newMethodsForProp("flexDirection", {
-    flexRow: "row",
-    flexRowReverse: "row-reverse",
-    flexColumn: "column",
-    flexColumnReverse: "column-reverse",
+    fdRow: "row",
+    fdRowReverse: "row-reverse",
+    fdColumn: "column",
+    fdColumnReverse: "column-reverse",
   }),
 ];

--- a/src/sections/flexbox.ts
+++ b/src/sections/flexbox.ts
@@ -1,25 +1,32 @@
 import { MethodFn } from "../config";
 import { newMethodsForProp } from "../methods";
 
+// We originally used the tachyons mappings:
+// https://github.com/tachyons-css/tachyons/blob/master/src/_flexbox.css#L17
+//
+// But later shortened them with the rationale that, once we've all been writing
+// flex on a day-to-day basis, we don't need the longer "not-Tachyons-ish" names
+// that Tachyons originally picked (i.e. maybe because the flex properties were
+// "too new/different" at the time of adding them?).
 export const flexbox: MethodFn = () => [
   ...newMethodsForProp(
     "justifyContent",
     {
-      js: "flex-start",
-      je: "flex-end",
-      jc: "center",
-      jb: "space-between",
-      ja: "space-around",
-      jEvenly: "space-evenly",
+      jcfs: "flex-start",
+      jcfe: "flex-end",
+      jcc: "center",
+      jcsb: "space-between",
+      jcsa: "space-around",
+      jce: "space-evenly",
     },
-    "j"
+    "jc"
   ),
 
   ...newMethodsForProp(
     "alignSelf",
     {
-      asStart: "flex-start",
-      ase: "flex-end",
+      asfs: "flex-start",
+      asfe: "flex-end",
       asc: "center",
       asb: "baseline",
       asStretch: "stretch",
@@ -30,11 +37,11 @@ export const flexbox: MethodFn = () => [
   ...newMethodsForProp(
     "alignItems",
     {
-      ais: "flex-start",
-      aie: "flex-end",
+      aifs: "flex-start",
+      aife: "flex-end",
       aic: "center",
       aib: "baseline",
-      aiStretch: "stretch",
+      ais: "stretch",
     },
     "ai"
   ),
@@ -55,18 +62,19 @@ export const flexbox: MethodFn = () => [
     "fb"
   ),
 
-  // https://github.com/tachyons-css/tachyons/blob/master/src/_flexbox.css#L17
   ...newMethodsForProp("flex", { flexAuto: "auto", flexNone: "none" }),
 
-  // https://github.com/tachyons-css/tachyons/blob/master/src/_flexbox.css#L69
   ...newMethodsForProp("flexGrow", { fg0: 0, fg1: 1 }),
   ...newMethodsForProp("flexShrink", { fs0: 0, fs1: 1 }),
 
-  // https://github.com/tachyons-css/tachyons/blob/master/src/_flexbox.css#L25
-  ...newMethodsForProp("flexDirection", {
-    fdRow: "row",
-    fdRowReverse: "row-reverse",
-    fdColumn: "column",
-    fdColumnReverse: "column-reverse",
-  }),
+  ...newMethodsForProp(
+    "flexDirection",
+    {
+      fdr: "row",
+      fdrr: "row-reverse",
+      fdc: "column",
+      fdcr: "column-reverse",
+    },
+    "fd"
+  ),
 ];

--- a/src/sections/flexbox.ts
+++ b/src/sections/flexbox.ts
@@ -17,7 +17,7 @@ export const flexbox: MethodFn = () => [
       jcc: "center",
       jcsb: "space-between",
       jcsa: "space-around",
-      jce: "space-evenly",
+      jcse: "space-evenly",
     },
     "jc"
   ),


### PR DESCRIPTION
Just making up rationale (for why the current Tachyons names are longer than usual for Tachyons), but maybe flex was so new when the abbreviations were first added to Tachyons, they maybe picked longer than usual names...? Not sure.

But now that flex is something we write every day, seems like we could shorten them up?