### PR TITLE
feat: support additional properties to utility method

### DIFF
--- a/packages/template-tachyons/src/Css.ts
+++ b/packages/template-tachyons/src/Css.ts
@@ -1172,51 +1172,58 @@ class CssBuilder<T extends Properties> {
   }
 
   // lineClamp
-  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitLineClamp: 1; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"`. */
+  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"; WebkitLineClamp: 1`. */
   get lineClamp1() {
-    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitLineClamp", 1).add(
-      "WebkitBoxOrient",
-      "vertical",
-    ).add("textOverflow", "ellipsis");
+    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitBoxOrient", "vertical").add(
+      "textOverflow",
+      "ellipsis",
+    ).add("WebkitLineClamp", 1);
   }
-  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitLineClamp: 2; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"`. */
+  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"; WebkitLineClamp: 2`. */
   get lineClamp2() {
-    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitLineClamp", 2).add(
-      "WebkitBoxOrient",
-      "vertical",
-    ).add("textOverflow", "ellipsis");
+    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitBoxOrient", "vertical").add(
+      "textOverflow",
+      "ellipsis",
+    ).add("WebkitLineClamp", 2);
   }
-  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitLineClamp: 3; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"`. */
+  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"; WebkitLineClamp: 3`. */
   get lineClamp3() {
-    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitLineClamp", 3).add(
-      "WebkitBoxOrient",
-      "vertical",
-    ).add("textOverflow", "ellipsis");
+    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitBoxOrient", "vertical").add(
+      "textOverflow",
+      "ellipsis",
+    ).add("WebkitLineClamp", 3);
   }
-  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitLineClamp: 4; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"`. */
+  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"; WebkitLineClamp: 4`. */
   get lineClamp4() {
-    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitLineClamp", 4).add(
-      "WebkitBoxOrient",
-      "vertical",
-    ).add("textOverflow", "ellipsis");
+    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitBoxOrient", "vertical").add(
+      "textOverflow",
+      "ellipsis",
+    ).add("WebkitLineClamp", 4);
   }
-  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitLineClamp: 5; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"`. */
+  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"; WebkitLineClamp: 5`. */
   get lineClamp5() {
-    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitLineClamp", 5).add(
-      "WebkitBoxOrient",
-      "vertical",
-    ).add("textOverflow", "ellipsis");
+    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitBoxOrient", "vertical").add(
+      "textOverflow",
+      "ellipsis",
+    ).add("WebkitLineClamp", 5);
   }
-  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitLineClamp: 6; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"`. */
+  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"; WebkitLineClamp: 6`. */
   get lineClamp6() {
-    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitLineClamp", 6).add(
-      "WebkitBoxOrient",
-      "vertical",
-    ).add("textOverflow", "ellipsis");
+    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitBoxOrient", "vertical").add(
+      "textOverflow",
+      "ellipsis",
+    ).add("WebkitLineClamp", 6);
   }
   /** Sets `WebkitLineClamp: "unset"`. */
   get lineClampNone() {
     return this.add("WebkitLineClamp", "unset");
+  }
+  /** Sets `WebkitLineClamp: value`. */
+  lineClamp(value: Properties["WebkitLineClamp"]) {
+    return this.add("WebkitLineClamp", value).add("overflow", "hidden").add("display", "-webkit-box").add(
+      "WebkitBoxOrient",
+      "vertical",
+    ).add("textOverflow", "ellipsis");
   }
 
   // objectFit

--- a/packages/testing-tachyons/src/Css.ts
+++ b/packages/testing-tachyons/src/Css.ts
@@ -1072,51 +1072,58 @@ class CssBuilder<T extends Properties> {
   }
 
   // lineClamp
-  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitLineClamp: 1; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"`. */
+  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"; WebkitLineClamp: 1`. */
   get lineClamp1() {
-    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitLineClamp", 1).add(
-      "WebkitBoxOrient",
-      "vertical",
-    ).add("textOverflow", "ellipsis");
+    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitBoxOrient", "vertical").add(
+      "textOverflow",
+      "ellipsis",
+    ).add("WebkitLineClamp", 1);
   }
-  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitLineClamp: 2; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"`. */
+  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"; WebkitLineClamp: 2`. */
   get lineClamp2() {
-    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitLineClamp", 2).add(
-      "WebkitBoxOrient",
-      "vertical",
-    ).add("textOverflow", "ellipsis");
+    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitBoxOrient", "vertical").add(
+      "textOverflow",
+      "ellipsis",
+    ).add("WebkitLineClamp", 2);
   }
-  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitLineClamp: 3; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"`. */
+  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"; WebkitLineClamp: 3`. */
   get lineClamp3() {
-    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitLineClamp", 3).add(
-      "WebkitBoxOrient",
-      "vertical",
-    ).add("textOverflow", "ellipsis");
+    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitBoxOrient", "vertical").add(
+      "textOverflow",
+      "ellipsis",
+    ).add("WebkitLineClamp", 3);
   }
-  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitLineClamp: 4; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"`. */
+  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"; WebkitLineClamp: 4`. */
   get lineClamp4() {
-    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitLineClamp", 4).add(
-      "WebkitBoxOrient",
-      "vertical",
-    ).add("textOverflow", "ellipsis");
+    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitBoxOrient", "vertical").add(
+      "textOverflow",
+      "ellipsis",
+    ).add("WebkitLineClamp", 4);
   }
-  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitLineClamp: 5; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"`. */
+  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"; WebkitLineClamp: 5`. */
   get lineClamp5() {
-    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitLineClamp", 5).add(
-      "WebkitBoxOrient",
-      "vertical",
-    ).add("textOverflow", "ellipsis");
+    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitBoxOrient", "vertical").add(
+      "textOverflow",
+      "ellipsis",
+    ).add("WebkitLineClamp", 5);
   }
-  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitLineClamp: 6; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"`. */
+  /** Sets `overflow: "hidden"; display: "-webkit-box"; WebkitBoxOrient: "vertical"; textOverflow: "ellipsis"; WebkitLineClamp: 6`. */
   get lineClamp6() {
-    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitLineClamp", 6).add(
-      "WebkitBoxOrient",
-      "vertical",
-    ).add("textOverflow", "ellipsis");
+    return this.add("overflow", "hidden").add("display", "-webkit-box").add("WebkitBoxOrient", "vertical").add(
+      "textOverflow",
+      "ellipsis",
+    ).add("WebkitLineClamp", 6);
   }
   /** Sets `WebkitLineClamp: "unset"`. */
   get lineClampNone() {
     return this.add("WebkitLineClamp", "unset");
+  }
+  /** Sets `WebkitLineClamp: value`. */
+  lineClamp(value: Properties["WebkitLineClamp"]) {
+    return this.add("WebkitLineClamp", value).add("overflow", "hidden").add("display", "-webkit-box").add(
+      "WebkitBoxOrient",
+      "vertical",
+    ).add("textOverflow", "ellipsis");
   }
 
   // objectFit

--- a/packages/truss/src/methods.ts
+++ b/packages/truss/src/methods.ts
@@ -16,12 +16,12 @@ export function newMethod(abbr: UtilityName, defs: Properties): UtilityMethod {
 /**
  * Given a single abbreviation (i.e. `mt`) and a property name (i.e. `marginTop`), returns the
  * TypeScript code for a `mt` utility method that accepts a user-provided value of the prop to set.
- * Use `extraDefs` for additional properties to set.
+ * Use `extraProperties` for additional properties to set.
  *
  * I.e. `Css.mt(someValue).$`
  */
-export function newParamMethod(abbr: UtilityName, prop: keyof Properties, extraDefs: Properties = {}): UtilityMethod {
-  const additionalDefs = Object.entries(extraDefs).map(([prop, value]) => `.add("${prop}", ${maybeWrap(value)})`).join("");
+export function newParamMethod(abbr: UtilityName, prop: keyof Properties, extraProperties: Properties = {}): UtilityMethod {
+  const additionalDefs = Object.entries(extraProperties).map(([prop, value]) => `.add("${prop}", ${maybeWrap(value)})`).join("");
   return `${comment({ [prop]: "value" })} ${abbr}(value: Properties["${prop}"]) { return this.add("${prop}", value)${additionalDefs}; }`;
 }
 
@@ -37,7 +37,7 @@ export function newParamMethod(abbr: UtilityName, prop: keyof Properties, extraD
  * to `null`.
  *
  * @param prop the CSS property we're setting, i.e. `marginTop`
- * @param defs a map of abbreviation name --> value
+ * @param defs a map of abbreviation name --> value (a property value or an object of properties to set)
  * @param baseName the base name to use, i.e. `mt`
  * @param includePx generate an extra `${baseName}Px` method that calls the base method with a converted px value
  * @param baseDefs additional properties to set for the base method
@@ -47,12 +47,15 @@ export function newMethodsForProp<P extends Prop>(
   defs: Record<UtilityName, Properties[P] | Properties>,
   baseName: string | null = prop,
   includePx: boolean = false,
-  baseDefs?: Omit<Properties, P>,
+  valueMethodExtraProperties?: Omit<Properties, P>,
 ): UtilityMethod[] {
   return [
-    ...Object.entries(defs).map(([abbr, value]) => newMethod(abbr, typeof value === "object" ? value : { [prop]: value })),
+    ...Object.entries(defs).map(([abbr, value]) => newMethod(abbr,
+      // If the value is an object, use it as the full defs, otherwise, use it as the prop value
+      typeof value === "object" ? value : { [prop]: value }
+    )),
     // Conditionally add a method that directly accepts a value for prop
-    ...(baseName !== null ? [newParamMethod(baseName, prop, baseDefs)] : []),
+    ...(baseName !== null ? [newParamMethod(baseName, prop, valueMethodExtraProperties)] : []),
     ...(baseName !== null && includePx ? [newPxMethod(baseName, prop)] : []),
   ];
 }

--- a/packages/truss/src/methods.ts
+++ b/packages/truss/src/methods.ts
@@ -16,11 +16,13 @@ export function newMethod(abbr: UtilityName, defs: Properties): UtilityMethod {
 /**
  * Given a single abbreviation (i.e. `mt`) and a property name (i.e. `marginTop`), returns the
  * TypeScript code for a `mt` utility method that accepts a user-provided value of the prop to set.
+ * Use `extraDefs` for additional properties to set.
  *
  * I.e. `Css.mt(someValue).$`
  */
-export function newParamMethod(abbr: UtilityName, prop: keyof Properties): UtilityMethod {
-  return `${comment({ [prop]: "value" })} ${abbr}(value: Properties["${prop}"]) { return this.add("${prop}", value); }`;
+export function newParamMethod(abbr: UtilityName, prop: keyof Properties, extraDefs: Properties = {}): UtilityMethod {
+  const additionalDefs = Object.entries(extraDefs).map(([prop, value]) => `.add("${prop}", ${maybeWrap(value)})`).join("");
+  return `${comment({ [prop]: "value" })} ${abbr}(value: Properties["${prop}"]) { return this.add("${prop}", value)${additionalDefs}; }`;
 }
 
 /**
@@ -38,17 +40,19 @@ export function newParamMethod(abbr: UtilityName, prop: keyof Properties): Utili
  * @param defs a map of abbreviation name --> value
  * @param baseName the base name to use, i.e. `mt`
  * @param includePx generate an extra `${baseName}Px` method that calls the base method with a converted px value
+ * @param baseDefs additional properties to set for the base method
  */
 export function newMethodsForProp<P extends Prop>(
   prop: P,
-  defs: Record<UtilityName, Properties[P]>,
+  defs: Record<UtilityName, Properties[P] | Properties>,
   baseName: string | null = prop,
   includePx: boolean = false,
+  baseDefs?: Omit<Properties, P>,
 ): UtilityMethod[] {
   return [
-    ...Object.entries(defs).map(([abbr, value]) => newMethod(abbr, { [prop]: value })),
+    ...Object.entries(defs).map(([abbr, value]) => newMethod(abbr, typeof value === "object" ? value : { [prop]: value })),
     // Conditionally add a method that directly accepts a value for prop
-    ...(baseName !== null ? [newParamMethod(baseName, prop)] : []),
+    ...(baseName !== null ? [newParamMethod(baseName, prop, baseDefs)] : []),
     ...(baseName !== null && includePx ? [newPxMethod(baseName, prop)] : []),
   ];
 }

--- a/packages/truss/src/sections/tachyons/lineClamp.ts
+++ b/packages/truss/src/sections/tachyons/lineClamp.ts
@@ -1,19 +1,31 @@
-import { newMethod, zeroTo } from "src/methods";
+import { Properties } from "csstype";
 import { CreateMethodsFn } from "src/config";
+import { newMethodsForProp } from "src/methods";
+
+const additionalDefs: Properties = {
+  overflow: "hidden",
+  display: "-webkit-box",
+  // As of 11/28/2022, this is deprecated but still necessary for lineClamp to work:
+  // https://github.com/tailwindlabs/tailwindcss-line-clamp/blob/master/src/index.js
+  WebkitBoxOrient: "vertical",
+  // tailwinds doesn't add this by default, but it seems like a good default for us.
+  textOverflow: "ellipsis",
+}
 
 // https://github.com/tailwindlabs/tailwindcss-line-clamp/
-export const lineClamp: CreateMethodsFn = () => [
-  ...zeroTo(5).map((i) =>
-    newMethod(`lineClamp${i + 1}`, {
-      overflow: "hidden",
-      display: "-webkit-box",
-      WebkitLineClamp: i + 1,
-      // As of 11/28/2022, this is deprecated but still necessary for lineClamp to work:
-      // https://github.com/tailwindlabs/tailwindcss-line-clamp/blob/master/src/index.js
-      WebkitBoxOrient: "vertical",
-      // tailwinds doesn't add this by default, but it seems like a good default for us.
-      textOverflow: "ellipsis",
-    }),
-  ),
-  newMethod(`lineClampNone`, { WebkitLineClamp: "unset" }),
-];
+export const lineClamp: CreateMethodsFn = () =>
+  newMethodsForProp(
+    "WebkitLineClamp",
+    {
+      lineClamp1: { ...additionalDefs, WebkitLineClamp: 1 },
+      lineClamp2: { ...additionalDefs, WebkitLineClamp: 2 },
+      lineClamp3: { ...additionalDefs, WebkitLineClamp: 3 },
+      lineClamp4: { ...additionalDefs, WebkitLineClamp: 4 },
+      lineClamp5: { ...additionalDefs, WebkitLineClamp: 5 },
+      lineClamp6: { ...additionalDefs, WebkitLineClamp: 6 },
+      lineClampNone: { WebkitLineClamp: "unset" },
+    },
+    "lineClamp",
+    false,
+    additionalDefs
+);


### PR DESCRIPTION
This PR enhances the utility method to support additional properties. For instance, the `lineClamp` [property](https://github.com/homebound-team/truss/blob/main/packages/truss/src/sections/tachyons/lineClamp.ts) does have additional properties but those can't be passed to the `lineClamp(value)` utility method.

Before
```ts
/** Sets `WebkitLineClamp: value`. */
  lineClamp(value: Properties["WebkitLineClamp"]) {
    return this.add("WebkitLineClamp", value);
  }
```

After
```ts
/** Sets `WebkitLineClamp: value`. */
  lineClamp(value: Properties["WebkitLineClamp"]) {
    return this.add("WebkitLineClamp", value) // default def
    .add("overflow", "hidden").add("display", "-webkit-box").add("WebkitBoxOrient","vertical",).add("textOverflow", "ellipsis"); // additional defs
  }
```

With these changes, `lineClamp(value)` will have the ability to define additional properties combining to the `value` param.

Also, added a few tests for `packages/truss/src/methods.test.ts`

cc @bdow since he's going to use it.