### PR TITLE
feat: Add defaultMethods to turn off the web-based output.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -55,7 +55,16 @@ export interface Config {
   breakpoints?: Record<string, number>;
 
   /**
-   * A map of "section" to list of rules to create utility methods.
+   * Which default methods to include.
+   *
+   * Currently, we support either `tachyons` or `none`. Could eventually support
+   * `tachyons-rn` or `tailwinds` / `tailwinds-rn` as additional options.
+   */
+  defaultMethods?: "tachyons" | "none";
+
+  /**
+   * A map of "section" to list of rules to create application-specific
+   * utility methods.
    *
    * I.e. "borderColors" -> () => [`get ml1() { ... }`].
    *

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -33,12 +33,16 @@ function generateCssBuilder(config: Config): Code {
     typeAliases,
     breakpoints,
     palette,
+    defaultMethods = "tachyons",
     sections: customSections,
   } = config;
 
   // Combine our out-of-the-box utility methods with any custom ones
   const sections: Record<string, string[]> = {
-    ...generateMethods(config, defaultSections),
+    // We only ship with tachyons methods currently
+    ...(defaultMethods === "tachyons"
+      ? generateMethods(config, defaultSections)
+      : {}),
     ...(customSections ? generateMethods(config, customSections) : {}),
     ...(aliases && { aliases: newAliasesMethods(aliases) }),
   };


### PR DESCRIPTION
This will give @KoltonG a clean slate to iterate on RN-based methods within the mobile app. 