### PR TITLE
ci: pin PR title action to SHA and restrict permissions

### DIFF
--- a/.github/workflows/conventional-commit-pr-title.yml
+++ b/.github/workflows/conventional-commit-pr-title.yml
@@ -8,10 +8,13 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   validate_pr_title:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v3.1.0
+      - uses: amannn/action-semantic-pull-request@d2ab30dcffc66150340abb5b947d518a3c3ce9cb # v3.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Small hardening pass on our PR title workflow, based on a [zizmor](https://docs.zizmor.sh) scan:

- Pinned `amannn/action-semantic-pull-request` to its commit SHA. Tags are mutable, so this protects us if the tag ever gets re-pointed.
- Added `permissions: pull-requests: read` so the job uses a minimal token instead of inheriting the default scopes.

Functionally identical — the action just validates that PR titles follow conventional commits. Same fix as homebound-team/beam#1242.

Note: zizmor also flags `on: pull_request_target` as risky in general. Per the [maintainer](https://github.com/amannn/action-semantic-pull-request/issues/182) and [GitHub Security Lab](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/), it's safe here since we don't check out PR code — the two changes above are the recommended defense-in-depth on top.