### PR TITLE
feat: Support else w/breakpoints, fix addIn w/conditionals

### DIFF
--- a/packages/testing-tachyons/src/Css.test.tsx
+++ b/packages/testing-tachyons/src/Css.test.tsx
@@ -123,8 +123,58 @@ describe("Css", () => {
     Css.black.if("rawstring").$;
   });
 
-  it("cannot 'else' when using `if(bp)`", () => {
-    expect(() => Css.ifSm.black.else.white.$).toThrow("else is not supported");
+  it("can use 'else' when using `ifSm`", () => {
+    expect(Css.ifSm.black.else.white.$).toMatchInlineSnapshot(`
+      {
+        "@media not screen and (max-width:599px)": {
+          "color": "#fcfcfa",
+        },
+        "@media screen and (max-width:599px)": {
+          "color": "#353535",
+        },
+      }
+    `);
+  });
+
+  it("can use 'else' when using `ifMdAndUp`", () => {
+    expect(Css.ifMdAndUp.black.else.white.$).toMatchInlineSnapshot(`
+      {
+        "@media not screen and (min-width:600px)": {
+          "color": "#fcfcfa",
+        },
+        "@media screen and (min-width:600px)": {
+          "color": "#353535",
+        },
+      }
+    `);
+  });
+
+  it("cannot use 'else' twice when using `ifMdAndUp`", () => {
+    expect(() => Css.ifMdAndUp.black.else.white.else.blue.$).toThrowError("else was already called");
+  });
+
+  it.skip("can use 'else' twice for conditional then breakpoint use 'else' twice when using `ifMdAndUp`", () => {
+    expect(Css.if(true).ifSm.black.else.blue.else.midGray.$).toMatchInlineSnapshot(`
+      {
+        "@media not screen and (max-width:599px)": {
+          "color": "#526675",
+        },
+        "@media screen and (max-width:599px)": {
+          "color": "#353535",
+        },
+      }
+    `);
+    expect(Css.if(false).ifSm.black.else.blue.else.midGray.$).toMatchInlineSnapshot(`
+      {
+        "@media not screen and (max-width:599px)": {
+          "color": "#888888",
+        },
+      }
+    `);
+  });
+
+  it("skips breakpoint code if conditional is disabled", () => {
+    expect(Css.if(false).ifMdAndUp.black.$).toMatchInlineSnapshot(`{}`);
   });
 
   it("can render with px conversion", () => {
@@ -176,6 +226,10 @@ describe("Css", () => {
 
   it("skips addIn if passed undefined", () => {
     expect(Css.addIn("& > * + *", undefined).$).toEqual({});
+  });
+
+  it("skips addIn if conditional is disabled", () => {
+    expect(Css.if(false).addIn("& > * + *", "marginBottom", "1px").$).toMatchInlineSnapshot(`{}`);
   });
 
   it("doesn't incorrectly infer never", () => {

--- a/packages/testing-tachyons/src/Css.test.tsx
+++ b/packages/testing-tachyons/src/Css.test.tsx
@@ -194,12 +194,12 @@ describe("Css", () => {
   });
 
   it("can set css variables", () => {
-    expect(Css.setVars.$).toMatchInlineSnapshot(`
+    expect(Css.darkMode.$).toMatchInlineSnapshot(`
       {
         "--primary": "#000000",
       }
     `);
-    expect(Css.var.$).toMatchInlineSnapshot(`
+    expect(Css.primary.$).toMatchInlineSnapshot(`
       {
         "color": "var(--primary)",
       }

--- a/packages/testing-tachyons/src/Css.test.tsx
+++ b/packages/testing-tachyons/src/Css.test.tsx
@@ -229,7 +229,21 @@ describe("Css", () => {
   });
 
   it("skips addIn if conditional is disabled", () => {
-    expect(Css.if(false).addIn("& > * + *", "marginBottom", "1px").$).toMatchInlineSnapshot(`{}`);
+    expect(Css.if(false).addIn(">div", Css.mb1.$).$).toMatchInlineSnapshot(`{}`);
+    expect(Css.if(false).addIn(">div", Css.mb1.$).else.addIn(">div", Css.mb2.$).$).toMatchInlineSnapshot(`
+      {
+        ">div": {
+          "marginBottom": "16px",
+        },
+      }
+    `);
+    expect(Css.if(true).addIn(">div", Css.mb1.$).else.addIn(">div", Css.mb2.$).$).toMatchInlineSnapshot(`
+      {
+        ">div": {
+          "marginBottom": "8px",
+        },
+      }
+    `);
   });
 
   it("doesn't incorrectly infer never", () => {

--- a/packages/testing-tachyons/src/Css.ts
+++ b/packages/testing-tachyons/src/Css.ts
@@ -1954,7 +1954,11 @@ class CssBuilder<T extends Properties> {
 
   get else() {
     if (this.selector !== undefined) {
-      throw new Error("else is not supported with if(selector)");
+      if (this.selector.includes("not")) {
+        throw new Error("else was already called");
+      } else {
+        return this.newCss({ selector: this.selector.replace("@media", "@media not") });
+      }
     }
     return this.newCss({ enabled: !this.enabled });
   }
@@ -1967,12 +1971,13 @@ class CssBuilder<T extends Properties> {
   add<P extends Properties>(props: P): CssBuilder<T & P>;
   add<K extends keyof Properties>(prop: K, value: Properties[K]): CssBuilder<T & { [U in K]: Properties[K] }>;
   add<K extends keyof Properties>(propOrProperties: K | Properties, value?: Properties[K]): CssBuilder<any> {
+    if (!this.enabled) {
+      return this;
+    }
     const newRules = typeof propOrProperties === "string" ? { [propOrProperties]: value } : propOrProperties;
     const rules = this.selector
       ? { ...this.rules, [this.selector]: { ...(this.rules as any)[this.selector], ...newRules } }
-      : this.enabled
-      ? { ...this.rules, ...newRules }
-      : this.rules;
+      : { ...this.rules, ...newRules };
     return this.newCss({ rules: rules as any });
   }
 
@@ -1989,6 +1994,9 @@ class CssBuilder<T extends Properties> {
     value?: Properties[K],
   ): CssBuilder<any> {
     const newRules = typeof propOrProperties === "string" ? { [propOrProperties]: value } : propOrProperties;
+    if (!this.enabled) {
+      return this;
+    }
     if (newRules === undefined) {
       return this;
     }

--- a/packages/testing-tachyons/src/Css.ts
+++ b/packages/testing-tachyons/src/Css.ts
@@ -1896,12 +1896,8 @@ class CssBuilder<T extends Properties> {
   }
 
   // vars
-  get setVars() {
+  get darkMode() {
     return this.add("--primary" as any, "#000000");
-  }
-  /** Sets `color: "var(--primary)"`. */
-  get var() {
-    return this.add("color", "var(--primary)");
   }
 
   // aliases

--- a/packages/testing-tachyons/truss-config.ts
+++ b/packages/testing-tachyons/truss-config.ts
@@ -28,10 +28,7 @@ const sections = {
   customStuff: () => [newMethod("foo", { color: "#000000" })],
 
   // Create a rule that sets a CSS variable.
-  vars: () => [
-    newSetCssVariablesMethod("setVars", { "--primary": "#000000" }),
-    newMethod("var", { color: "var(--primary)" }),
-  ],
+  vars: () => [newSetCssVariablesMethod("darkMode", { "--primary": "#000000" })],
 };
 
 // You can also define common application-specific aliases.

--- a/packages/truss/src/generate.ts
+++ b/packages/truss/src/generate.ts
@@ -122,7 +122,11 @@ class CssBuilder<T extends Properties> {
 
   get else() {
     if (this.selector !== undefined) {
-      throw new Error("else is not supported with if(selector)");
+      if (this.selector.includes("not")) {
+        throw new Error("else was already called");
+      } else {
+        return this.newCss({ selector: this.selector.replace("@media", "@media not") });
+      }
     }
     return this.newCss({ enabled: !this.enabled });
   }
@@ -133,10 +137,11 @@ class CssBuilder<T extends Properties> {
   add<P extends Properties>(props: P): CssBuilder<T & P>;
   add<K extends keyof Properties>(prop: K, value: Properties[K]): CssBuilder<T & { [U in K]: Properties[K] }>;
   add<K extends keyof Properties>(propOrProperties: K | Properties, value?: Properties[K]): CssBuilder<any> {
+    if (!this.enabled) return this;
     const newRules = typeof propOrProperties === "string" ?  { [propOrProperties]: value } : propOrProperties;
     const rules = this.selector
       ? { ...this.rules, [this.selector]: { ...(this.rules as any)[this.selector], ...newRules } }
-      : this.enabled ? { ...this.rules, ...newRules } : this.rules;
+      : { ...this.rules, ...newRules };
     return this.newCss({ rules: rules as any });
   }
 
@@ -145,6 +150,7 @@ class CssBuilder<T extends Properties> {
   addIn<K extends keyof Properties>(selector: string, prop: K, value: Properties[K]): CssBuilder<T & { [U in K]: Properties[K] }>;
   addIn<K extends keyof Properties>(selector: string, propOrProperties: K | Properties, value?: Properties[K]): CssBuilder<any> {
     const newRules = typeof propOrProperties === "string" ?  { [propOrProperties]: value } : propOrProperties;
+    if (!this.enabled) return this;
     if (newRules === undefined) {
       return this;
     }

--- a/packages/truss/src/methods.ts
+++ b/packages/truss/src/methods.ts
@@ -69,7 +69,7 @@ export function newAliasesMethods(aliases: Aliases): UtilityMethod[] {
  * I.e. `newSetCssVariableMethod("dark", { "--Primary": "white" })` will create a
  * utility method `Css.dark.$ that will set `--Primary` to `white`.
  *
- * Currently this only supports compile-time/hard-coded values. I.e. we don't support
+ * Currently, this only supports compile-time/hard-coded values. I.e. we don't support
  * something like `Css.dark({ "--Primary", someRuntimeValue }).$` yet.
  *
  * TODO: Create a `Css.set(cssVars).$` method.


### PR DESCRIPTION
Turns out there is a `not` operator for media queries, which makes this really easy.

Also fixes `addIn` not respecting `if` / `enabled`.