### PR TITLE
feat: Add breakpoint types and enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ A basic development flow is:
 - Iterate as you want
 - In the root directory, run `yarn test` to run all tests
   - Running individual tests in your IDE/each package should work as well
+- In the root directory run `yarn workspaces foreach run codegen` to generate the testing `Css.ts` files
 
 ## Todo
 

--- a/packages/template-tachyons/src/Css.ts
+++ b/packages/template-tachyons/src/Css.ts
@@ -150,6 +150,13 @@ class CssBuilder<T extends Properties1> {
   get jcsa() { return this.add("justifyContent", "space-around"); }
   get jcse() { return this.add("justifyContent", "space-evenly"); }
   jc(value: Properties["justifyContent"]) { return this.add("justifyContent", value); }
+  get jifs() { return this.add("justifyItems", "flex-start"); }
+  get jife() { return this.add("justifyItems", "flex-end"); }
+  get jic() { return this.add("justifyItems", "center"); }
+  get jisb() { return this.add("justifyItems", "space-between"); }
+  get jisa() { return this.add("justifyItems", "space-around"); }
+  get jise() { return this.add("justifyItems", "space-evenly"); }
+  ji(value: Properties["justifyItems"]) { return this.add("justifyItems", value); }
   get asfs() { return this.add("alignSelf", "flex-start"); }
   get asfe() { return this.add("alignSelf", "flex-end"); }
   get asc() { return this.add("alignSelf", "center"); }
@@ -710,6 +717,17 @@ export type Padding = "padding" | "paddingTop" | "paddingRight" | "paddingBottom
 
 type Brand<K, T> = K & { __brand: T };
 type Breakpoint = Brand<string, "Breakpoint">;
+export type BreakpointKey = "print" | "sm" | "md" | "smOrMd" | "mdAndUp" | "mdAndDown" | "lg" | "mdOrLg";
+export enum Breakpoints {
+  print = "@media print",
+  sm = "@media screen and (max-width:599px)",
+  md = "@media screen and (min-width:600px) and (max-width:959px)",
+  smOrMd = "@media screen and (max-width:959px)",
+  mdAndUp = "@media screen and (min-width:600px)",
+  mdAndDown = "@media screen and (max-width:959px)",
+  lg = "@media screen and (min-width:960px)",
+  mdOrLg = "@media screen and (min-width:600px)",
+}
 export const print = "@media print" as Breakpoint;
 export const sm = "@media screen and (max-width:599px)" as Breakpoint;
 export const md = "@media screen and (min-width:600px) and (max-width:959px)" as Breakpoint;

--- a/packages/testing-tachyons/src/Css.ts
+++ b/packages/testing-tachyons/src/Css.ts
@@ -137,6 +137,13 @@ class CssBuilder<T extends Properties1> {
   get jcsa() { return this.add("justifyContent", "space-around"); }
   get jcse() { return this.add("justifyContent", "space-evenly"); }
   jc(value: Properties["justifyContent"]) { return this.add("justifyContent", value); }
+  get jifs() { return this.add("justifyItems", "flex-start"); }
+  get jife() { return this.add("justifyItems", "flex-end"); }
+  get jic() { return this.add("justifyItems", "center"); }
+  get jisb() { return this.add("justifyItems", "space-between"); }
+  get jisa() { return this.add("justifyItems", "space-around"); }
+  get jise() { return this.add("justifyItems", "space-evenly"); }
+  ji(value: Properties["justifyItems"]) { return this.add("justifyItems", value); }
   get asfs() { return this.add("alignSelf", "flex-start"); }
   get asfe() { return this.add("alignSelf", "flex-end"); }
   get asc() { return this.add("alignSelf", "center"); }
@@ -641,6 +648,17 @@ export type Padding = "padding" | "paddingTop" | "paddingRight" | "paddingBottom
 
 type Brand<K, T> = K & { __brand: T };
 type Breakpoint = Brand<string, "Breakpoint">;
+export type BreakpointKey = "print" | "sm" | "md" | "smOrMd" | "mdAndUp" | "mdAndDown" | "lg" | "mdOrLg";
+export enum Breakpoints {
+  print = "@media print",
+  sm = "@media screen and (max-width:599px)",
+  md = "@media screen and (min-width:600px) and (max-width:959px)",
+  smOrMd = "@media screen and (max-width:959px)",
+  mdAndUp = "@media screen and (min-width:600px)",
+  mdAndDown = "@media screen and (max-width:959px)",
+  lg = "@media screen and (min-width:960px)",
+  mdOrLg = "@media screen and (min-width:600px)",
+}
 export const print = "@media print" as Breakpoint;
 export const sm = "@media screen and (max-width:599px)" as Breakpoint;
 export const md = "@media screen and (min-width:600px) and (max-width:959px)" as Breakpoint;

--- a/packages/truss/src/generate.ts
+++ b/packages/truss/src/generate.ts
@@ -66,16 +66,25 @@ function generateCssBuilder(config: Config): Code {
     .join(" | ")};
   `;
 
+  const genBreakpoints = makeBreakpoints(breakpoints || {});
+
   let breakpointCode =
     breakpoints === undefined
       ? []
       : [
           "type Brand<K, T> = K & { __brand: T };",
           "type Breakpoint = Brand<string, 'Breakpoint'>;",
-          ...Object.entries(makeBreakpoints(breakpoints || {})).map(
+          `export type BreakpointKey = ${Object.keys(genBreakpoints).map(quote).join(" | ")};`,
+          `export enum Breakpoints {
+            ${Object.entries(genBreakpoints).map(([name, value]) => {
+                return `${name} = "${value}"`;
+              })}
+            };`,
+           ...Object.entries(genBreakpoints).map(
             ([name, query]) =>
               `export const ${name} = "${query}" as Breakpoint;`
           ),
+
         ];
 
   return code`


### PR DESCRIPTION
[SC-24344](https://app.shortcut.com/homebound-team/story/24344/export-breakpoint-types-from-truss)

- exposing enum and type definitions in the truss Css generator to be consumed in beam via a new `useBreakpoint` hook that I am building. [sc-24345](https://app.shortcut.com/homebound-team/story/24345/create-usebreakpoint-hook)