### PR TITLE
refactor: Simplify the plugin compiler internals.

### DIFF
--- a/packages/truss/src/plugin/ast-utils.ts
+++ b/packages/truss/src/plugin/ast-utils.ts
@@ -1,110 +1,9 @@
 import * as t from "@babel/types";
 import type { ChainNode } from "./resolve-chain";
 
-/**
- * Collect module-scope bindings so generated declarations can avoid collisions.
- *
- * We only care about top-level names because the transform injects declarations
- * at the module root, not inside nested blocks.
- */
-export function collectTopLevelBindings(ast: t.File): Set<string> {
-  const used = new Set<string>();
-
-  for (const node of ast.program.body) {
-    if (t.isImportDeclaration(node)) {
-      for (const spec of node.specifiers) {
-        used.add(spec.local.name);
-      }
-      continue;
-    }
-
-    if (t.isVariableDeclaration(node)) {
-      for (const decl of node.declarations) {
-        collectPatternBindings(decl.id, used);
-      }
-      continue;
-    }
-
-    if (t.isFunctionDeclaration(node) && node.id) {
-      used.add(node.id.name);
-      continue;
-    }
-
-    if (t.isClassDeclaration(node) && node.id) {
-      used.add(node.id.name);
-      continue;
-    }
-
-    if (t.isExportNamedDeclaration(node) && node.declaration) {
-      const decl = node.declaration;
-      if (t.isVariableDeclaration(decl)) {
-        for (const varDecl of decl.declarations) {
-          collectPatternBindings(varDecl.id, used);
-        }
-      } else if ((t.isFunctionDeclaration(decl) || t.isClassDeclaration(decl)) && decl.id) {
-        used.add(decl.id.name);
-      }
-      continue;
-    }
-
-    if (t.isExportDefaultDeclaration(node)) {
-      const decl = node.declaration;
-      if ((t.isFunctionDeclaration(decl) || t.isClassDeclaration(decl)) && decl.id) {
-        used.add(decl.id.name);
-      }
-    }
-  }
-
-  return used;
-}
-
-/**
- * Recursively collect names introduced by binding patterns.
- *
- * This handles destructuring (`const { a } = ...`, `const [x] = ...`) so we do
- * not accidentally generate a helper that shadows an existing binding.
- */
-function collectPatternBindings(pattern: t.LVal | t.VoidPattern, used: Set<string>): void {
-  if (t.isVoidPattern(pattern)) {
-    return;
-  }
-
-  if (t.isIdentifier(pattern)) {
-    used.add(pattern.name);
-    return;
-  }
-
-  if (t.isAssignmentPattern(pattern)) {
-    collectPatternBindings(pattern.left, used);
-    return;
-  }
-
-  if (t.isRestElement(pattern)) {
-    collectPatternBindings(pattern.argument as t.LVal, used);
-    return;
-  }
-
-  if (t.isObjectPattern(pattern)) {
-    for (const prop of pattern.properties) {
-      if (t.isObjectProperty(prop)) {
-        collectPatternBindings(prop.value as t.LVal, used);
-      } else if (t.isRestElement(prop)) {
-        collectPatternBindings(prop.argument as t.LVal, used);
-      }
-    }
-    return;
-  }
-
-  if (t.isArrayPattern(pattern)) {
-    for (const el of pattern.elements) {
-      if (!el) continue;
-      if (t.isIdentifier(el) || t.isAssignmentPattern(el) || t.isObjectPattern(el) || t.isArrayPattern(el)) {
-        collectPatternBindings(el, used);
-      } else if (t.isRestElement(el)) {
-        collectPatternBindings(el.argument as t.LVal, used);
-      }
-    }
-  }
+export interface NamedImport {
+  importedName: string;
+  localName: string;
 }
 
 /**
@@ -138,19 +37,9 @@ export function reservePreferredName(used: Set<string>, preferred: string, secon
   return candidate;
 }
 
-/**
- * Find the local binding name for `Css` from import declarations.
- */
+/** Find the local binding name for `Css` from import declarations. */
 export function findCssImportBinding(ast: t.File): string | null {
-  for (const node of ast.program.body) {
-    if (!t.isImportDeclaration(node)) continue;
-    for (const spec of node.specifiers) {
-      if (t.isImportSpecifier(spec) && t.isIdentifier(spec.imported, { name: "Css" })) {
-        return spec.local.name;
-      }
-    }
-  }
-  return null;
+  return findNamedImportBinding(ast, "Css");
 }
 
 /**
@@ -176,22 +65,14 @@ export function findCssBuilderBinding(ast: t.File): string | null {
   return null;
 }
 
-/** Check if the AST contains a `binding.method(...)` call expression. */
-export function hasCssMethodCall(ast: t.File, binding: string, method: string): boolean {
-  let found = false;
-  t.traverseFast(ast, (node) => {
-    if (found) return;
-    if (
-      t.isCallExpression(node) &&
-      t.isMemberExpression(node.callee) &&
-      !node.callee.computed &&
-      t.isIdentifier(node.callee.object, { name: binding }) &&
-      t.isIdentifier(node.callee.property, { name: method })
-    ) {
-      found = true;
-    }
-  });
-  return found;
+/** True for a `binding.method(...)` call, i.e. `Css.props(...)` when `binding` is `"Css"` and `method` is `"props"`. */
+export function isCssMethodCall(node: t.CallExpression, binding: string, method: string): boolean {
+  return (
+    t.isMemberExpression(node.callee) &&
+    !node.callee.computed &&
+    t.isIdentifier(node.callee.object, { name: binding }) &&
+    t.isIdentifier(node.callee.property, { name: method })
+  );
 }
 
 /**
@@ -225,9 +106,27 @@ export function findLastImportIndex(ast: t.File): number {
   return lastImportIndex;
 }
 
-export function findNamedImportBinding(ast: t.File, source: string, importedName: string): string | null {
+/**
+ * Insert statements directly after the module's leading block of imports.
+ *
+ * I.e. before the first non-import statement, so helpers land near the top even when a
+ * later import (like the test-mode `import "virtual:truss:test-css"`) trails the module body.
+ */
+export function insertAfterLeadingImports(ast: t.File, statements: t.Statement[]): void {
+  if (statements.length === 0) return;
+  const firstNonImport = ast.program.body.findIndex((node) => !t.isImportDeclaration(node));
+  ast.program.body.splice(firstNonImport === -1 ? ast.program.body.length : firstNonImport, 0, ...statements);
+}
+
+/**
+ * Find the local name of a named import, i.e. `mergeProps13` for `import { mergeProps as mergeProps13 }`.
+ *
+ * When `source` is given, only imports from that module are considered.
+ */
+export function findNamedImportBinding(ast: t.File, importedName: string, source?: string): string | null {
   for (const node of ast.program.body) {
-    if (!t.isImportDeclaration(node) || node.source.value !== source) continue;
+    if (!t.isImportDeclaration(node)) continue;
+    if (source !== undefined && node.source.value !== source) continue;
     for (const spec of node.specifiers) {
       if (t.isImportSpecifier(spec) && t.isIdentifier(spec.imported, { name: importedName })) {
         return spec.local.name;
@@ -237,6 +136,7 @@ export function findNamedImportBinding(ast: t.File, source: string, importedName
   return null;
 }
 
+/** Find the import declaration for `source`, if the module has one. */
 export function findImportDeclaration(ast: t.File, source: string): t.ImportDeclaration | null {
   for (const node of ast.program.body) {
     if (t.isImportDeclaration(node) && node.source.value === source) {
@@ -246,11 +146,15 @@ export function findImportDeclaration(ast: t.File, source: string): t.ImportDecl
   return null;
 }
 
+/**
+ * Repoint an import that only binds `Css` at `source` with `imports`, so the runtime import
+ * lands on the line the Css import occupied. Returns false when no such sole-specifier import exists.
+ */
 export function replaceCssImportWithNamedImports(
   ast: t.File,
   cssBinding: string,
   source: string,
-  imports: Array<{ importedName: string; localName: string }>,
+  imports: NamedImport[],
 ): boolean {
   for (const node of ast.program.body) {
     if (!t.isImportDeclaration(node)) continue;
@@ -261,44 +165,30 @@ export function replaceCssImportWithNamedImports(
     if (cssSpecIndex === -1 || node.specifiers.length !== 1) continue;
 
     node.source = t.stringLiteral(source);
-    node.specifiers = imports.map((entry) => {
-      return t.importSpecifier(t.identifier(entry.localName), t.identifier(entry.importedName));
-    });
+    node.specifiers = imports.map(toImportSpecifier);
     return true;
   }
 
   return false;
 }
 
-export function upsertNamedImports(
-  ast: t.File,
-  source: string,
-  imports: Array<{ importedName: string; localName: string }>,
-): void {
+/** Add `imports` to the existing import of `source`, or add a new import after the last one. */
+export function upsertNamedImports(ast: t.File, source: string, imports: NamedImport[]): void {
   if (imports.length === 0) return;
 
-  for (const node of ast.program.body) {
-    if (!t.isImportDeclaration(node) || node.source.value !== source) continue;
-
-    for (const entry of imports) {
-      const exists = node.specifiers.some((spec) => {
-        return t.isImportSpecifier(spec) && t.isIdentifier(spec.imported, { name: entry.importedName });
-      });
-      if (exists) continue;
-
-      node.specifiers.push(t.importSpecifier(t.identifier(entry.localName), t.identifier(entry.importedName)));
-    }
+  const existing = findImportDeclaration(ast, source);
+  if (!existing) {
+    const importDecl = t.importDeclaration(imports.map(toImportSpecifier), t.stringLiteral(source));
+    ast.program.body.splice(findLastImportIndex(ast) + 1, 0, importDecl);
     return;
   }
 
-  const importDecl = t.importDeclaration(
-    imports.map((entry) => {
-      return t.importSpecifier(t.identifier(entry.localName), t.identifier(entry.importedName));
-    }),
-    t.stringLiteral(source),
-  );
-  const idx = findLastImportIndex(ast);
-  ast.program.body.splice(idx + 1, 0, importDecl);
+  for (const entry of imports) {
+    const exists = existing.specifiers.some((spec) => {
+      return t.isImportSpecifier(spec) && t.isIdentifier(spec.imported, { name: entry.importedName });
+    });
+    if (!exists) existing.specifiers.push(toImportSpecifier(entry));
+  }
 }
 
 /**
@@ -359,4 +249,48 @@ export function extractChain(node: t.Expression, cssBinding: string): ChainNode[
 
     return null;
   }
+}
+
+/**
+ * Extract the chain of a complete `Css.*.$` expression.
+ *
+ * Returns `null` when `node` does not end in `.$` or is not rooted at `cssBinding`.
+ */
+export function extractDollarChain(node: t.Node, cssBinding: string): ChainNode[] | null {
+  if (!t.isMemberExpression(node) || node.computed || !t.isIdentifier(node.property, { name: "$" })) return null;
+  if (t.isSuper(node.object)) return null;
+  return extractChain(node.object, cssBinding);
+}
+
+/** Strip parentheses and TypeScript-only wrappers, i.e. `(x as Foo)!` → `x`. */
+export function unwrapExpression(node: t.Expression): t.Expression {
+  let current = node;
+  while (
+    t.isParenthesizedExpression(current) ||
+    t.isTSAsExpression(current) ||
+    t.isTSTypeAssertion(current) ||
+    t.isTSNonNullExpression(current) ||
+    t.isTSSatisfiesExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+/** The static name of an object key, i.e. `foo` and `"foo"` → `"foo"`; null for computed or other keys. */
+export function staticPropertyName(key: t.Node): string | null {
+  if (t.isIdentifier(key)) return key.name;
+  if (t.isStringLiteral(key)) return key.value;
+  return null;
+}
+
+/** The static member name of `obj.foo` or `obj["foo"]` → `"foo"`; null for other member access. */
+export function memberPropertyName(node: t.MemberExpression): string | null {
+  if (!node.computed && t.isIdentifier(node.property)) return node.property.name;
+  if (node.computed && t.isStringLiteral(node.property)) return node.property.value;
+  return null;
+}
+
+function toImportSpecifier(entry: NamedImport): t.ImportSpecifier {
+  return t.importSpecifier(t.identifier(entry.localName), t.identifier(entry.importedName));
 }

--- a/packages/truss/src/plugin/css-ts-utils.ts
+++ b/packages/truss/src/plugin/css-ts-utils.ts
@@ -1,4 +1,5 @@
 import * as t from "@babel/types";
+import { unwrapExpression } from "./ast-utils";
 
 /** Resolve module-scope string constants so .css.ts selectors can reuse them. */
 export function collectStaticStringBindings(ast: t.File): Map<string, string> {
@@ -31,6 +32,7 @@ export function collectStaticStringBindings(ast: t.File): Map<string, string> {
 /** Resolve a static string expression from a literal, template, or identifier. */
 export function resolveStaticString(node: t.Node | null | undefined, bindings: Map<string, string>): string | null {
   if (!node) return null;
+  if (t.isExpression(node)) node = unwrapExpression(node);
 
   if (t.isStringLiteral(node)) return node.value;
 
@@ -49,14 +51,6 @@ export function resolveStaticString(node: t.Node | null | undefined, bindings: M
 
   if (t.isIdentifier(node)) {
     return bindings.get(node.name) ?? null;
-  }
-
-  if (t.isTSAsExpression(node) || t.isTSSatisfiesExpression(node) || t.isTSNonNullExpression(node)) {
-    return resolveStaticString(node.expression, bindings);
-  }
-
-  if (t.isParenthesizedExpression(node)) {
-    return resolveStaticString(node.expression, bindings);
   }
 
   if (t.isBinaryExpression(node, { operator: "+" })) {

--- a/packages/truss/src/plugin/emit-truss.ts
+++ b/packages/truss/src/plugin/emit-truss.ts
@@ -1,8 +1,10 @@
 import * as t from "@babel/types";
-import type { ResolvedChain } from "./resolve-chain";
-import { getLonghandLookup, type ResolvedSegment, type TrussMapping, type WhenCondition } from "./types";
-import { computeRulePriority, sortRulesByPriority } from "./priority";
+import { chainSegments, type ResolvedChain } from "./resolve-chain";
+import { isStyleSegment, type ResolvedSegment, type TrussMapping, type WhenCondition } from "./types";
+import { breakpointNameForMediaQuery, findCanonicalAbbreviation } from "./mapping-utils";
+import { sortRulesByPriority } from "./priority";
 import { cssPropertyAbbreviations } from "./css-property-abbreviations";
+import { WHEN_RELATIONSHIPS, type WhenRelationship } from "./when-relationships";
 import { pseudoSelectorPrefix } from "../pseudo-selectors";
 import { variableValueNeedsMaybeCssVar } from "../css-custom-property";
 import { SPACING_CUSTOM_PROPERTY, tryParseIncrementCalcMultiplier } from "../spacing-css-var";
@@ -25,23 +27,28 @@ export interface AtomicRule {
    * `[{ cssProperty: "height", cssValue: "var(--height)", cssVarName: "--height" },
    *   { cssProperty: "width", cssValue: "var(--width)", cssVarName: "--width" }]` for `sq(x)`.
    */
-  declarations: Array<{
-    cssProperty: string;
-    cssValue: string;
-    /** I.e. `"--marginTop"` — present when this declaration uses a CSS custom property. */
-    cssVarName?: string;
-  }>;
+  declarations: AtomicDeclaration[];
   pseudoClass?: string;
   mediaQuery?: string;
   pseudoElement?: string;
   /** I.e. `when(row, "ancestor", ":hover")` → `{ relationship: "ancestor", markerClass: "_row_mrk", pseudo: ":hover" }`. */
-  whenSelector?: {
-    relationship: string;
-    markerClass: string;
-    pseudo: string;
-  };
+  whenSelector?: WhenSelector;
 }
 
+export interface AtomicDeclaration {
+  cssProperty: string;
+  cssValue: string;
+  /** I.e. `"--marginTop"` — present when this declaration uses a CSS custom property. */
+  cssVarName?: string;
+}
+
+export interface WhenSelector {
+  relationship: WhenRelationship;
+  markerClass: string;
+  pseudo: string;
+}
+
+/** One class/property pair derived from a segment; the shared model both CSS rules and style hashes consume. */
 interface StyleEntry {
   cssProp: string;
   className: string;
@@ -51,23 +58,12 @@ interface StyleEntry {
   /** Concrete CSS declaration value for emitted CSS rules. */
   cssValue: string;
   varName?: string;
-  argNode?: unknown;
+  argNode?: t.Expression;
   /** Compile-time resolved tuple value for `_var` segments (e.g. `"var(--theme-accent)"`). */
   argResolved?: string;
   incremented?: boolean;
   appendPx?: boolean;
 }
-
-// ── Class-name constants and abbreviation maps ────────────────────────
-
-/** I.e. `"ancestor"` → `"anc"`, `"siblingAfter"` → `"sibA"`. */
-const RELATIONSHIP_SHORT: Record<string, string> = {
-  ancestor: "anc",
-  descendant: "desc",
-  siblingAfter: "sibA",
-  siblingBefore: "sibB",
-  anySibling: "anyS",
-};
 
 // ── Marker class helpers ──────────────────────────────────────────────
 
@@ -75,133 +71,10 @@ const RELATIONSHIP_SHORT: Record<string, string> = {
 export const DEFAULT_MARKER_CLASS = "_mrk";
 
 /** I.e. `markerClassName(row)` → `"_row_mrk"`, `markerClassName()` → `"_mrk"`. */
-export function markerClassName(markerNode?: { type: string; name?: string }): string {
+export function markerClassName(markerNode?: t.Expression): string {
   if (!markerNode) return DEFAULT_MARKER_CLASS;
-  if (markerNode.type === "Identifier" && markerNode.name) {
-    return `_${markerNode.name}_mrk`;
-  }
+  if (t.isIdentifier(markerNode)) return `_${markerNode.name}_mrk`;
   return "_marker_mrk";
-}
-
-// ── Class-name prefix builders ────────────────────────────────────────
-
-/** I.e. `when(marker, "ancestor", ":hover")` → `"wh_anc_h_"`, `when(row, …)` → `"wh_anc_h_row_"`. */
-function whenPrefix(whenPseudo: WhenCondition): string {
-  const rel = RELATIONSHIP_SHORT[whenPseudo.relationship ?? "ancestor"] ?? "anc";
-  const pseudoPrefix = pseudoSelectorPrefix(whenPseudo.pseudo);
-  const markerPart = whenPseudo.markerNode?.type === "Identifier" ? `${whenPseudo.markerNode.name}_` : "";
-  return `wh_${rel}_${pseudoPrefix}_${markerPart}`;
-}
-
-/**
- * Build a condition prefix string for class naming.
- *
- * I.e. `conditionPrefix(":hover", smMedia, null, breakpoints)` → `"sm_h_"`,
- * so the final class reads `sm_h_bgBlack` ("on sm + hover, bgBlack").
- */
-function conditionPrefix(
-  pseudoClass: string | null | undefined,
-  mediaQuery: string | null | undefined,
-  pseudoElement: string | null | undefined,
-  breakpoints?: Record<string, string>,
-): string {
-  const parts: string[] = [];
-  if (pseudoElement) {
-    // I.e. "::placeholder" → "placeholder_"
-    parts.push(`${pseudoElement.replace(/^::/, "")}_`);
-  }
-  if (mediaQuery && breakpoints) {
-    // I.e. find breakpoint name: "ifSm" → "sm_"
-    const bpKey = Object.entries(breakpoints).find(([, v]) => v === mediaQuery)?.[0];
-    if (bpKey) {
-      const shortName = bpKey.replace(/^if/, "").toLowerCase();
-      parts.push(`${shortName}_`);
-    } else {
-      parts.push("mq_");
-    }
-  } else if (mediaQuery) {
-    parts.push("mq_");
-  }
-  if (pseudoClass) {
-    parts.push(`${pseudoSelectorPrefix(pseudoClass)}_`);
-  }
-  return parts.join("");
-}
-
-// ── CSS property / value helpers ──────────────────────────────────────
-
-/** I.e. `"backgroundColor"` → `"background-color"`, `"WebkitTransform"` → `"-webkit-transform"`. */
-export function camelToKebab(s: string): string {
-  return s.replace(/^(Webkit|Moz|Ms|O)/, (m) => `-${m.toLowerCase()}`).replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
-}
-
-/** I.e. `"-8px"` → `"neg8px"`, `"0 0 0 1px blue"` → `"0_0_0_1px_blue"`. */
-function cleanValueForClassName(value: string): string {
-  let cleaned = value;
-  if (cleaned.startsWith("-")) {
-    cleaned = "neg" + cleaned.slice(1);
-  }
-  return cleaned
-    .replace(/[^a-zA-Z0-9]/g, "_")
-    .replace(/_+/g, "_")
-    .replace(/^_|_$/g, "");
-}
-
-/** Class-name fragment for a resolved CSS value (short path for truss increment calcs). */
-function classNameFragmentForResolvedValue(value: string): string {
-  const inc = tryParseIncrementCalcMultiplier(value);
-  return inc !== null ? cleanValueForClassName(inc) : cleanValueForClassName(value);
-}
-
-/** I.e. `"backgroundColor"` → `"bg"` (from the abbreviation table), or the raw name as fallback. */
-function getPropertyAbbreviation(cssProp: string): string {
-  return cssPropertyAbbreviations[cssProp] ?? cssProp;
-}
-
-// ── Longhand lookup (canonical abbreviation reuse) ────────────────────
-
-// ── Static base class-name computation ────────────────────────────────
-
-/**
- * Compute the base class name for a static segment.
- *
- * For multi-property abbreviations, looks up the canonical single-property
- * abbreviation name so classes are maximally reused.
- * I.e. `p1` → `pt1`, `pr1`, `pb1`, `pl1` (not `p1_paddingTop`, etc.)
- * I.e. `ba` → `bss`, `bw1` (not `ba_borderStyle`, etc.)
- *
- * For literal-folded variables (argResolved set), includes the value:
- * I.e. `mt(2)` → `mt_2` (web increment calc), `mt(-1)` → `mt_neg1`, `bc("red")` → `bc_red`.
- */
-function computeStaticBaseName(
-  seg: ResolvedSegment,
-  cssProp: string,
-  cssValue: string,
-  isMultiProp: boolean,
-  mapping: TrussMapping,
-): string {
-  const abbr = seg.abbr;
-
-  if (seg.argResolved !== undefined) {
-    const valuePart = classNameFragmentForResolvedValue(seg.argResolved);
-    if (isMultiProp) {
-      const lookup = getLonghandLookup(mapping);
-      const canonical = lookup.get(`${cssProp}\0${cssValue}`);
-      if (canonical) return canonical;
-      // I.e. lineClamp("3") display:-webkit-box → `d_negwebkit_box`, not `d_3`
-      return `${getPropertyAbbreviation(cssProp)}_${classNameFragmentForResolvedValue(cssValue)}`;
-    }
-    return `${abbr}_${valuePart}`;
-  }
-
-  if (isMultiProp) {
-    const lookup = getLonghandLookup(mapping);
-    const canonical = lookup.get(`${cssProp}\0${cssValue}`);
-    if (canonical) return canonical;
-    return `${getPropertyAbbreviation(cssProp)}_${classNameFragmentForResolvedValue(cssValue)}`;
-  }
-
-  return abbr;
 }
 
 // ── Collecting atomic rules from resolved chains ──────────────────────
@@ -224,15 +97,13 @@ export function collectAtomicRules(chains: ResolvedChain[], mapping: TrussMappin
   let needsMaybeCssVar = false;
 
   function collectSegment(seg: ResolvedSegment): void {
-    if (seg.error || seg.styleArrayArg || seg.classNameArg || seg.styleArg) return;
     if (seg.typographyLookup) {
       for (const segments of Object.values(seg.typographyLookup.segmentsByName)) {
-        for (const nestedSeg of segments) {
-          collectSegment(nestedSeg);
-        }
+        segments.forEach(collectSegment);
       }
       return;
     }
+    if (!isStyleSegment(seg)) return;
     if (seg.incremented) needsMaybeInc = true;
     if (seg.variableProps && seg.argResolved === undefined && variableValueNeedsMaybeCssVar(seg)) {
       needsMaybeCssVar = true;
@@ -241,58 +112,16 @@ export function collectAtomicRules(chains: ResolvedChain[], mapping: TrussMappin
   }
 
   for (const chain of chains) {
-    for (const part of chain.parts) {
-      const segs = part.type === "unconditional" ? part.segments : [...part.thenSegments, ...part.elseSegments];
-      for (const seg of segs) {
-        collectSegment(seg);
-      }
-    }
+    chainSegments(chain).forEach(collectSegment);
   }
 
   return { rules, needsMaybeInc, needsMaybeCssVar };
 }
 
-/**
- * Compute the class name prefix and optional whenSelector for a segment.
- *
- * I.e. a segment with `pseudoClass: ":hover"` and `mediaQuery: smMedia` gets
- * prefix `"sm_h_"`, while one with `whenPseudo: { relationship: "ancestor", pseudo: ":hover" }`
- * also gets its `whenSelector` populated for CSS rule generation.
- */
-function segmentContext(
-  seg: ResolvedSegment,
-  mapping: TrussMapping,
-): { prefix: string; whenSelector?: AtomicRule["whenSelector"] } {
-  const prefix = `${conditionPrefix(seg.pseudoClass, seg.mediaQuery, seg.pseudoElement, mapping.breakpoints)}${seg.whenPseudo ? whenPrefix(seg.whenPseudo) : ""}`;
-  if (seg.whenPseudo) {
-    const wp = seg.whenPseudo;
-    return {
-      prefix,
-      whenSelector: {
-        relationship: wp.relationship ?? "ancestor",
-        markerClass: markerClassName(wp.markerNode),
-        pseudo: wp.pseudo,
-      },
-    };
-  }
-  return { prefix };
-}
-
-/** I.e. extracts `pseudoClass`, `mediaQuery`, `pseudoElement` from a segment for AtomicRule fields. */
-function baseRuleFields(seg: ResolvedSegment): Pick<AtomicRule, "pseudoClass" | "mediaQuery" | "pseudoElement"> {
-  return {
-    pseudoClass: seg.pseudoClass ?? undefined,
-    mediaQuery: seg.mediaQuery ?? undefined,
-    pseudoElement: seg.pseudoElement ?? undefined,
-  };
-}
-
 /** Collect atomic CSS rules for one resolved style segment. */
 function collectSegmentRules(rules: Map<string, AtomicRule>, seg: ResolvedSegment, mapping: TrussMapping): void {
-  const { whenSelector } = segmentContext(seg, mapping);
-
   for (const entry of styleEntriesForSegment(seg, mapping)) {
-    const declaration = {
+    const declaration: AtomicDeclaration = {
       cssProperty: camelToKebab(entry.cssProp),
       cssValue: entry.cssValue,
       ...(entry.varName ? { cssVarName: entry.varName } : {}),
@@ -302,21 +131,34 @@ function collectSegmentRules(rules: Map<string, AtomicRule>, seg: ResolvedSegmen
       rules.set(entry.className, {
         className: entry.className,
         declarations: [declaration],
-        ...baseRuleFields(seg),
-        whenSelector,
+        pseudoClass: seg.pseudoClass ?? undefined,
+        mediaQuery: seg.mediaQuery ?? undefined,
+        pseudoElement: seg.pseudoElement ?? undefined,
+        whenSelector: seg.whenPseudo ? whenSelectorFor(seg.whenPseudo) : undefined,
       });
       continue;
     }
 
-    if (
-      !existingRule.declarations.some((existingDeclaration) => {
-        return existingDeclaration.cssProperty === declaration.cssProperty;
-      })
-    ) {
+    // I.e. `sq(x)` registers `height` and then `width` on the one `sq_var` rule.
+    const alreadyDeclared = existingRule.declarations.some(
+      (existing) => existing.cssProperty === declaration.cssProperty,
+    );
+    if (!alreadyDeclared) {
       existingRule.declarations.push(declaration);
     }
   }
 }
+
+/** I.e. `when(row, "ancestor", ":hover")` → `{ relationship: "ancestor", markerClass: "_row_mrk", pseudo: ":hover" }`. */
+function whenSelectorFor(whenPseudo: WhenCondition): WhenSelector {
+  return {
+    relationship: whenPseudo.relationship,
+    markerClass: markerClassName(whenPseudo.markerNode),
+    pseudo: whenPseudo.pseudo,
+  };
+}
+
+// ── Style entries (shared by CSS rules and style hashes) ──────────────
 
 /**
  * Build normalized class/property entries from a segment for CSS and AST emitters.
@@ -324,7 +166,7 @@ function collectSegmentRules(rules: Map<string, AtomicRule>, seg: ResolvedSegmen
  * I.e. convert one resolved segment into the shared model both CSS rules and style hashes consume.
  */
 function styleEntriesForSegment(seg: ResolvedSegment, mapping: TrussMapping): StyleEntry[] {
-  const { prefix } = segmentContext(seg, mapping);
+  const prefix = segmentClassPrefix(seg, mapping);
   const isConditional = prefix !== "";
 
   if (seg.variableProps) {
@@ -347,28 +189,20 @@ function staticStyleEntries(
   defs: Record<string, unknown>,
   forceLonghandNames = false,
 ): StyleEntry[] {
-  const entries: StyleEntry[] = [];
   const isMultiProp = forceLonghandNames || Object.keys(defs).length > 1;
 
-  for (const [cssProp, value] of Object.entries(defs)) {
+  return Object.entries(defs).map(([cssProp, value]) => {
     const cssValue = String(value);
     const baseName = computeStaticBaseName(seg, cssProp, cssValue, isMultiProp, mapping);
-    entries.push({
-      cssProp,
-      className: prefix ? `${prefix}${baseName}` : baseName,
-      isVariable: false,
-      isConditional,
-      cssValue,
-    });
-  }
-
-  return entries;
+    return { cssProp, className: `${prefix}${baseName}`, isVariable: false, isConditional, cssValue };
+  });
 }
 
 /**
  * Build entries for runtime variable CSS defs.
  *
- * I.e. `Css.mt(x).$` becomes `marginTop -> mt_var` plus `--marginTop` metadata.
+ * I.e. `Css.mt(x).$` becomes `marginTop -> mt_var` plus `--marginTop` metadata,
+ * and `Css.ifSm.mt(x).$` becomes `sm_mt_var` with `--sm_marginTop`.
  */
 function variableStyleEntries(
   seg: ResolvedSegment,
@@ -376,12 +210,10 @@ function variableStyleEntries(
   prefix: string,
   isConditional: boolean,
 ): StyleEntry[] {
-  const entries: StyleEntry[] = [];
-
-  for (const cssProp of seg.variableProps!) {
-    const className = prefix ? `${prefix}${seg.abbr}_var` : `${seg.abbr}_var`;
-    const varName = toCssVariableName(className, seg.abbr, cssProp);
-    entries.push({
+  const className = `${prefix}${seg.abbr}_var`;
+  const entries: StyleEntry[] = (seg.variableProps ?? []).map((cssProp) => {
+    const varName = `--${prefix}${cssProp}`;
+    return {
       cssProp,
       className,
       isVariable: true,
@@ -392,14 +224,107 @@ function variableStyleEntries(
       argResolved: seg.argResolved,
       incremented: seg.incremented,
       appendPx: seg.appendPx,
-    });
-  }
+    };
+  });
 
   if (seg.variableExtraDefs) {
     entries.push(...staticStyleEntries(seg, mapping, prefix, isConditional, seg.variableExtraDefs, true));
   }
 
   return entries;
+}
+
+/**
+ * Compute the base class name for a static segment.
+ *
+ * For multi-property abbreviations, looks up the canonical single-property
+ * abbreviation name so classes are maximally reused.
+ * I.e. `p1` → `pt1`, `pr1`, `pb1`, `pl1` (not `p1_paddingTop`, etc.)
+ * I.e. `ba` → `bss`, `bw1` (not `ba_borderStyle`, etc.)
+ * I.e. `lineClamp("3")` display:-webkit-box → `d_negwebkit_box`, not `d_3`
+ *
+ * For literal-folded variables (argResolved set), includes the value:
+ * I.e. `mt(2)` → `mt_2` (web increment calc), `mt(-1)` → `mt_neg1`, `bc("red")` → `bc_red`.
+ */
+function computeStaticBaseName(
+  seg: ResolvedSegment,
+  cssProp: string,
+  cssValue: string,
+  isMultiProp: boolean,
+  mapping: TrussMapping,
+): string {
+  if (isMultiProp) {
+    const canonical = findCanonicalAbbreviation(mapping, cssProp, cssValue);
+    return canonical ?? `${getPropertyAbbreviation(cssProp)}_${classNameFragmentForResolvedValue(cssValue)}`;
+  }
+  if (seg.argResolved !== undefined) {
+    return `${seg.abbr}_${classNameFragmentForResolvedValue(seg.argResolved)}`;
+  }
+  return seg.abbr;
+}
+
+// ── Class-name building blocks ────────────────────────────────────────
+
+/**
+ * Build the condition prefix for a segment's class names.
+ *
+ * I.e. `ifSm.onHover.bgBlack` → `"sm_h_"` so the final class reads `sm_h_bgBlack`
+ * ("on sm + hover, bgBlack"), and `when(row, "ancestor", ":hover").blue` → `"wh_anc_h_row_"`.
+ */
+function segmentClassPrefix(seg: ResolvedSegment, mapping: TrussMapping): string {
+  const parts: string[] = [];
+  if (seg.pseudoElement) {
+    // I.e. "::placeholder" → "placeholder_"
+    parts.push(`${seg.pseudoElement.replace(/^::/, "")}_`);
+  }
+  if (seg.mediaQuery) {
+    // I.e. the `ifSm` breakpoint → "sm_"; any other media/container query → "mq_"
+    const breakpoint = breakpointNameForMediaQuery(mapping, seg.mediaQuery);
+    parts.push(breakpoint ? `${breakpoint.toLowerCase()}_` : "mq_");
+  }
+  if (seg.pseudoClass) {
+    parts.push(`${pseudoSelectorPrefix(seg.pseudoClass)}_`);
+  }
+  if (seg.whenPseudo) {
+    parts.push(whenPrefix(seg.whenPseudo));
+  }
+  return parts.join("");
+}
+
+/** I.e. `when(marker, "ancestor", ":hover")` → `"wh_anc_h_"`, `when(row, …)` → `"wh_anc_h_row_"`. */
+function whenPrefix(whenPseudo: WhenCondition): string {
+  const rel = WHEN_RELATIONSHIPS[whenPseudo.relationship].short;
+  const pseudoPrefix = pseudoSelectorPrefix(whenPseudo.pseudo);
+  const markerPart = whenPseudo.markerNode ? `${whenPseudo.markerNode.name}_` : "";
+  return `wh_${rel}_${pseudoPrefix}_${markerPart}`;
+}
+
+/** I.e. `"backgroundColor"` → `"background-color"`, `"WebkitTransform"` → `"-webkit-transform"`. */
+export function camelToKebab(s: string): string {
+  return s.replace(/^(Webkit|Moz|Ms|O)/, (m) => `-${m.toLowerCase()}`).replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
+}
+
+/** Collapse anything that is not a letter or digit into single underscores, i.e. `"0 0 0 1px blue"` → `"0_0_0_1px_blue"`. */
+export function sanitizeClassNameToken(value: string): string {
+  return value
+    .replace(/[^a-zA-Z0-9]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "");
+}
+
+/** I.e. `"-8px"` → `"neg8px"`, `"0 0 0 1px blue"` → `"0_0_0_1px_blue"`. */
+function cleanValueForClassName(value: string): string {
+  return sanitizeClassNameToken(value.startsWith("-") ? `neg${value.slice(1)}` : value);
+}
+
+/** Class-name fragment for a resolved CSS value, i.e. `calc(var(--t-spacing) * 2)` → `"2"`, `"red"` → `"red"`. */
+function classNameFragmentForResolvedValue(value: string): string {
+  return cleanValueForClassName(tryParseIncrementCalcMultiplier(value) ?? value);
+}
+
+/** I.e. `"backgroundColor"` → `"bg"` (from the abbreviation table), or the raw name as fallback. */
+function getPropertyAbbreviation(cssProp: string): string {
+  return cssPropertyAbbreviations[cssProp] ?? cssProp;
 }
 
 // ── CSS text generation ───────────────────────────────────────────────
@@ -416,23 +341,17 @@ function variableStyleEntries(
  * ```
  */
 export function generateCssText(rules: Map<string, AtomicRule>): string {
-  const allRules = Array.from(rules.values());
-
-  sortRulesByPriority(allRules);
-
-  const priorities = allRules.map(computeRulePriority);
+  const sorted = sortRulesByPriority(rules.values());
   const lines: string[] = [];
 
-  for (let i = 0; i < allRules.length; i++) {
-    const rule = allRules[i];
-    const priority = priorities[i];
+  for (const { rule, priority } of sorted) {
     lines.push(`/* @truss p:${priority} c:${rule.className} */`);
     lines.push(formatRule(rule));
   }
 
   // I.e. `@property --marginTop { syntax: "*"; inherits: false; }` for variable rules
-  for (const rule of allRules) {
-    for (const declaration of getRuleDeclarations(rule)) {
+  for (const { rule } of sorted) {
+    for (const declaration of rule.declarations) {
       if (declaration.cssVarName) {
         lines.push(`/* @truss @property */`);
         lines.push(`@property ${declaration.cssVarName} { syntax: "*"; inherits: false; }`);
@@ -443,56 +362,28 @@ export function generateCssText(rules: Map<string, AtomicRule>): string {
   return lines.join("\n");
 }
 
-// ── CSS rule formatting ───────────────────────────────────────────────
-
 /**
- * Format a single rule into its CSS text, dispatching by rule kind.
+ * Format a single rule into its CSS text.
  *
  * I.e. a base rule → `.black { color: #353535; }`,
  * a media rule → `@media (...) { .sm_blue.sm_blue { color: #526675; } }`,
  * a when rule → `._mrk:hover .wh_anc_h_blue { color: #526675; }`.
+ *
+ * Inside a media query the class is doubled (`.sm_blue.sm_blue`) so it outranks the base class.
  */
 function formatRule(rule: AtomicRule): string {
-  const whenSelector = rule.whenSelector;
-  if (whenSelector) return formatWhenRule(rule, whenSelector);
-  const selector = buildTargetSelector(rule, !!rule.mediaQuery);
-  return formatRuleWithOptionalMedia(rule, selector);
-}
-
-/**
- * Format a when()-relationship rule with the correct combinator per relationship kind.
- *
- * I.e. ancestor → `._mrk:hover .target { … }`,
- * descendant → `.target:has(._mrk:hover) { … }`,
- * anySibling → `.target:has(~ ._mrk:hover), ._mrk:hover ~ .target { … }`.
- */
-function formatWhenRule(rule: AtomicRule, whenSelector: NonNullable<AtomicRule["whenSelector"]>): string {
-  const markerSelector = `.${whenSelector.markerClass}${whenSelector.pseudo}`;
   const duplicateClassName = !!rule.mediaQuery;
+  const whenSelector = rule.whenSelector;
+  const selector = whenSelector
+    ? WHEN_RELATIONSHIPS[whenSelector.relationship].selector(
+        `.${whenSelector.markerClass}${whenSelector.pseudo}`,
+        (extraPseudoClass) => buildTargetSelector(rule, duplicateClassName, extraPseudoClass),
+      )
+    : buildTargetSelector(rule, duplicateClassName);
 
-  if (whenSelector.relationship === "ancestor") {
-    return formatRuleWithOptionalMedia(rule, `${markerSelector} ${buildTargetSelector(rule, duplicateClassName)}`);
-  }
-  if (whenSelector.relationship === "descendant") {
-    return formatRuleWithOptionalMedia(rule, buildTargetSelector(rule, duplicateClassName, `:has(${markerSelector})`));
-  }
-  if (whenSelector.relationship === "siblingAfter") {
-    return formatRuleWithOptionalMedia(
-      rule,
-      buildTargetSelector(rule, duplicateClassName, `:has(~ ${markerSelector})`),
-    );
-  }
-  if (whenSelector.relationship === "siblingBefore") {
-    return formatRuleWithOptionalMedia(rule, `${markerSelector} ~ ${buildTargetSelector(rule, duplicateClassName)}`);
-  }
-  if (whenSelector.relationship === "anySibling") {
-    const afterSelector = buildTargetSelector(rule, duplicateClassName, `:has(~ ${markerSelector})`);
-    const beforeSelector = `${markerSelector} ~ ${buildTargetSelector(rule, duplicateClassName)}`;
-    return formatRuleWithOptionalMedia(rule, `${afterSelector}, ${beforeSelector}`);
-  }
-
-  // I.e. unknown relationship falls back to ancestor-style descendant combinator
-  return formatRuleWithOptionalMedia(rule, `${markerSelector} ${buildTargetSelector(rule, duplicateClassName)}`);
+  const body = rule.declarations.map((d) => `${d.cssProperty}: ${d.cssValue};`).join(" ");
+  const block = `${selector} { ${body} }`;
+  return rule.mediaQuery ? `${rule.mediaQuery} { ${block} }` : block;
 }
 
 /**
@@ -501,45 +392,9 @@ function formatWhenRule(rule: AtomicRule, whenSelector: NonNullable<AtomicRule["
  * I.e. `buildTargetSelector(rule, true)` → `.sm_h_blue.sm_h_blue:hover`,
  * `buildTargetSelector(rule, false, ":has(._mrk:hover)")` → `.wh_anc_h_blue:has(._mrk:hover)`.
  */
-function buildTargetSelector(rule: AtomicRule, duplicateClassName: boolean, extraPseudoClass?: string): string {
+function buildTargetSelector(rule: AtomicRule, duplicateClassName: boolean, extraPseudoClass = ""): string {
   const classSelector = duplicateClassName ? `.${rule.className}.${rule.className}` : `.${rule.className}`;
-  const pseudoClass = rule.pseudoClass ?? "";
-  const relationshipPseudoClass = extraPseudoClass ?? "";
-  const pseudoElement = rule.pseudoElement ?? "";
-  return `${classSelector}${pseudoClass}${relationshipPseudoClass}${pseudoElement}`;
-}
-
-/** I.e. wraps the selector in a media-query block when `rule.mediaQuery` is set. */
-function formatRuleWithOptionalMedia(rule: AtomicRule, selector: string): string {
-  if (rule.mediaQuery) {
-    return formatNestedRuleBlock(rule.mediaQuery, selector, rule);
-  }
-  return formatRuleBlock(selector, rule);
-}
-
-/** I.e. returns the rule's declarations array (always has at least one entry). */
-function getRuleDeclarations(rule: AtomicRule): Array<{ cssProperty: string; cssValue: string; cssVarName?: string }> {
-  return rule.declarations;
-}
-
-/** I.e. `.black { color: #353535; }`. */
-function formatRuleBlock(selector: string, rule: AtomicRule): string {
-  const body = getRuleDeclarations(rule)
-    .map((declaration) => {
-      return `${declaration.cssProperty}: ${declaration.cssValue};`;
-    })
-    .join(" ");
-  return `${selector} { ${body} }`;
-}
-
-/** I.e. `@media (...) { .sm_blue.sm_blue { color: #526675; } }`. */
-function formatNestedRuleBlock(wrapper: string, selector: string, rule: AtomicRule): string {
-  const body = getRuleDeclarations(rule)
-    .map((declaration) => {
-      return `${declaration.cssProperty}: ${declaration.cssValue};`;
-    })
-    .join(" ");
-  return `${wrapper} { ${selector} { ${body} } }`;
+  return `${classSelector}${rule.pseudoClass ?? ""}${extraPseudoClass}${rule.pseudoElement ?? ""}`;
 }
 
 // ── AST generation for style hash objects ─────────────────────────────
@@ -569,22 +424,13 @@ export function buildStyleHashProperties(
    * but `Css.blue.onHover.black.$` accumulates both because `onHover.black` is conditional.
    */
   function pushEntry(entry: StyleEntry): void {
-    const cssProp = entry.cssProp;
-    if (!propGroups.has(cssProp)) propGroups.set(cssProp, []);
-    const entries = propGroups.get(cssProp)!;
-    if (!entry.isConditional) {
-      for (let i = entries.length - 1; i >= 0; i--) {
-        if (!entries[i].isConditional) {
-          entries.splice(i, 1);
-        }
-      }
-    }
-    entries.push(entry);
+    const entries = propGroups.get(entry.cssProp) ?? [];
+    const kept = entry.isConditional ? entries : entries.filter((existing) => existing.isConditional);
+    propGroups.set(entry.cssProp, [...kept, entry]);
   }
 
   for (const seg of segments) {
-    if (seg.error || seg.styleArrayArg || seg.typographyLookup || seg.classNameArg || seg.styleArg) continue;
-
+    if (!isStyleSegment(seg)) continue;
     for (const entry of styleEntriesForSegment(seg, mapping)) {
       pushEntry(entry);
     }
@@ -593,54 +439,59 @@ export function buildStyleHashProperties(
   // Build AST ObjectProperty nodes
   const properties: t.ObjectProperty[] = [];
 
-  for (const [cssProp, entries] of Array.from(propGroups.entries())) {
+  for (const [cssProp, entries] of propGroups) {
     const classNames = entries.map((e) => e.className).join(" ");
     const variableEntries = entries.filter((e) => e.isVariable);
 
-    if (variableEntries.length > 0) {
-      // I.e. `{ marginTop: ["mt_var", { "--marginTop": __maybeInc(x) }] }`
-      const varsProps: t.ObjectProperty[] = [];
-      for (const dyn of variableEntries) {
-        let valueExpr: t.Expression;
-        if (dyn.argResolved !== undefined) {
-          valueExpr = t.stringLiteral(dyn.argResolved);
-        } else {
-          valueExpr = dyn.argNode as t.Expression;
-          if (dyn.incremented) {
-            // I.e. wrap with `__maybeInc(x)` for increment-based values
-            valueExpr = t.callExpression(t.identifier(maybeIncHelperName ?? "__maybeInc"), [valueExpr]);
-          } else if (dyn.appendPx) {
-            // I.e. wrap with `` `${v}px` `` for Px delegate values
-            valueExpr = t.templateLiteral(
-              [t.templateElement({ raw: "", cooked: "" }, false), t.templateElement({ raw: "px", cooked: "px" }, true)],
-              [valueExpr],
-            );
-          }
-          if (maybeCssVarHelperName && variableValueNeedsMaybeCssVar(dyn)) {
-            valueExpr = t.callExpression(t.identifier(maybeCssVarHelperName), [valueExpr]);
-          }
-        }
-        varsProps.push(t.objectProperty(t.stringLiteral(dyn.varName!), valueExpr));
-      }
-
-      const tuple = t.arrayExpression([t.stringLiteral(classNames), t.objectExpression(varsProps)]);
-      properties.push(t.objectProperty(toPropertyKey(cssProp), tuple));
-    } else {
+    if (variableEntries.length === 0) {
       // I.e. static: `{ color: "blue h_white" }`
       properties.push(t.objectProperty(toPropertyKey(cssProp), t.stringLiteral(classNames)));
+      continue;
     }
+
+    // I.e. `{ marginTop: ["mt_var", { "--marginTop": __maybeInc(x) }] }`
+    const varsProps = variableEntries.map((dyn) => {
+      return t.objectProperty(
+        t.stringLiteral(dyn.varName!),
+        variableValueExpression(dyn, maybeIncHelperName, maybeCssVarHelperName),
+      );
+    });
+    const tuple = t.arrayExpression([t.stringLiteral(classNames), t.objectExpression(varsProps)]);
+    properties.push(t.objectProperty(toPropertyKey(cssProp), tuple));
   }
 
   return properties;
 }
 
-// ── CSS variable naming ───────────────────────────────────────────────
+/**
+ * The runtime value stored in a variable tuple's vars object.
+ *
+ * I.e. a folded `Tokens.gap` → `"var(--gap)"`; `mt(x)` → `maybeCssVar(__maybeInc(x))`; `mtPx(x)` → `` `${x}px` ``.
+ */
+function variableValueExpression(
+  dyn: StyleEntry,
+  maybeIncHelperName?: string | null,
+  maybeCssVarHelperName?: string | null,
+): t.Expression {
+  if (dyn.argResolved !== undefined) {
+    return t.stringLiteral(dyn.argResolved);
+  }
 
-/** I.e. `toCssVariableName("sm_mt_var", "mt", "marginTop")` → `"--sm_marginTop"`. */
-function toCssVariableName(className: string, baseKey: string, cssProp: string): string {
-  const baseClassName = `${baseKey}_var`;
-  const cp = className.endsWith(baseClassName) ? className.slice(0, -baseClassName.length) : "";
-  return `--${cp}${cssProp}`;
+  let valueExpr = dyn.argNode!;
+  if (dyn.incremented) {
+    // I.e. wrap with `__maybeInc(x)` for increment-based values
+    valueExpr = t.callExpression(t.identifier(maybeIncHelperName ?? "__maybeInc"), [valueExpr]);
+  } else if (dyn.appendPx) {
+    // I.e. wrap with `` `${v}px` `` for Px delegate values
+    valueExpr = t.templateLiteral(
+      [t.templateElement({ raw: "", cooked: "" }, false), t.templateElement({ raw: "px", cooked: "px" }, true)],
+      [valueExpr],
+    );
+  }
+  if (maybeCssVarHelperName && variableValueNeedsMaybeCssVar(dyn)) {
+    valueExpr = t.callExpression(t.identifier(maybeCssVarHelperName), [valueExpr]);
+  }
+  return valueExpr;
 }
 
 // ── Helper AST declarations ───────────────────────────────────────────
@@ -659,7 +510,10 @@ export function buildMaybeIncDeclaration(helperName: string): t.VariableDeclarat
         t.binaryExpression("===", t.unaryExpression("typeof", incParam), t.stringLiteral("string")),
         incParam,
         t.templateLiteral(
-          [t.templateElement({ raw: calcPrefix, cooked: calcPrefix }, false), t.templateElement({ raw: ")", cooked: ")" }, true)],
+          [
+            t.templateElement({ raw: calcPrefix, cooked: calcPrefix }, false),
+            t.templateElement({ raw: ")", cooked: ")" }, true),
+          ],
           [incParam],
         ),
       ),
@@ -669,16 +523,6 @@ export function buildMaybeIncDeclaration(helperName: string): t.VariableDeclarat
   return t.variableDeclaration("const", [
     t.variableDeclarator(t.identifier(helperName), t.arrowFunctionExpression([incParam], body)),
   ]);
-}
-
-/** I.e. `"color"` → `t.identifier("color")`, `"box-shadow"` → `t.stringLiteral("box-shadow")`. */
-function toPropertyKey(key: string): t.Identifier | t.StringLiteral {
-  return isValidIdentifier(key) ? t.identifier(key) : t.stringLiteral(key);
-}
-
-/** I.e. `"color"` → true, `"box-shadow"` → false. */
-function isValidIdentifier(s: string): boolean {
-  return /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(s);
 }
 
 /**
@@ -691,12 +535,15 @@ export function buildRuntimeLookupDeclaration(
   segmentsByName: Record<string, ResolvedSegment[]>,
   mapping: TrussMapping,
 ): t.VariableDeclaration {
-  const properties: t.ObjectProperty[] = [];
-  for (const [name, segs] of Object.entries(segmentsByName)) {
-    const hashProps = buildStyleHashProperties(segs, mapping);
-    properties.push(t.objectProperty(t.identifier(name), t.objectExpression(hashProps)));
-  }
+  const properties = Object.entries(segmentsByName).map(([name, segs]) => {
+    return t.objectProperty(t.identifier(name), t.objectExpression(buildStyleHashProperties(segs, mapping)));
+  });
   return t.variableDeclaration("const", [
     t.variableDeclarator(t.identifier(lookupName), t.objectExpression(properties)),
   ]);
+}
+
+/** I.e. `"color"` → `t.identifier("color")`, `"box-shadow"` → `t.stringLiteral("box-shadow")`. */
+function toPropertyKey(key: string): t.Identifier | t.StringLiteral {
+  return /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key) ? t.identifier(key) : t.stringLiteral(key);
 }

--- a/packages/truss/src/plugin/esbuild-plugin.ts
+++ b/packages/truss/src/plugin/esbuild-plugin.ts
@@ -27,7 +27,6 @@ export interface TrussEsbuildPluginOptions {
  * ```
  */
 export function trussEsbuildPlugin(opts: TrussEsbuildPluginOptions) {
-  let outDir: string | undefined;
   const session = createTrussTransformSession({
     mappingPath() {
       return resolve(process.cwd(), opts.mapping);
@@ -40,8 +39,7 @@ export function trussEsbuildPlugin(opts: TrussEsbuildPluginOptions) {
   return {
     name: "truss",
     setup(build: EsbuildPluginBuild) {
-      // Resolve outDir from esbuild config
-      outDir = build.initialOptions.outdir ?? build.initialOptions.outdir;
+      const outDir = build.initialOptions.outdir ?? join(process.cwd(), "dist");
 
       build.onLoad({ filter: /\.[cm]?[jt]sx?$/ }, (args: { path: string }) => {
         const code = readFileSync(args.path, "utf8");
@@ -64,8 +62,7 @@ export function trussEsbuildPlugin(opts: TrussEsbuildPluginOptions) {
 
         const css = session.collectCss();
         if (css.length === 0) return;
-        const cssFileName = opts.outputCss ?? "truss.css";
-        const cssPath = resolve(outDir ?? join(process.cwd(), "dist"), cssFileName);
+        const cssPath = resolve(outDir, opts.outputCss ?? "truss.css");
 
         mkdirSync(resolve(cssPath, ".."), { recursive: true });
         writeFileSync(cssPath, css, "utf8");

--- a/packages/truss/src/plugin/index.ts
+++ b/packages/truss/src/plugin/index.ts
@@ -245,12 +245,12 @@ __injectTrussCSS(${JSON.stringify(css)});
     },
 
     transform(code: string, id: string) {
-      // Only process JS/TS/JSX/TSX files
+      // Only process JS/TS/JSX/TSX files outside node_modules
       if (!/\.[cm]?[jt]sx?(\?|$)/.test(id)) return null;
+      const fileId = stripQueryAndHash(id);
+      if (isNodeModulesFile(fileId)) return null;
 
       const rewrittenImports = rewriteCssTsImports(code, id);
-      const rewrittenCode = rewrittenImports.code;
-      const fileId = stripQueryAndHash(id);
 
       // In tests, we do not boot through index.html and the dev runtime fetch path
       // (`virtual:truss:runtime` -> fetch("/virtual:truss.css")), so we inject the
@@ -260,14 +260,13 @@ __injectTrussCSS(${JSON.stringify(css)});
       // but ESM module caching should evaluate that virtual module only once per test
       // module graph. Transformed files may still emit per-file `__injectTrussCSS`
       // calls; exact repeated chunks are deduped in the runtime helper.
-      const shouldBootstrapTestCss = isTest && libraryPaths.length > 0 && !isNodeModulesFile(fileId);
-      const testCssBootstrap = injectTestCssBootstrapImport(rewrittenCode, shouldBootstrapTestCss);
-      const transformedCode = testCssBootstrap.code;
-      const hasCssDsl = rewrittenCode.includes("Css") || rewrittenCode.includes("css=");
-      if (isNodeModulesFile(fileId)) {
-        return null;
-      }
-      if (!hasCssDsl && !rewrittenImports.changed && !testCssBootstrap.changed) return null;
+      const shouldBootstrapTestCss = isTest && libraryPaths.length > 0;
+      const transformedCode = shouldBootstrapTestCss
+        ? `${rewrittenImports.code}\nimport "${VIRTUAL_TEST_CSS_ID}";`
+        : rewrittenImports.code;
+      // The result to return when only the import rewrites changed the module
+      const importsOnlyResult =
+        rewrittenImports.changed || shouldBootstrapTestCss ? { code: transformedCode, map: null } : null;
 
       if (fileId.endsWith(".css.ts")) {
         // Keep `.css.ts` modules as normal TS so named exports like class-name
@@ -278,24 +277,18 @@ __injectTrussCSS(${JSON.stringify(css)});
         // the load hook only runs on first resolve, so edits need to refresh
         // the registry here where Vite re-transforms changed files.
         session.updateArbitraryCssRegistry(fileId, code);
-        return rewrittenImports.changed || testCssBootstrap.changed ? { code: transformedCode, map: null } : null;
+        return importsOnlyResult;
       }
 
-      if (!hasCssDsl) {
-        // Some non-`.css.ts` modules only need the import rewrite and do not have
-        // any `Css.*.$` expressions for the main Truss transform to process.
-        return { code: transformedCode, map: null };
-      }
+      // Some non-`.css.ts` modules only need the import rewrite and do not have
+      // any `Css.*.$` expressions for the main Truss transform to process.
+      const hasCssDsl = rewrittenImports.code.includes("Css") || rewrittenImports.code.includes("css=");
+      if (!hasCssDsl) return importsOnlyResult;
 
       // For regular JS/TS modules that still use the DSL, run the full Truss
       // transform after the import rewrite so both behaviors compose.
       const result = session.transformCode(transformedCode, fileId, { debug, injectCss: isTest });
-      if (!result) {
-        if (!rewrittenImports.changed && !testCssBootstrap.changed) return null;
-        return { code: transformedCode, map: null };
-      }
-
-      return { code: result.code, map: result.map };
+      return result ? { code: result.code, map: result.map } : importsOnlyResult;
     },
 
     // -- Production CSS emission --
@@ -365,19 +358,6 @@ function stripQueryAndHash(id: string): string {
 
 function isNodeModulesFile(filePath: string): boolean {
   return filePath.replace(/\\/g, "/").includes("/node_modules/");
-}
-
-function injectTestCssBootstrapImport(code: string, shouldInject: boolean): { code: string; changed: boolean } {
-  // Keep this as a normal ESM import so Vite/Vitest module caching ensures the
-  // bootstrap executes once per module graph instead of once per transformed file.
-  if (!shouldInject) {
-    return { code, changed: false };
-  }
-
-  return {
-    code: `${code}\nimport "${VIRTUAL_TEST_CSS_ID}";`,
-    changed: true,
-  };
 }
 
 export type { TrussMapping, TrussMappingEntry } from "./types";

--- a/packages/truss/src/plugin/mapping-utils.ts
+++ b/packages/truss/src/plugin/mapping-utils.ts
@@ -6,3 +6,57 @@ export function loadMapping(path: string): TrussMapping {
   const raw = readFileSync(path, "utf8");
   return JSON.parse(raw);
 }
+
+const longhandCache = new WeakMap<TrussMapping, Map<string, string>>();
+
+/**
+ * Reverse lookup from `"cssProperty\0cssValue"` → canonical abbreviation name.
+ *
+ * I.e. `{ paddingTop: "8px" }` → `"pt1"`, `{ borderStyle: "solid" }` → `"bss"`.
+ * Cached per mapping via WeakMap.
+ */
+export function getLonghandLookup(mapping: TrussMapping): Map<string, string> {
+  let lookup = longhandCache.get(mapping);
+  if (lookup) return lookup;
+  lookup = new Map();
+  for (const [abbr, entry] of Object.entries(mapping.abbreviations)) {
+    if (entry.kind !== "static") continue;
+    const keys = Object.keys(entry.defs);
+    if (keys.length !== 1) continue;
+    const key = `${keys[0]}\0${entry.defs[keys[0]]}`;
+    // First match wins — if multiple abbreviations produce the same declaration,
+    // the one that appears first in the mapping is canonical.
+    if (!lookup.has(key)) lookup.set(key, abbr);
+  }
+  longhandCache.set(mapping, lookup);
+  return lookup;
+}
+
+/** The canonical single-property abbreviation for `{ [cssProp]: cssValue }`, i.e. `("display", "grid")` → `"dg"`. */
+export function findCanonicalAbbreviation(
+  mapping: TrussMapping,
+  cssProp: string,
+  cssValue: string,
+): string | undefined {
+  return getLonghandLookup(mapping).get(`${cssProp}\0${cssValue}`);
+}
+
+/** The media query behind a breakpoint getter, i.e. `"ifSm"` → `"@media screen and (max-width: 599px)"`, or null. */
+export function breakpointMediaQuery(mapping: TrussMapping, getterName: string): string | null {
+  const breakpoints = mapping.breakpoints;
+  if (!breakpoints || !Object.hasOwn(breakpoints, getterName)) return null;
+  return breakpoints[getterName];
+}
+
+/**
+ * The breakpoint name behind a media query, without its `if` prefix.
+ *
+ * I.e. `"@media screen and (max-width: 599px)"` → `"Sm"` when `breakpoints.ifSm` is that query,
+ * or null for media queries that are not a configured breakpoint.
+ */
+export function breakpointNameForMediaQuery(mapping: TrussMapping, mediaQuery: string): string | null {
+  const breakpoints = mapping.breakpoints;
+  if (!breakpoints) return null;
+  const getterName = Object.keys(breakpoints).find((name) => breakpoints[name] === mediaQuery);
+  return getterName === undefined ? null : getterName.replace(/^if/, "");
+}

--- a/packages/truss/src/plugin/merge-css.ts
+++ b/packages/truss/src/plugin/merge-css.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "fs";
+import { compareClassNames } from "./priority";
 
 /** A parsed CSS rule extracted from an annotated truss.css file. */
 export interface ParsedCssRule {
@@ -23,7 +24,7 @@ export interface ParsedArbitraryCssBlock {
 export interface ParsedTrussCss {
   rules: ParsedCssRule[];
   properties: ParsedPropertyDeclaration[];
-  arbitraryCssBlocks?: ParsedArbitraryCssBlock[];
+  arbitraryCssBlocks: ParsedArbitraryCssBlock[];
 }
 
 /** Regex matching `/* @truss p:<priority> c:<className> *\/` annotations. */
@@ -55,19 +56,23 @@ export function parseTrussCss(cssText: string): ParsedTrussCss {
   const arbitraryCssBlocks: ParsedArbitraryCssBlock[] = [];
 
   let i = 0;
+
+  /** Advance past the current annotation line and any blank lines to the annotated content line. */
+  function takeAnnotatedLine(): string | null {
+    i++;
+    while (i < lines.length && lines[i].trim() === "") i++;
+    return i < lines.length ? lines[i].trim() : null;
+  }
+
   while (i < lines.length) {
     const line = lines[i].trim();
 
     // Check for rule annotation
     const ruleMatch = RULE_ANNOTATION_RE.exec(line);
     if (ruleMatch) {
-      const priority = parseFloat(ruleMatch[1]);
-      const className = ruleMatch[2];
-      // Next non-empty line is the CSS rule
-      i++;
-      while (i < lines.length && lines[i].trim() === "") i++;
-      if (i < lines.length) {
-        rules.push({ priority, className, cssText: lines[i].trim() });
+      const cssText = takeAnnotatedLine();
+      if (cssText !== null) {
+        rules.push({ priority: parseFloat(ruleMatch[1]), className: ruleMatch[2], cssText });
       }
       i++;
       continue;
@@ -75,14 +80,10 @@ export function parseTrussCss(cssText: string): ParsedTrussCss {
 
     // Check for @property annotation
     if (PROPERTY_ANNOTATION_RE.test(line)) {
-      i++;
-      while (i < lines.length && lines[i].trim() === "") i++;
-      if (i < lines.length) {
-        const propLine = lines[i].trim();
-        const varMatch = PROPERTY_VAR_RE.exec(propLine);
-        if (varMatch) {
-          properties.push({ cssText: propLine, varName: varMatch[1] });
-        }
+      const propLine = takeAnnotatedLine();
+      const varMatch = propLine === null ? null : PROPERTY_VAR_RE.exec(propLine);
+      if (propLine !== null && varMatch) {
+        properties.push({ cssText: propLine, varName: varMatch[1] });
       }
       i++;
       continue;
@@ -159,15 +160,11 @@ export function mergeTrussCss(sources: ParsedTrussCss[]): string {
         allProperties.push(prop);
       }
     }
-    allArbitraryCssBlocks.push(...(source.arbitraryCssBlocks ?? []));
+    allArbitraryCssBlocks.push(...source.arbitraryCssBlocks);
   }
 
   // Sort by priority ascending, tiebreak alphabetically by class name
-  allRules.sort((a, b) => {
-    const diff = a.priority - b.priority;
-    if (diff !== 0) return diff;
-    return a.className < b.className ? -1 : a.className > b.className ? 1 : 0;
-  });
+  allRules.sort((a, b) => a.priority - b.priority || compareClassNames(a.className, b.className));
 
   const lines: string[] = [];
 

--- a/packages/truss/src/plugin/priority.ts
+++ b/packages/truss/src/plugin/priority.ts
@@ -12,16 +12,8 @@ import {
   getAtRulePriority,
   PSEUDO_ELEMENT_PRIORITY,
 } from "./property-priorities";
+import { WHEN_RELATIONSHIPS } from "./when-relationships";
 import type { AtomicRule } from "./emit-truss";
-
-/** Relationship base priorities for when() selectors, matching StyleX's relational selector system. */
-const RELATIONSHIP_BASE: Record<string, number> = {
-  ancestor: 10,
-  descendant: 15,
-  anySibling: 20,
-  siblingBefore: 30,
-  siblingAfter: 40,
-};
 
 /**
  * Compute the numeric priority for a single AtomicRule.
@@ -45,7 +37,7 @@ export function computeRulePriority(rule: AtomicRule): number {
   }
 
   if (rule.whenSelector) {
-    const relBase = RELATIONSHIP_BASE[rule.whenSelector.relationship] ?? 10;
+    const relBase = WHEN_RELATIONSHIPS[rule.whenSelector.relationship].priority;
     const pseudoFraction = getPseudoClassPriority(rule.whenSelector.pseudo) / 100;
     priority += relBase + pseudoFraction;
   }
@@ -64,27 +56,26 @@ function isVariableRule(rule: AtomicRule): boolean {
 }
 
 /**
- * Sort an array of AtomicRules in-place by their computed priority.
+ * Pair each rule with its computed priority and sort ascending.
  *
  * When two rules have the same priority (e.g. two different longhands both at 3000),
  * we tiebreak by class name so the output is fully deterministic regardless of
  * file processing order (which differs between dev HMR and production builds).
  *
- * Uses a decorate-sort-undecorate pattern so each rule's priority is computed
- * once upfront rather than re-evaluated on every comparator call.
+ * Priorities are computed once upfront so the O(n log n) comparisons are just
+ * number/string compares, and callers can reuse them for the `@truss p:` annotations.
  */
-export function sortRulesByPriority(rules: AtomicRule[]): void {
-  // Pre-compute priorities so the O(n log n) comparisons are just number/string compares
-  const decorated = rules.map((rule, i) => {
-    return { rule, priority: computeRulePriority(rule), index: i };
+export function sortRulesByPriority(rules: Iterable<AtomicRule>): Array<{ rule: AtomicRule; priority: number }> {
+  const decorated = Array.from(rules, (rule) => {
+    return { rule, priority: computeRulePriority(rule) };
   });
   decorated.sort((a, b) => {
-    const diff = a.priority - b.priority;
-    if (diff !== 0) return diff;
-    // Alphabetical tiebreaker ensures identical output in dev and production
-    return a.rule.className < b.rule.className ? -1 : a.rule.className > b.rule.className ? 1 : 0;
+    return a.priority - b.priority || compareClassNames(a.rule.className, b.rule.className);
   });
-  for (let i = 0; i < decorated.length; i++) {
-    rules[i] = decorated[i].rule;
-  }
+  return decorated;
+}
+
+/** Code-point order, so identical class sets sort identically in dev and production. */
+export function compareClassNames(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
 }

--- a/packages/truss/src/plugin/resolve-chain.ts
+++ b/packages/truss/src/plugin/resolve-chain.ts
@@ -1,7 +1,7 @@
-import type * as t from "@babel/types";
+import * as t from "@babel/types";
 import { pascalCase } from "change-case";
 import {
-  getLonghandLookup,
+  hasCondition,
   type MarkerSegment,
   type ResolvedConditionContext,
   type ResolvedSegment,
@@ -9,7 +9,16 @@ import {
   type TrussMappingEntry,
   type WhenCondition,
 } from "./types";
-import { extractChain } from "./ast-utils";
+import { breakpointMediaQuery, breakpointNameForMediaQuery, findCanonicalAbbreviation } from "./mapping-utils";
+import {
+  extractChain,
+  extractDollarChain,
+  memberPropertyName,
+  staticPropertyName,
+  unwrapExpression,
+} from "./ast-utils";
+import { sanitizeClassNameToken } from "./emit-truss";
+import { isWhenRelationship, WHEN_RELATIONSHIPS } from "./when-relationships";
 import { invertMediaQuery } from "../media-query";
 import { isTrussPseudoMethod, trussPseudoSelector } from "../pseudo-selectors";
 import { isCustomPropertyName, maybeCssVar } from "../css-custom-property";
@@ -52,119 +61,21 @@ export interface ResolvedChain {
 
 export type ResolvedChainPart =
   | { type: "unconditional"; segments: ResolvedSegment[] }
-  | { type: "conditional"; conditionNode: any; thenSegments: ResolvedSegment[]; elseSegments: ResolvedSegment[] };
+  | {
+      type: "conditional";
+      conditionNode: t.Expression;
+      thenSegments: ResolvedSegment[];
+      elseSegments: ResolvedSegment[];
+    };
 
-function emptyConditionContext(): ResolvedConditionContext {
-  return {
-    mediaQuery: null,
-    pseudoClass: null,
-    pseudoElement: null,
-    whenPseudo: null,
-  };
+/** Every segment in a chain part, i.e. both branches of a conditional part. */
+export function partSegments(part: ResolvedChainPart): ResolvedSegment[] {
+  return part.type === "unconditional" ? part.segments : [...part.thenSegments, ...part.elseSegments];
 }
 
-function cloneConditionContext(context: ResolvedConditionContext): ResolvedConditionContext {
-  return {
-    mediaQuery: context.mediaQuery,
-    pseudoClass: context.pseudoClass,
-    pseudoElement: context.pseudoElement,
-    whenPseudo: context.whenPseudo ? { ...context.whenPseudo } : null,
-  };
-}
-
-function resetConditionContext(context: ResolvedConditionContext): void {
-  context.mediaQuery = null;
-  context.pseudoClass = null;
-  context.pseudoElement = null;
-  context.whenPseudo = null;
-}
-
-function segmentWithConditionContext(
-  segment: Omit<ResolvedSegment, "mediaQuery" | "pseudoClass" | "pseudoElement" | "whenPseudo">,
-  context: ResolvedConditionContext,
-): ResolvedSegment {
-  return {
-    ...segment,
-    mediaQuery: context.mediaQuery,
-    pseudoClass: context.pseudoClass,
-    pseudoElement: context.pseudoElement,
-    whenPseudo: context.whenPseudo,
-  };
-}
-
-/**
- * Apply context-only chain nodes like breakpoints/pseudos/end.
- *
- * `resolveFullChain` catches errors at speculative context-tracking call sites;
- * `resolveChain` lets them surface so unsupported patterns are reported.
- */
-function applyModifierNodeToConditionContext(
-  context: ResolvedConditionContext,
-  node: ChainNode,
-  mapping: TrussMapping,
-): boolean {
-  if ((node as any).type === "__mediaQuery") {
-    context.mediaQuery = (node as any).mediaQuery;
-    return true;
-  }
-
-  if (node.type === "getter") {
-    if (node.name === "end") {
-      resetConditionContext(context);
-      return true;
-    }
-    if (isTrussPseudoMethod(node.name)) {
-      context.pseudoClass = trussPseudoSelector(node.name);
-      return true;
-    }
-    if (mapping.breakpoints && node.name in mapping.breakpoints) {
-      context.mediaQuery = mapping.breakpoints[node.name];
-      return true;
-    }
-    return false;
-  }
-
-  if (node.type !== "call") {
-    return false;
-  }
-
-  if (node.name === "ifContainer") {
-    context.mediaQuery = containerSelectorFromCall(node);
-    return true;
-  }
-
-  if (node.name === "element") {
-    if (node.args.length !== 1 || node.args[0].type !== "StringLiteral") {
-      throw new UnsupportedPatternError(`element() requires exactly one string literal argument (e.g. "::placeholder")`);
-    }
-    context.pseudoElement = node.args[0].value;
-    return true;
-  }
-
-  if (node.name === "when") {
-    if (isWhenObjectCall(node)) {
-      return false;
-    }
-    const resolved = resolveWhenCall(node);
-    if (resolved.kind === "selector") {
-      context.pseudoClass = resolved.selector;
-    } else {
-      context.whenPseudo = resolved;
-    }
-    return true;
-  }
-
-  if (isTrussPseudoMethod(node.name)) {
-    context.pseudoClass = trussPseudoSelector(node.name);
-    if (node.args.length > 0) {
-      throw new UnsupportedPatternError(
-        `${node.name}() does not take arguments -- use when(marker, "ancestor", ":hover") for relationship selectors`,
-      );
-    }
-    return true;
-  }
-
-  return false;
+/** Every segment in a resolved chain, across all parts and branches. */
+export function chainSegments(chain: ResolvedChain): ResolvedSegment[] {
+  return chain.parts.flatMap((part) => partSegments(part));
 }
 
 /**
@@ -225,13 +136,13 @@ export function resolveFullChain(ctx: ResolveChainCtx, chain: ChainNode[]): Reso
   const parts: ResolvedChainPart[] = [];
   const nestedErrors: string[] = [];
   const markerScan = scanMarkerNodes(chain);
-  const filteredChain = markerScan.chain;
+  const nodes = markerScan.chain;
   const markers = [...markerScan.markers];
 
   // Split chain at if/else boundaries
   let i = 0;
   let currentNodes: ChainNode[] = [];
-  let currentContext = cloneConditionContext(initialContext);
+  const currentContext = cloneConditionContext(initialContext);
   let currentNodesStartContext = cloneConditionContext(initialContext);
 
   function flushCurrentNodes(): void {
@@ -241,7 +152,7 @@ export function resolveFullChain(ctx: ResolveChainCtx, chain: ChainNode[]): Reso
 
     parts.push({
       type: "unconditional",
-      segments: resolveChain({ ...ctx, initialContext: currentNodesStartContext }, currentNodes),
+      segments: resolveSegments({ ...ctx, initialContext: currentNodesStartContext }, currentNodes),
     });
     currentNodes = [];
     currentNodesStartContext = cloneConditionContext(currentContext);
@@ -256,46 +167,42 @@ export function resolveFullChain(ctx: ResolveChainCtx, chain: ChainNode[]): Reso
     try {
       applyModifierNodeToConditionContext(currentContext, nodeToPush, mapping);
     } catch {
-      // resolveChain() reports the real unsupported-pattern error later.
+      // resolveSegments() reports the real unsupported-pattern error later.
     }
   }
 
-  while (i < filteredChain.length) {
-    const node = filteredChain[i];
-    const mediaStart = getMediaConditionalStartNode(node, mapping);
-    if (mediaStart) {
-      const elseIndex = findElseIndex(filteredChain, i + 1);
-      if (elseIndex !== -1) {
-        flushCurrentNodes();
-        const branchContext = cloneConditionContext(currentContext);
-        let branchEnd = filteredChain.length;
-        // Find an explicit `.end` that closes the media else branch.
-        for (let branchIndex = elseIndex + 1; branchIndex < filteredChain.length; branchIndex++) {
-          const branchNode = filteredChain[branchIndex];
-          if (branchNode.type === "getter" && branchNode.name === "end") {
-            branchEnd = branchIndex;
-            break;
-          }
-        }
+  while (i < nodes.length) {
+    const node = nodes[i];
 
-        const thenNodes = mediaStart.thenNodes
-          ? [...mediaStart.thenNodes, ...filteredChain.slice(i + 1, elseIndex)]
-          : filteredChain.slice(i, elseIndex);
-        const elseNodes = [
-          makeMediaQueryNode(mediaStart.inverseMediaQuery),
-          ...filteredChain.slice(elseIndex + 1, branchEnd),
-        ];
-        const thenSegs = resolveChain({ ...ctx, initialContext: branchContext }, thenNodes);
-        const elseSegs = resolveChain({ ...ctx, initialContext: branchContext }, elseNodes);
-        parts.push({ type: "unconditional", segments: [...thenSegs, ...elseSegs] });
-        if (branchEnd === filteredChain.length) {
-          i = filteredChain.length;
-          break;
-        }
-        resetConditionContext(currentContext);
-        i = branchEnd + 1;
+    const mediaQuery = mediaQueryOfNode(node, mapping);
+    if (mediaQuery !== null) {
+      const elseIndex = findElseIndex(nodes, i + 1);
+      if (elseIndex === -1) {
+        // I.e. `ifSm.black` or `if("@media ...").black`: a media context for the nodes that follow.
+        pushCurrentNode(makeMediaQueryNode(mediaQuery));
+        i++;
         continue;
       }
+
+      // I.e. `ifSm.black.else.white[.end]`: the else branch gets the inverted media query.
+      flushCurrentNodes();
+      const branchContext = cloneConditionContext(currentContext);
+      const branchEnd = findEndIndex(nodes, elseIndex + 1);
+      const thenNodes = [makeMediaQueryNode(mediaQuery), ...nodes.slice(i + 1, elseIndex)];
+      const elseNodes = [makeMediaQueryNode(invertMediaQuery(mediaQuery)), ...nodes.slice(elseIndex + 1, branchEnd)];
+      parts.push({
+        type: "unconditional",
+        segments: [
+          ...resolveSegments({ ...ctx, initialContext: branchContext }, thenNodes),
+          ...resolveSegments({ ...ctx, initialContext: branchContext }, elseNodes),
+        ],
+      });
+      if (branchEnd === nodes.length) {
+        break;
+      }
+      resetConditionContext(currentContext);
+      i = branchEnd + 1;
+      continue;
     }
 
     if (isWhenObjectCall(node)) {
@@ -309,15 +216,7 @@ export function resolveFullChain(ctx: ResolveChainCtx, chain: ChainNode[]): Reso
     }
 
     if (node.type === "if") {
-      // if(stringLiteral) → media query pseudo, not a boolean conditional
-      if (node.conditionNode.type === "StringLiteral") {
-        const mediaQuery: string = (node.conditionNode as any).value;
-        pushCurrentNode({ type: "__mediaQuery" as any, mediaQuery } as any);
-        i++;
-        continue;
-      }
-
-      // Flush any accumulated unconditional nodes
+      // Boolean conditional; the string-literal `if(mediaQuery)` overload was handled above.
       flushCurrentNodes();
       const branchContext = cloneConditionContext(currentContext);
 
@@ -326,8 +225,8 @@ export function resolveFullChain(ctx: ResolveChainCtx, chain: ChainNode[]): Reso
       const elseNodes: ChainNode[] = [];
       i++;
       let inElse = false;
-      while (i < filteredChain.length) {
-        const branchNode = filteredChain[i];
+      while (i < nodes.length) {
+        const branchNode = nodes[i];
         if (branchNode.type === "getter" && branchNode.name === "end") {
           resetConditionContext(currentContext);
           i++;
@@ -349,25 +248,178 @@ export function resolveFullChain(ctx: ResolveChainCtx, chain: ChainNode[]): Reso
         }
         i++;
       }
-      const thenSegs = resolveChain({ ...ctx, initialContext: branchContext }, thenNodes);
-      const elseSegs = resolveChain({ ...ctx, initialContext: branchContext }, elseNodes);
       parts.push({
         type: "conditional",
         conditionNode: node.conditionNode,
-        thenSegments: thenSegs,
-        elseSegments: elseSegs,
+        thenSegments: resolveSegments({ ...ctx, initialContext: branchContext }, thenNodes),
+        elseSegments: resolveSegments({ ...ctx, initialContext: branchContext }, elseNodes),
       });
-    } else {
-      pushCurrentNode(node);
-      i++;
+      continue;
     }
+
+    pushCurrentNode(node);
+    i++;
   }
 
   // Flush remaining unconditional nodes
   flushCurrentNodes();
 
-  return { parts, markers, errors: [...new Set([...markerScan.errors, ...nestedErrors, ...segmentErrors(parts)])] };
+  const segmentErrors = parts.flatMap((part) => partSegments(part)).flatMap((seg) => (seg.error ? [seg.error] : []));
+  return { parts, markers, errors: [...new Set([...markerScan.errors, ...nestedErrors, ...segmentErrors])] };
 }
+
+/**
+ * Walks a Css member-expression chain (the AST between `Css` and `.$`) and
+ * resolves each segment into CSS property definitions using the truss mapping.
+ *
+ * Returns an array of ResolvedSegment with flat defs (no condition nesting).
+ * Does NOT handle if/else — use resolveFullChain for that.
+ */
+function resolveSegments(ctx: ResolveChainCtx, chain: ChainNode[]): ResolvedSegment[] {
+  const { mapping } = ctx;
+  const segments: ResolvedSegment[] = [];
+  const context = cloneConditionContext(ctx.initialContext ?? emptyConditionContext());
+
+  for (const node of chain) {
+    try {
+      if (isWhenObjectCall(node)) {
+        segments.push(...flattenWhenObjectParts(resolveWhenObjectSelectors(ctx, node, context)));
+        continue;
+      }
+
+      if (applyModifierNodeToConditionContext(context, node, mapping)) {
+        continue;
+      }
+
+      if (node.type === "getter") {
+        segments.push(...resolveEntry(node.name, requireEntry(mapping, node.name), mapping, context));
+      } else if (node.type === "call") {
+        segments.push(...resolveCallNode(node, mapping, context));
+      }
+    } catch (err) {
+      if (!(err instanceof UnsupportedPatternError)) throw err;
+      segments.push(errorSegment(err.message));
+    }
+  }
+
+  return segments;
+}
+
+// ── Condition context ─────────────────────────────────────────────────
+
+function emptyConditionContext(): ResolvedConditionContext {
+  return {
+    mediaQuery: null,
+    pseudoClass: null,
+    pseudoElement: null,
+    whenPseudo: null,
+  };
+}
+
+/** `WhenCondition` objects are never mutated after creation, so a shallow copy is a full snapshot. */
+function cloneConditionContext(context: ResolvedConditionContext): ResolvedConditionContext {
+  return { ...context };
+}
+
+function resetConditionContext(context: ResolvedConditionContext): void {
+  Object.assign(context, emptyConditionContext());
+}
+
+/** Snapshot the active condition axes onto a segment. */
+function segmentWithConditionContext(
+  segment: Omit<ResolvedSegment, "mediaQuery" | "pseudoClass" | "pseudoElement" | "whenPseudo">,
+  context: ResolvedConditionContext,
+): ResolvedSegment {
+  return {
+    ...segment,
+    mediaQuery: context.mediaQuery,
+    pseudoClass: context.pseudoClass,
+    pseudoElement: context.pseudoElement,
+    whenPseudo: context.whenPseudo,
+  };
+}
+
+/**
+ * Apply context-only chain nodes like breakpoints/pseudos/end.
+ *
+ * Returns false for nodes that produce styles instead. `resolveFullChain` catches errors at
+ * speculative context-tracking call sites; `resolveSegments` lets them surface so unsupported
+ * patterns are reported.
+ */
+function applyModifierNodeToConditionContext(
+  context: ResolvedConditionContext,
+  node: ChainNode,
+  mapping: TrussMapping,
+): boolean {
+  if (node.type === "mediaQuery") {
+    context.mediaQuery = node.mediaQuery;
+    return true;
+  }
+
+  if (node.type === "getter") {
+    if (node.name === "end") {
+      resetConditionContext(context);
+      return true;
+    }
+    if (isTrussPseudoMethod(node.name)) {
+      context.pseudoClass = trussPseudoSelector(node.name);
+      return true;
+    }
+    const mediaQuery = breakpointMediaQuery(mapping, node.name);
+    if (mediaQuery !== null) {
+      context.mediaQuery = mediaQuery;
+      return true;
+    }
+    return false;
+  }
+
+  if (node.type !== "call") {
+    return false;
+  }
+
+  if (node.name === "ifContainer") {
+    context.mediaQuery = containerQueryFromCall(node);
+    return true;
+  }
+
+  if (node.name === "element") {
+    const arg = node.args.length === 1 ? node.args[0] : null;
+    if (!t.isStringLiteral(arg)) {
+      throw new UnsupportedPatternError(
+        `element() requires exactly one string literal argument (e.g. "::placeholder")`,
+      );
+    }
+    context.pseudoElement = arg.value;
+    return true;
+  }
+
+  if (node.name === "when") {
+    if (isWhenObjectCall(node)) {
+      return false;
+    }
+    const resolved = resolveWhenCall(node);
+    if (resolved.kind === "selector") {
+      context.pseudoClass = resolved.selector;
+    } else {
+      context.whenPseudo = resolved.condition;
+    }
+    return true;
+  }
+
+  if (isTrussPseudoMethod(node.name)) {
+    context.pseudoClass = trussPseudoSelector(node.name);
+    if (node.args.length > 0) {
+      throw new UnsupportedPatternError(
+        `${node.name}() does not take arguments -- use when(marker, "ancestor", ":hover") for relationship selectors`,
+      );
+    }
+    return true;
+  }
+
+  return false;
+}
+
+// ── Chain scanning helpers for resolveFullChain ───────────────────────
 
 /** Pull marker nodes out of a chain before style resolution. */
 function scanMarkerNodes(chain: ChainNode[]): { chain: ChainNode[]; markers: MarkerSegment[]; errors: string[] } {
@@ -382,10 +434,11 @@ function scanMarkerNodes(chain: ChainNode[]): { chain: ChainNode[]; markers: Mar
     }
 
     if (node.type === "call" && node.name === "markerOf") {
-      if (node.args.length !== 1) {
+      const arg = node.args.length === 1 ? node.args[0] : null;
+      if (!arg || t.isSpreadElement(arg)) {
         errors.push("[truss] Unsupported pattern: markerOf() requires exactly one argument (a marker variable)");
       } else {
-        markers.push({ type: "marker", markerNode: node.args[0] });
+        markers.push({ type: "marker", markerNode: arg });
       }
       continue;
     }
@@ -396,156 +449,18 @@ function scanMarkerNodes(chain: ChainNode[]): { chain: ChainNode[]; markers: Mar
   return { chain: filteredChain, markers, errors };
 }
 
-/** Collect unsupported-pattern errors from all resolved chain parts. */
-function segmentErrors(parts: ResolvedChainPart[]): string[] {
-  const errors: string[] = [];
-
-  for (const part of parts) {
-    const segs = part.type === "unconditional" ? part.segments : [...part.thenSegments, ...part.elseSegments];
-    for (const seg of segs) {
-      if (seg.error) {
-        errors.push(seg.error);
-      }
-    }
+/** The media query a node switches into, i.e. `ifSm` or `if("@media ...")`; null for every other node. */
+function mediaQueryOfNode(node: ChainNode, mapping: TrussMapping): string | null {
+  if (node.type === "if" && t.isStringLiteral(node.conditionNode)) {
+    return node.conditionNode.value;
   }
-
-  return errors;
-}
-
-/** Detect `when({ ... })` so object-form selector groups can be resolved specially. */
-type WhenObjectCallChainNode = CallChainNode & { name: "when"; args: [t.ObjectExpression] };
-
-function isWhenObjectCall(node: ChainNode): node is WhenObjectCallChainNode {
-  return (
-    node.type === "call" && node.name === "when" && node.args.length === 1 && node.args[0].type === "ObjectExpression"
-  );
-}
-
-/**
- * Resolve `when({ ":hover": Css.blue.$, ... })` by recursively resolving each
- * nested `Css.*.$` value with the selector key as its initial pseudo-class.
- */
-function resolveWhenObjectSelectors(
-  ctx: ResolveChainCtx,
-  node: CallChainNode,
-  initialContext: ResolvedConditionContext,
-): ResolvedChain {
-  const { cssBindingName } = ctx;
-  if (!cssBindingName) {
-    return {
-      parts: [],
-      markers: [],
-      errors: [new UnsupportedPatternError(`when({ ... }) requires a resolvable Css binding`).message],
-    };
+  if (node.type === "getter") {
+    return breakpointMediaQuery(mapping, node.name);
   }
-
-  const objectArg = node.args[0];
-  if (objectArg.type !== "ObjectExpression") {
-    throw new UnsupportedPatternError(`when({ ... }) requires an object literal argument`);
-  }
-
-  const parts: ResolvedChainPart[] = [];
-  const markers: MarkerSegment[] = [];
-  const errors: string[] = [];
-
-  for (const property of objectArg.properties) {
-    try {
-      if (property.type === "SpreadElement") {
-        throw new UnsupportedPatternError(`when({ ... }) does not support spread properties`);
-      }
-      if (property.type !== "ObjectProperty") {
-        throw new UnsupportedPatternError(`when({ ... }) only supports plain object properties`);
-      }
-      if (property.computed || property.key.type !== "StringLiteral") {
-        throw new UnsupportedPatternError(`when({ ... }) selector keys must be string literals`);
-      }
-
-      const value = unwrapExpression(property.value as t.Expression);
-      const innerChain = resolveWhenObjectValueChain(ctx, value);
-      if (!innerChain) {
-        throw new UnsupportedPatternError(`when({ ... }) values must be Css.*.$ expressions`);
-      }
-
-      const selectorContext = cloneConditionContext(initialContext);
-      selectorContext.pseudoClass = property.key.value;
-      const resolved = resolveFullChain({ ...ctx, initialContext: selectorContext }, innerChain);
-      parts.push(...resolved.parts);
-      markers.push(...resolved.markers);
-      errors.push(...resolved.errors);
-    } catch (err) {
-      if (err instanceof UnsupportedPatternError) {
-        errors.push(err.message);
-      } else {
-        throw err;
-      }
-    }
-  }
-
-  return { parts, markers, errors: [...new Set(errors)] };
-}
-
-/**
- * Resolve a `when({ ... })` value into an inner `ChainNode[]`.
- *
- * I.e. this accepts either a direct `Css.blue.$` member expression or a
- * transform-provided reference resolver for identifiers like `const same = Css.blue.$`.
- * The reference lookup itself stays outside this file because it depends on
- * Babel scope/NodePath traversal state, while `resolve-chain.ts` is kept focused
- * on chain semantics rather than lexical binding analysis.
- */
-function resolveWhenObjectValueChain(ctx: ResolveChainCtx, value: t.Expression): ChainNode[] | null {
-  const { cssBindingName, resolveCssChainReference } = ctx;
-  if (
-    cssBindingName &&
-    value.type === "MemberExpression" &&
-    !value.computed &&
-    value.property.type === "Identifier" &&
-    value.property.name === "$"
-  ) {
-    return extractChain(value.object as t.Expression, cssBindingName);
-  }
-
-  return resolveCssChainReference?.(value) ?? null;
-}
-
-/** Flatten nested `when({ ... })` parts back into plain segments for `resolveChain()`. */
-function flattenWhenObjectParts(resolved: ResolvedChain): ResolvedSegment[] {
-  const segments: ResolvedSegment[] = [];
-
-  // I.e. `resolveChain()` needs a flat segment list, even though `when({ ... })` is resolved via `resolveFullChain()`.
-  for (const part of resolved.parts) {
-    if (part.type !== "unconditional") {
-      throw new UnsupportedPatternError(`when({ ... }) values cannot use if()/else in this context`);
-    }
-
-    segments.push(...part.segments);
-  }
-
-  for (const err of resolved.errors) {
-    segments.push({ abbr: "__error", defs: {}, error: err });
-  }
-
-  return segments;
-}
-
-function getMediaConditionalStartNode(
-  node: ChainNode,
-  mapping: TrussMapping,
-): { inverseMediaQuery: string; thenNodes?: ChainNode[] } | null {
-  if (node.type === "if" && node.conditionNode.type === "StringLiteral") {
-    return {
-      inverseMediaQuery: invertMediaQuery(node.conditionNode.value),
-      thenNodes: [makeMediaQueryNode(node.conditionNode.value)],
-    };
-  }
-
-  if (node.type === "getter" && mapping.breakpoints && node.name in mapping.breakpoints) {
-    return { inverseMediaQuery: invertMediaQuery(mapping.breakpoints[node.name]) };
-  }
-
   return null;
 }
 
+/** Index of the `else` that closes the branch starting at `start`, or -1 when an `if`/`end` comes first. */
 function findElseIndex(chain: ChainNode[], start: number): number {
   for (let i = start; i < chain.length; i++) {
     const node = chain[i];
@@ -562,294 +477,131 @@ function findElseIndex(chain: ChainNode[], start: number): number {
   return -1;
 }
 
-function makeMediaQueryNode(mediaQuery: string): ChainNode {
-  return { type: "__mediaQuery" as any, mediaQuery } as any;
+/** Index of the first `end` at or after `start`, or `chain.length` when the chain has none. */
+function findEndIndex(chain: ChainNode[], start: number): number {
+  for (let i = start; i < chain.length; i++) {
+    const node = chain[i];
+    if (node.type === "getter" && node.name === "end") {
+      return i;
+    }
+  }
+  return chain.length;
+}
+
+function makeMediaQueryNode(mediaQuery: string): MediaQueryChainNode {
+  return { type: "mediaQuery", mediaQuery };
+}
+
+// ── when({ ... }) object form ─────────────────────────────────────────
+
+/** Detect `when({ ... })` so object-form selector groups can be resolved specially. */
+type WhenObjectCallChainNode = CallChainNode & { name: "when"; args: [t.ObjectExpression] };
+
+function isWhenObjectCall(node: ChainNode): node is WhenObjectCallChainNode {
+  return node.type === "call" && node.name === "when" && node.args.length === 1 && t.isObjectExpression(node.args[0]);
 }
 
 /**
- * Walks a Css member-expression chain (the AST between `Css` and `.$`) and
- * resolves each segment into CSS property definitions using the truss mapping.
- *
- * Returns an array of ResolvedSegment with flat defs (no condition nesting).
- * Does NOT handle if/else — use resolveFullChain for that.
+ * Resolve `when({ ":hover": Css.blue.$, ... })` by recursively resolving each
+ * nested `Css.*.$` value with the selector key as its initial pseudo-class.
  */
-export function resolveChain(ctx: ResolveChainCtx, chain: ChainNode[]): ResolvedSegment[] {
-  const { mapping, cssBindingName } = ctx;
-  const initialContext = ctx.initialContext ?? emptyConditionContext();
-  const segments: ResolvedSegment[] = [];
-  const context = cloneConditionContext(initialContext);
+function resolveWhenObjectSelectors(
+  ctx: ResolveChainCtx,
+  node: WhenObjectCallChainNode,
+  initialContext: ResolvedConditionContext,
+): ResolvedChain {
+  if (!ctx.cssBindingName) {
+    return {
+      parts: [],
+      markers: [],
+      errors: [new UnsupportedPatternError(`when({ ... }) requires a resolvable Css binding`).message],
+    };
+  }
 
-  for (const node of chain) {
+  const parts: ResolvedChainPart[] = [];
+  const markers: MarkerSegment[] = [];
+  const errors: string[] = [];
+
+  for (const property of node.args[0].properties) {
     try {
-      if (isWhenObjectCall(node)) {
-        const resolved = resolveWhenObjectSelectors(ctx, node, context);
-        segments.push(...flattenWhenObjectParts(resolved));
-        continue;
+      if (t.isSpreadElement(property)) {
+        throw new UnsupportedPatternError(`when({ ... }) does not support spread properties`);
+      }
+      if (!t.isObjectProperty(property)) {
+        throw new UnsupportedPatternError(`when({ ... }) only supports plain object properties`);
+      }
+      if (property.computed || !t.isStringLiteral(property.key)) {
+        throw new UnsupportedPatternError(`when({ ... }) selector keys must be string literals`);
       }
 
-      if (applyModifierNodeToConditionContext(context, node, mapping)) {
-        continue;
+      const value = unwrapExpression(property.value as t.Expression);
+      const innerChain = resolveWhenObjectValueChain(ctx, value);
+      if (!innerChain) {
+        throw new UnsupportedPatternError(`when({ ... }) values must be Css.*.$ expressions`);
       }
 
-      if (node.type === "getter") {
-        const abbr = node.name;
-
-        const entry = mapping.abbreviations[abbr];
-        if (!entry) {
-          throw new UnsupportedPatternError(`Unknown abbreviation "${abbr}"`);
-        }
-
-        const resolved = resolveEntry(
-          abbr,
-          entry,
-          mapping,
-          context.mediaQuery,
-          context.pseudoClass,
-          context.pseudoElement,
-          context.whenPseudo,
-        );
-        segments.push(...resolved);
-      } else if (node.type === "call") {
-        const abbr = node.name;
-
-        // with(cssProp) — compose an existing Css expression
-        if (abbr === "with") {
-          const seg = resolveWithCall(
-            node,
-            context.mediaQuery,
-            context.pseudoClass,
-            context.pseudoElement,
-            context.whenPseudo,
-          );
-          segments.push(seg);
-          continue;
-        }
-
-        // add(prop, value) / add({...})
-        if (abbr === "add") {
-          const segs = resolveAddCall(
-            node,
-            mapping,
-            context.mediaQuery,
-            context.pseudoClass,
-            context.pseudoElement,
-            context.whenPseudo,
-          );
-          segments.push(...segs);
-          continue;
-        }
-
-        // Raw class passthrough, i.e. `Css.className(buttonClass).df.$`
-        if (abbr === "className") {
-          const seg = resolveClassNameCall(
-            node,
-            context.mediaQuery,
-            context.pseudoClass,
-            context.pseudoElement,
-            context.whenPseudo,
-          );
-          segments.push(seg);
-          continue;
-        }
-
-        // Raw inline style passthrough, i.e. `Css.mt(x).style(vars).$`
-        if (abbr === "style") {
-          const seg = resolveStyleCall(
-            node,
-            context.mediaQuery,
-            context.pseudoClass,
-            context.pseudoElement,
-            context.whenPseudo,
-          );
-          segments.push(seg);
-          continue;
-        }
-
-        // CSS custom properties as atomic classes, i.e. `Css.setVar({ [Tokens.x]: "1px" }).$`
-        if (abbr === "setVar") {
-          const segs = resolveSetVarCall(
-            node,
-            mapping,
-            context.mediaQuery,
-            context.pseudoClass,
-            context.pseudoElement,
-            context.whenPseudo,
-          );
-          segments.push(...segs);
-          continue;
-        }
-
-        if (abbr === "typography") {
-          const resolved = resolveTypographyCall(
-            node,
-            mapping,
-            context.mediaQuery,
-            context.pseudoClass,
-            context.pseudoElement,
-            context.whenPseudo,
-          );
-          segments.push(...resolved);
-          continue;
-        }
-
-        const entry = mapping.abbreviations[abbr];
-        if (!entry) {
-          throw new UnsupportedPatternError(`Unknown abbreviation "${abbr}"`);
-        }
-
-        if (entry.kind === "variable") {
-          const seg = resolveVariableCall(
-            abbr,
-            entry,
-            node,
-            mapping,
-            context.mediaQuery,
-            context.pseudoClass,
-            context.pseudoElement,
-            context.whenPseudo,
-          );
-          segments.push(seg);
-        } else if (entry.kind === "delegate") {
-          const seg = resolveDelegateCall(
-            abbr,
-            entry,
-            node,
-            mapping,
-            context.mediaQuery,
-            context.pseudoClass,
-            context.pseudoElement,
-            context.whenPseudo,
-          );
-          segments.push(seg);
-        } else {
-          throw new UnsupportedPatternError(`Abbreviation "${abbr}" is ${entry.kind}, cannot be called as a function`);
-        }
-      }
+      const selectorContext = cloneConditionContext(initialContext);
+      selectorContext.pseudoClass = property.key.value;
+      const resolved = resolveFullChain({ ...ctx, initialContext: selectorContext }, innerChain);
+      parts.push(...resolved.parts);
+      markers.push(...resolved.markers);
+      errors.push(...resolved.errors);
     } catch (err) {
-      if (err instanceof UnsupportedPatternError) {
-        segments.push({ abbr: "__error", defs: {}, error: err.message });
-      } else {
-        throw err;
-      }
+      if (!(err instanceof UnsupportedPatternError)) throw err;
+      errors.push(err.message);
     }
+  }
+
+  return { parts, markers, errors: [...new Set(errors)] };
+}
+
+/**
+ * Resolve a `when({ ... })` value into an inner `ChainNode[]`.
+ *
+ * I.e. this accepts either a direct `Css.blue.$` member expression or a
+ * transform-provided reference resolver for identifiers like `const same = Css.blue.$`.
+ * The reference lookup itself stays outside this file because it depends on
+ * Babel scope/NodePath traversal state, while `resolve-chain.ts` is kept focused
+ * on chain semantics rather than lexical binding analysis.
+ */
+function resolveWhenObjectValueChain(ctx: ResolveChainCtx, value: t.Expression): ChainNode[] | null {
+  const direct = ctx.cssBindingName ? extractDollarChain(value, ctx.cssBindingName) : null;
+  return direct ?? ctx.resolveCssChainReference?.(value) ?? null;
+}
+
+/** Flatten nested `when({ ... })` parts back into plain segments for `resolveSegments()`. */
+function flattenWhenObjectParts(resolved: ResolvedChain): ResolvedSegment[] {
+  const segments: ResolvedSegment[] = [];
+
+  // I.e. `resolveSegments()` needs a flat segment list, even though `when({ ... })` is resolved via `resolveFullChain()`.
+  for (const part of resolved.parts) {
+    if (part.type !== "unconditional") {
+      throw new UnsupportedPatternError(`when({ ... }) values cannot use if()/else in this context`);
+    }
+
+    segments.push(...part.segments);
+  }
+
+  for (const err of resolved.errors) {
+    segments.push(errorSegment(err));
   }
 
   return segments;
 }
 
-/**
- * Build a typography lookup key suffix from condition context.
- *
- * I.e. `typography(key)` → `"typography"`, `ifSm.typography(key)` → `"typography__sm"`.
- */
-function typographyLookupKeySuffix(
-  mediaQuery: string | null,
-  pseudoClass: string | null,
-  pseudoElement: string | null,
-  whenPseudo: WhenCondition | null,
-  breakpoints?: Record<string, string>,
-): string {
-  const parts: string[] = [];
-  if (pseudoElement) parts.push(pseudoElement.replace(/^::/, ""));
-  if (mediaQuery && breakpoints) {
-    const bp = Object.entries(breakpoints).find(([, v]) => v === mediaQuery)?.[0];
-    parts.push(bp ? bp.replace(/^if/, "").replace(/^./, (c) => c.toLowerCase()) : "mq");
-  } else if (mediaQuery) {
-    parts.push("mq");
-  }
-  if (pseudoClass) parts.push(pseudoClass.replace(/^:+/, "").replace(/-/g, "_"));
-  if (whenPseudo) parts.push(whenLookupKeyPart(whenPseudo));
-  return parts.join("_");
-}
+// ── Getter and call resolution ────────────────────────────────────────
 
-function whenLookupKeyPart(whenPseudo: WhenCondition): string {
-  const parts = ["when", whenPseudo.relationship ?? "ancestor", sanitizeLookupToken(whenPseudo.pseudo)];
-
-  if (whenPseudo.markerNode?.type === "Identifier" && whenPseudo.markerNode.name) {
-    parts.push(whenPseudo.markerNode.name);
-  }
-
-  return parts.join("_");
-}
-
-function sanitizeLookupToken(value: string): string {
-  return (
-    value
-      .replace(/[^a-zA-Z0-9]+/g, "_")
-      .replace(/_+/g, "_")
-      .replace(/^_|_$/g, "") || "value"
-  );
-}
-
-/** Resolve `typography(key)` into either direct segments or a runtime lookup-backed segment. */
-function resolveTypographyCall(
-  node: CallChainNode,
-  mapping: TrussMapping,
-  mediaQuery: string | null,
-  pseudoClass: string | null,
-  pseudoElement: string | null,
-  whenPseudo: WhenCondition | null,
-): ResolvedSegment[] {
-  if (node.args.length !== 1) {
-    throw new UnsupportedPatternError(`typography() expects exactly 1 argument, got ${node.args.length}`);
-  }
-
-  const argAst = node.args[0];
-  if (argAst.type === "StringLiteral") {
-    return resolveTypographyEntry(argAst.value, mapping, mediaQuery, pseudoClass, pseudoElement, whenPseudo);
-  }
-
-  const typography = mapping.typography ?? [];
-  if (typography.length === 0) {
-    throw new UnsupportedPatternError(`typography() is unavailable because no typography abbreviations were generated`);
-  }
-
-  const suffix = typographyLookupKeySuffix(mediaQuery, pseudoClass, pseudoElement, whenPseudo, mapping.breakpoints);
-  const lookupKey = suffix ? `typography__${suffix}` : "typography";
-  const segmentsByName: Record<string, ResolvedSegment[]> = {};
-
-  for (const name of typography) {
-    segmentsByName[name] = resolveTypographyEntry(name, mapping, mediaQuery, pseudoClass, pseudoElement, whenPseudo);
-  }
-
-  return [
-    {
-      abbr: lookupKey,
-      defs: {},
-      typographyLookup: {
-        lookupKey,
-        argNode: argAst,
-        segmentsByName,
-      },
-    },
-  ];
-}
-
-/** Resolve a single typography abbreviation name within the current condition context. */
-function resolveTypographyEntry(
-  name: string,
-  mapping: TrussMapping,
-  mediaQuery: string | null,
-  pseudoClass: string | null,
-  pseudoElement: string | null,
-  whenPseudo: WhenCondition | null,
-): ResolvedSegment[] {
-  if (!(mapping.typography ?? []).includes(name)) {
-    throw new UnsupportedPatternError(`Unknown typography abbreviation "${name}"`);
-  }
-
-  const entry = mapping.abbreviations[name];
+function requireEntry(mapping: TrussMapping, abbr: string): TrussMappingEntry {
+  const entry = mapping.abbreviations[abbr];
   if (!entry) {
-    throw new UnsupportedPatternError(`Unknown typography abbreviation "${name}"`);
+    throw new UnsupportedPatternError(`Unknown abbreviation "${abbr}"`);
   }
+  return entry;
+}
 
-  const resolved = resolveEntry(name, entry, mapping, mediaQuery, pseudoClass, pseudoElement, whenPseudo);
-  for (const segment of resolved) {
-    if (segment.variableProps) {
-      throw new UnsupportedPatternError(`Typography abbreviation "${name}" cannot require runtime arguments`);
-    }
-  }
-  return resolved;
+/** Placeholder segment that carries an unsupported-pattern message through to the emitter. */
+function errorSegment(message: string): ResolvedSegment {
+  return { abbr: "__error", defs: {}, error: message };
 }
 
 /** Resolve a static or alias entry (from a getter access). Defs are always flat. */
@@ -857,18 +609,8 @@ function resolveEntry(
   abbr: string,
   entry: TrussMappingEntry,
   mapping: TrussMapping,
-  mediaQuery: string | null,
-  pseudoClass: string | null,
-  pseudoElement: string | null,
-  whenPseudo: WhenCondition | null,
+  context: ResolvedConditionContext,
 ): ResolvedSegment[] {
-  const context: ResolvedConditionContext = {
-    mediaQuery,
-    pseudoClass,
-    pseudoElement,
-    whenPseudo,
-  };
-
   switch (entry.kind) {
     case "static": {
       return [segmentWithConditionContext({ abbr, defs: entry.defs }, context)];
@@ -880,7 +622,7 @@ function resolveEntry(
         if (!subEntry) {
           throw new UnsupportedPatternError(`Alias "${abbr}" references unknown abbreviation "${chainAbbr}"`);
         }
-        result.push(...resolveEntry(chainAbbr, subEntry, mapping, mediaQuery, pseudoClass, pseudoElement, whenPseudo));
+        result.push(...resolveEntry(chainAbbr, subEntry, mapping, context));
       }
       return result;
     }
@@ -892,103 +634,80 @@ function resolveEntry(
   }
 }
 
+/** Resolve a call node: a built-in like `add(...)`/`setVar(...)`, or a variable/delegate abbreviation like `mt(2)`. */
+function resolveCallNode(
+  node: CallChainNode,
+  mapping: TrussMapping,
+  context: ResolvedConditionContext,
+): ResolvedSegment[] {
+  switch (node.name) {
+    case "with":
+      return [resolveWithCall(node)];
+    case "add":
+      return resolveAddCall(node, mapping, context);
+    case "className":
+      return [resolveClassNameCall(node, context)];
+    case "style":
+      return [resolveStyleCall(node, context)];
+    case "setVar":
+      return resolveSetVarCall(node, mapping, context);
+    case "typography":
+      return resolveTypographyCall(node, mapping, context);
+  }
+
+  const entry = requireEntry(mapping, node.name);
+  if (entry.kind === "variable") {
+    return [resolveVariableCall(node.name, entry, node, mapping, context)];
+  }
+  if (entry.kind === "delegate") {
+    return [resolveDelegateCall(node.name, entry, node, mapping, context)];
+  }
+  throw new UnsupportedPatternError(`Abbreviation "${node.name}" is ${entry.kind}, cannot be called as a function`);
+}
+
 /** Resolve a variable (parameterized) call like mt(2) or mt(x). */
 function resolveVariableCall(
   abbr: string,
-  entry: { kind: "variable"; props: string[]; incremented: boolean; extraDefs?: Record<string, unknown> },
+  entry: Extract<TrussMappingEntry, { kind: "variable" }>,
   node: CallChainNode,
   mapping: TrussMapping,
-  mediaQuery: string | null,
-  pseudoClass: string | null,
-  pseudoElement: string | null,
-  whenPseudo: WhenCondition | null,
+  context: ResolvedConditionContext,
 ): ResolvedSegment {
-  if (node.args.length !== 1) {
-    throw new UnsupportedPatternError(`${abbr}() expects exactly 1 argument, got ${node.args.length}`);
-  }
-  const literalValue = tryEvaluatePropertyLiteral(node.args[0], mapping, entry.incremented);
-  return buildParameterizedSegment({
+  const arg = singleArg(node, abbr);
+  return resolveLiteralOrVariableSegment({
     abbr,
     props: entry.props,
     incremented: entry.incremented,
     extraDefs: entry.extraDefs,
-    argAst: node.args[0],
-    literalValue,
+    argAst: arg,
+    literalValue: tryEvaluatePropertyLiteral(arg, mapping, entry.incremented),
     mapping,
-    mediaQuery,
-    pseudoClass,
-    pseudoElement,
-    whenPseudo,
+    context,
   });
 }
 
 /** Resolve a delegate call like mtPx(12). */
 function resolveDelegateCall(
   abbr: string,
-  entry: { kind: "delegate"; target: string },
+  entry: Extract<TrussMappingEntry, { kind: "delegate" }>,
   node: CallChainNode,
   mapping: TrussMapping,
-  mediaQuery: string | null,
-  pseudoClass: string | null,
-  pseudoElement: string | null,
-  whenPseudo: WhenCondition | null,
+  context: ResolvedConditionContext,
 ): ResolvedSegment {
   const targetEntry = mapping.abbreviations[entry.target];
   if (!targetEntry || targetEntry.kind !== "variable") {
     throw new UnsupportedPatternError(`Delegate "${abbr}" targets "${entry.target}" which is not a variable entry`);
   }
-  if (node.args.length !== 1) {
-    throw new UnsupportedPatternError(`${abbr}() expects exactly 1 argument, got ${node.args.length}`);
-  }
-  const literalValue = tryEvaluatePxLiteral(node.args[0]);
+  const arg = singleArg(node, abbr);
   // Use the target abbreviation name for delegate segments (i.e. mtPx → mt)
-  return buildParameterizedSegment({
+  return resolveLiteralOrVariableSegment({
     abbr: entry.target,
     props: targetEntry.props,
     incremented: false,
     appendPx: true,
     extraDefs: targetEntry.extraDefs,
-    argAst: node.args[0],
-    literalValue,
-    mapping,
-    mediaQuery,
-    pseudoClass,
-    pseudoElement,
-    whenPseudo,
-  });
-}
-
-/** Shared builder for variable and delegate call segments. */
-function buildParameterizedSegment(params: {
-  abbr: string;
-  props: string[];
-  incremented: boolean;
-  appendPx?: boolean;
-  extraDefs?: Record<string, unknown>;
-  argAst: t.Expression | t.SpreadElement;
-  literalValue: string | null;
-  mapping: TrussMapping;
-  mediaQuery: string | null;
-  pseudoClass: string | null;
-  pseudoElement: string | null;
-  whenPseudo: WhenCondition | null;
-}): ResolvedSegment {
-  const { abbr, props, incremented, appendPx, extraDefs, argAst, literalValue, mapping, whenPseudo } = params;
-  const context: ResolvedConditionContext = {
-    mediaQuery: params.mediaQuery,
-    pseudoClass: params.pseudoClass,
-    pseudoElement: params.pseudoElement,
-    whenPseudo,
-  };
-
-  return resolveLiteralOrVariableSegment({
-    abbr,
-    props,
-    incremented,
-    appendPx,
-    extraDefs,
-    argAst,
-    literalValue,
+    argAst: arg,
+    literalValue: t.isNumericLiteral(arg) ? `${arg.value}px` : null,
     mapping,
     context,
   });
@@ -997,6 +716,10 @@ function buildParameterizedSegment(params: {
 /**
  * Resolve a parameterized call argument to either a static fold, a compile-time `_var` tuple,
  * or a runtime `_var` tuple.
+ *
+ * I.e. `mt(2)` folds to `defs: { marginTop: "calc(var(--t-spacing) * 2)" }`; `mt(Tokens.gap)` stays a
+ * `_var` segment with `argResolved: "var(--gap)"` so every token shares one `mt_var` class; and `mt(x)`
+ * is a `_var` segment whose value is only known at runtime.
  */
 function resolveLiteralOrVariableSegment(params: {
   abbr: string;
@@ -1004,112 +727,55 @@ function resolveLiteralOrVariableSegment(params: {
   incremented: boolean;
   appendPx?: boolean;
   extraDefs?: Record<string, unknown>;
-  argAst: t.Expression | t.SpreadElement;
+  argAst: t.Expression;
   literalValue: string | null;
   mapping: TrussMapping;
   context: ResolvedConditionContext;
 }): ResolvedSegment {
   const { abbr, props, incremented, appendPx, extraDefs, argAst, literalValue, mapping, context } = params;
 
-  if (literalValue !== null) {
-    const raw = tryResolveValueLiteral(argAst, mapping);
-    if (raw !== null && isCustomPropertyName(raw)) {
-      const base = segmentWithConditionContext(
-        {
-          abbr,
-          defs: {},
-          variableProps: props,
-          incremented,
-          variableExtraDefs: extraDefs,
-          argResolved: literalValue,
-        },
-        context,
-      );
-      if (appendPx) base.appendPx = true;
-      return base;
-    }
-
-    const defs: Record<string, unknown> = {};
-    for (const prop of props) {
-      defs[prop] = literalValue;
-    }
-    if (extraDefs) Object.assign(defs, extraDefs);
-    return segmentWithConditionContext({ abbr, defs, argResolved: literalValue }, context);
+  if (literalValue !== null && !isCustomPropertyLiteral(argAst, mapping)) {
+    const defs: Record<string, unknown> = Object.fromEntries(props.map((prop) => [prop, literalValue]));
+    return segmentWithConditionContext({ abbr, defs: { ...defs, ...extraDefs }, argResolved: literalValue }, context);
   }
 
-  const base = segmentWithConditionContext(
+  return segmentWithConditionContext(
     {
       abbr,
       defs: {},
       variableProps: props,
       incremented,
+      appendPx,
       variableExtraDefs: extraDefs,
-      argNode: argAst,
+      argNode: literalValue === null ? argAst : undefined,
+      argResolved: literalValue ?? undefined,
     },
     context,
   );
-  if (appendPx) base.appendPx = true;
-  return base;
 }
 
-function resolveClassNameCall(
-  node: CallChainNode,
-  mediaQuery: string | null,
-  pseudoClass: string | null,
-  pseudoElement: string | null,
-  whenPseudo: WhenCondition | null,
-): ResolvedSegment {
-  if (node.args.length !== 1) {
-    throw new UnsupportedPatternError(`className() expects exactly 1 argument, got ${node.args.length}`);
-  }
-
-  const arg = node.args[0];
-  if (arg.type === "SpreadElement") {
-    throw new UnsupportedPatternError(`className() does not support spread arguments`);
-  }
-
-  if (mediaQuery || pseudoClass || pseudoElement || whenPseudo) {
+/** Raw class passthrough, i.e. `Css.className(buttonClass).df.$`. */
+function resolveClassNameCall(node: CallChainNode, context: ResolvedConditionContext): ResolvedSegment {
+  const arg = singleArg(node, "className");
+  if (hasCondition(context)) {
     // I.e. `ifSm.className("x")` cannot be represented as a runtime-only class append.
     throw new UnsupportedPatternError(
       `className() cannot be used inside media query, pseudo-class, pseudo-element, or when() contexts`,
     );
   }
-
-  return {
-    // I.e. this is metadata for the rewriter/runtime, not an atomic CSS rule.
-    abbr: "className",
-    defs: {},
-    classNameArg: arg,
-  };
+  // I.e. this is metadata for the rewriter/runtime, not an atomic CSS rule.
+  return { abbr: "className", defs: {}, classNameArg: arg };
 }
 
-function resolveStyleCall(
-  node: CallChainNode,
-  mediaQuery: string | null,
-  pseudoClass: string | null,
-  pseudoElement: string | null,
-  whenPseudo: WhenCondition | null,
-): ResolvedSegment {
-  if (node.args.length !== 1) {
-    throw new UnsupportedPatternError(`style() expects exactly 1 argument, got ${node.args.length}`);
-  }
-
-  const arg = node.args[0];
-  if (arg.type === "SpreadElement") {
-    throw new UnsupportedPatternError(`style() does not support spread arguments`);
-  }
-
-  if (mediaQuery || pseudoClass || pseudoElement || whenPseudo) {
+/** Raw inline style passthrough, i.e. `Css.mt(x).style(vars).$`. */
+function resolveStyleCall(node: CallChainNode, context: ResolvedConditionContext): ResolvedSegment {
+  const arg = singleArg(node, "style");
+  if (hasCondition(context)) {
     throw new UnsupportedPatternError(
       `style() cannot be used inside media query, pseudo-class, pseudo-element, or when() contexts`,
     );
   }
-
-  return {
-    abbr: "style",
-    defs: {},
-    styleArg: arg,
-  };
+  return { abbr: "style", defs: {}, styleArg: arg };
 }
 
 /**
@@ -1119,34 +785,17 @@ function resolveStyleCall(
  * - `with(expr)` — spread an existing Css expression into the chain output
  * - `with({ height })` — inline a partial style hash, skipping undefined values
  */
-function resolveWithCall(
-  node: CallChainNode,
-  mediaQuery: string | null,
-  pseudoClass: string | null,
-  pseudoElement: string | null,
-  whenPseudo: WhenCondition | null,
-): ResolvedSegment {
+function resolveWithCall(node: CallChainNode): ResolvedSegment {
   if (node.args.length !== 1) {
     throw new UnsupportedPatternError(`with() requires exactly 1 argument`);
   }
   const styleArg = node.args[0];
-  if (styleArg.type === "SpreadElement") {
+  if (t.isSpreadElement(styleArg)) {
     throw new UnsupportedPatternError(`with() does not support spread arguments`);
   }
   // Object literal: skip undefined values (the old addCss({ height }) pattern)
-  if (styleArg.type === "ObjectExpression") {
-    return {
-      abbr: "__composed_css_prop",
-      defs: {},
-      styleArrayArg: styleArg,
-      isAddCss: true,
-    };
-  }
-  return {
-    abbr: "__composed_css_prop",
-    defs: {},
-    styleArrayArg: styleArg,
-  };
+  const isAddCss = t.isObjectExpression(styleArg) ? { isAddCss: true } : {};
+  return { abbr: "__composed_css_prop", defs: {}, styleArrayArg: styleArg, ...isAddCss };
 }
 
 /**
@@ -1159,56 +808,42 @@ function resolveWithCall(
 function resolveAddCall(
   node: CallChainNode,
   mapping: TrussMapping,
-  mediaQuery: string | null,
-  pseudoClass: string | null,
-  pseudoElement: string | null,
-  whenPseudo: WhenCondition | null,
+  context: ResolvedConditionContext,
 ): ResolvedSegment[] {
-  const context: ResolvedConditionContext = {
-    mediaQuery,
-    pseudoClass,
-    pseudoElement,
-    whenPseudo,
-  };
+  const usage =
+    `add() requires 1 or 2 arguments (property name and value, or an object literal), got ${node.args.length}. ` +
+    `Supported overloads are add({ prop: value }), add("propName", value), and with(cssProp)`;
 
   if (node.args.length === 1) {
     const styleArg = node.args[0];
-    if (styleArg.type === "SpreadElement") {
+    if (t.isSpreadElement(styleArg)) {
       throw new UnsupportedPatternError(`add() does not support spread arguments`);
     }
-    if (styleArg.type === "ObjectExpression") {
-      // New behavior: expand object literal into individual property/value segments
-      return resolveAddObjectLiteral(styleArg as any, mapping, context);
+    if (t.isObjectExpression(styleArg)) {
+      return resolveAddObjectLiteral(styleArg, mapping, context);
     }
-    throw new UnsupportedPatternError(
-      `add() requires 1 or 2 arguments (property name and value, or an object literal), got ${node.args.length}. ` +
-        `Supported overloads are add({ prop: value }), add("propName", value), and with(cssProp)`,
-    );
+    throw new UnsupportedPatternError(usage);
   }
 
   if (node.args.length !== 2) {
-    throw new UnsupportedPatternError(
-      `add() requires 1 or 2 arguments (property name and value, or an object literal), got ${node.args.length}. ` +
-        `Supported overloads are add({ prop: value }), add("propName", value), and with(cssProp)`,
-    );
+    throw new UnsupportedPatternError(usage);
   }
 
-  const propArg = node.args[0];
-  if (propArg.type !== "StringLiteral") {
+  const [propArg, valueArg] = node.args;
+  if (!t.isStringLiteral(propArg)) {
     throw new UnsupportedPatternError(`add() first argument must be a string literal property name`);
   }
-  const propName: string = (propArg as any).value;
-
-  const valueArg = node.args[1];
-  const literalValue = tryEvaluatePropertyLiteral(valueArg, mapping, false);
+  if (t.isSpreadElement(valueArg)) {
+    throw new UnsupportedPatternError(`add() does not support spread arguments`);
+  }
 
   return [
     resolveLiteralOrVariableSegment({
-      abbr: propName,
-      props: [propName],
+      abbr: propArg.value,
+      props: [propArg.value],
       incremented: false,
       argAst: valueArg,
-      literalValue,
+      literalValue: tryEvaluatePropertyLiteral(valueArg, mapping, false),
       mapping,
       context,
     }),
@@ -1223,110 +858,129 @@ function resolveAddCall(
  * `{ display: "grid" }` → `dg`), the canonical abbreviation is reused.
  */
 function resolveAddObjectLiteral(
-  obj: import("@babel/types").ObjectExpression,
+  obj: t.ObjectExpression,
   mapping: TrussMapping,
   context: ResolvedConditionContext,
 ): ResolvedSegment[] {
   const segments: ResolvedSegment[] = [];
   for (const property of obj.properties) {
-    if (property.type === "SpreadElement") {
+    if (t.isSpreadElement(property)) {
       throw new UnsupportedPatternError(`add({...}) does not support spread properties -- use with() instead`);
     }
-    if (property.type !== "ObjectProperty" || property.computed) {
+    if (!t.isObjectProperty(property) || property.computed) {
       throw new UnsupportedPatternError(`add({...}) only supports simple property keys`);
     }
-    let propName: string;
-    if (property.key.type === "Identifier") {
-      propName = property.key.name;
-    } else if (property.key.type === "StringLiteral") {
-      propName = (property.key as any).value;
-    } else {
+    const propName = staticPropertyName(property.key);
+    if (propName === null) {
       throw new UnsupportedPatternError(`add({...}) property keys must be identifiers or string literals`);
     }
-    const valueNode = property.value;
-    const literalValue = tryEvaluatePropertyLiteral(valueNode as any, mapping, false);
-    if (literalValue !== null) {
-      const raw = tryResolveValueLiteral(valueNode as any, mapping);
-      if (raw === null || !isCustomPropertyName(raw)) {
-        // Check if this prop/value matches an existing abbreviation in the mapping
-        const canonicalAbbr = findCanonicalAbbreviation(mapping, propName, literalValue);
-        if (canonicalAbbr) {
-          const entry = mapping.abbreviations[canonicalAbbr];
-          segments.push(segmentWithConditionContext(
-            { abbr: canonicalAbbr, defs: (entry as any).defs },
-            context,
-          ));
-          continue;
-        }
-      }
-      segments.push(
-        resolveLiteralOrVariableSegment({
-          abbr: propName,
-          props: [propName],
-          incremented: false,
-          argAst: valueNode as any,
-          literalValue,
-          mapping,
-          context,
-        }),
-      );
-    } else {
-      segments.push(segmentWithConditionContext(
-        { abbr: propName, defs: {}, variableProps: [propName], incremented: false, argNode: valueNode },
-        context,
-      ));
+    const valueNode = property.value as t.Expression;
+    const literalValue = tryEvaluatePropertyLiteral(valueNode, mapping, false);
+
+    const canonicalAbbr =
+      literalValue !== null && !isCustomPropertyLiteral(valueNode, mapping)
+        ? findCanonicalAbbreviation(mapping, propName, literalValue)
+        : undefined;
+    if (canonicalAbbr) {
+      const entry = mapping.abbreviations[canonicalAbbr] as Extract<TrussMappingEntry, { kind: "static" }>;
+      segments.push(segmentWithConditionContext({ abbr: canonicalAbbr, defs: entry.defs }, context));
+      continue;
     }
+
+    segments.push(
+      resolveLiteralOrVariableSegment({
+        abbr: propName,
+        props: [propName],
+        incremented: false,
+        argAst: valueNode,
+        literalValue,
+        mapping,
+        context,
+      }),
+    );
   }
   return segments;
 }
 
-/** Find a canonical abbreviation whose static defs exactly match `{ prop: value }`. */
-function findCanonicalAbbreviation(mapping: TrussMapping, prop: string, value: string): string | null {
-  return getLonghandLookup(mapping).get(`${prop}\0${value}`) ?? null;
+// ── typography(...) ───────────────────────────────────────────────────
+
+/** Resolve `typography(key)` into either direct segments or a runtime lookup-backed segment. */
+function resolveTypographyCall(
+  node: CallChainNode,
+  mapping: TrussMapping,
+  context: ResolvedConditionContext,
+): ResolvedSegment[] {
+  const arg = singleArg(node, "typography");
+  if (t.isStringLiteral(arg)) {
+    return resolveTypographyEntry(arg.value, mapping, context);
+  }
+
+  const typography = mapping.typography ?? [];
+  if (typography.length === 0) {
+    throw new UnsupportedPatternError(`typography() is unavailable because no typography abbreviations were generated`);
+  }
+
+  const suffix = typographyLookupKeySuffix(context, mapping);
+  const lookupKey = suffix ? `typography__${suffix}` : "typography";
+  const segmentsByName: Record<string, ResolvedSegment[]> = {};
+  for (const name of typography) {
+    segmentsByName[name] = resolveTypographyEntry(name, mapping, context);
+  }
+
+  return [{ abbr: lookupKey, defs: {}, typographyLookup: { lookupKey, argNode: arg, segmentsByName } }];
 }
 
-/** Resolve a literal value without wrapping (for setVar values, etc.). */
-function tryResolveValueLiteral(node: t.Expression | t.SpreadElement, mapping?: TrussMapping): string | null {
-  if (mapping) {
-    const token = tryResolveTokensMember(node as t.Expression, mapping);
-    if (token !== null) return token;
+/** Resolve a single typography abbreviation name within the current condition context. */
+function resolveTypographyEntry(
+  name: string,
+  mapping: TrussMapping,
+  context: ResolvedConditionContext,
+): ResolvedSegment[] {
+  if (!(mapping.typography ?? []).includes(name)) {
+    throw new UnsupportedPatternError(`Unknown typography abbreviation "${name}"`);
   }
-  if (node.type === "StringLiteral") {
-    return node.value;
+
+  const entry = mapping.abbreviations[name];
+  if (!entry) {
+    throw new UnsupportedPatternError(`Unknown typography abbreviation "${name}"`);
   }
-  if (node.type === "NumericLiteral") {
-    return String(node.value);
+
+  const resolved = resolveEntry(name, entry, mapping, context);
+  for (const segment of resolved) {
+    if (segment.variableProps) {
+      throw new UnsupportedPatternError(`Typography abbreviation "${name}" cannot require runtime arguments`);
+    }
   }
-  if (node.type === "UnaryExpression" && node.operator === "-" && node.argument.type === "NumericLiteral") {
-    return String(-node.argument.value);
-  }
-  return null;
+  return resolved;
 }
 
-/** Resolve `Tokens.Member` / `Tokens["Member"]` to a `--` custom property name. */
-function tryResolveTokensMember(node: t.Expression, mapping: TrussMapping): string | null {
-  if (node.type !== "MemberExpression") return null;
-  if (node.object.type !== "Identifier" || node.object.name !== "Tokens") return null;
-
-  const memberName =
-    !node.computed && node.property.type === "Identifier"
-      ? node.property.name
-      : node.computed && node.property.type === "StringLiteral"
-        ? node.property.value
-        : null;
-  if (memberName == null) return null;
-
-  const tokenMap = mapping.tokens;
-  if (!tokenMap) {
-    throw new UnsupportedPatternError(`Tokens.* requires config.tokens`);
+/**
+ * Build a typography lookup key suffix from condition context.
+ *
+ * I.e. `typography(key)` → `""`, `ifSm.typography(key)` → `"sm"`, `onHover.typography(key)` → `"hover"`.
+ */
+function typographyLookupKeySuffix(context: ResolvedConditionContext, mapping: TrussMapping): string {
+  const parts: string[] = [];
+  if (context.pseudoElement) parts.push(context.pseudoElement.replace(/^::/, ""));
+  if (context.mediaQuery) {
+    const breakpoint = breakpointNameForMediaQuery(mapping, context.mediaQuery);
+    parts.push(breakpoint ? breakpoint.replace(/^./, (c) => c.toLowerCase()) : "mq");
   }
-  if (!(memberName in tokenMap)) {
-    throw new UnsupportedPatternError(`Unknown token "${memberName}" - add it to config.tokens`);
-  }
-  return tokenMap[memberName];
+  if (context.pseudoClass) parts.push(context.pseudoClass.replace(/^:+/, "").replace(/-/g, "_"));
+  if (context.whenPseudo) parts.push(whenLookupKeyPart(context.whenPseudo));
+  return parts.join("_");
 }
 
-const WHEN_RELATIONSHIPS = new Set(["ancestor", "descendant", "anySibling", "siblingBefore", "siblingAfter"]);
+/** I.e. `when(row, "ancestor", ":hover")` → `"when_ancestor_hover_row"`. */
+function whenLookupKeyPart(whenPseudo: WhenCondition): string {
+  const parts = ["when", whenPseudo.relationship, sanitizeClassNameToken(whenPseudo.pseudo) || "value"];
+  if (whenPseudo.markerNode) {
+    parts.push(whenPseudo.markerNode.name);
+  }
+  return parts.join("_");
+}
+
+// ── when(...) selector form ───────────────────────────────────────────
 
 /**
  * Resolve a `when(selector)` or `when(marker, relationship, pseudo)` call.
@@ -1338,9 +992,7 @@ const WHEN_RELATIONSHIPS = new Set(["ancestor", "descendant", "anySibling", "sib
  */
 function resolveWhenCall(
   node: CallChainNode,
-):
-  | { kind: "selector"; selector: string }
-  | { kind: "relationship"; pseudo: string; markerNode?: any; relationship: string } {
+): { kind: "selector"; selector: string } | { kind: "relationship"; condition: WhenCondition } {
   if (node.args.length !== 1 && node.args.length !== 3) {
     throw new UnsupportedPatternError(
       `when() expects 1 or 3 arguments (selector) or (marker, relationship, pseudo), got ${node.args.length}`,
@@ -1349,244 +1001,275 @@ function resolveWhenCall(
 
   if (node.args.length === 1) {
     const selectorArg = node.args[0];
-    if (selectorArg.type !== "StringLiteral") {
+    if (!t.isStringLiteral(selectorArg)) {
       throw new UnsupportedPatternError(`when() selector must be a string literal`);
     }
-    return { kind: "selector", selector: (selectorArg as any).value };
+    return { kind: "selector", selector: selectorArg.value };
   }
 
-  const markerArg = node.args[0];
+  const [markerArg, relationshipArg, pseudoArg] = node.args;
   const markerNode = resolveWhenMarker(markerArg);
-  const relationshipArg = node.args[1];
-  if (relationshipArg.type !== "StringLiteral") {
+  if (!t.isStringLiteral(relationshipArg)) {
     throw new UnsupportedPatternError(`when() relationship argument must be a string literal`);
   }
-  const relationship: string = (relationshipArg as any).value;
-  if (!WHEN_RELATIONSHIPS.has(relationship)) {
+  const relationship = relationshipArg.value;
+  if (!isWhenRelationship(relationship)) {
     throw new UnsupportedPatternError(
-      `when() relationship must be one of: ${[...WHEN_RELATIONSHIPS].join(", ")} -- got "${relationship}"`,
+      `when() relationship must be one of: ${Object.keys(WHEN_RELATIONSHIPS).join(", ")} -- got "${relationship}"`,
     );
   }
-
-  const pseudoArg = node.args[2];
-  if (pseudoArg.type !== "StringLiteral") {
+  if (!t.isStringLiteral(pseudoArg)) {
     throw new UnsupportedPatternError(`when() pseudo selector (3rd argument) must be a string literal`);
   }
-  return { kind: "relationship", pseudo: (pseudoArg as any).value, markerNode, relationship };
+  return { kind: "relationship", condition: { pseudo: pseudoArg.value, markerNode, relationship } };
 }
 
-function resolveWhenMarker(node: t.Expression | t.SpreadElement): any | undefined {
+/** The user's marker variable, or undefined for the shared default marker. */
+function resolveWhenMarker(node: t.Expression | t.SpreadElement): t.Identifier | undefined {
   if (isDefaultMarkerNode(node)) {
     return undefined;
   }
-  if (node.type === "Identifier") {
+  if (t.isIdentifier(node)) {
     return node;
   }
   throw new UnsupportedPatternError(`when() marker must be a marker variable or marker`);
 }
 
+/** I.e. `marker`, `defaultMarker`, or the legacy `Css.defaultMarker()` call. */
 function isDefaultMarkerNode(node: t.Expression | t.SpreadElement): boolean {
-  if (node.type === "Identifier" && (node.name === "marker" || node.name === "defaultMarker")) {
+  if (t.isIdentifier(node) && (node.name === "marker" || node.name === "defaultMarker")) {
     return true;
   }
-  return isLegacyDefaultMarkerExpression(node);
-}
-
-function isLegacyDefaultMarkerExpression(node: t.Expression | t.SpreadElement): boolean {
   return (
-    node.type === "CallExpression" &&
+    t.isCallExpression(node) &&
     node.arguments.length === 0 &&
-    node.callee.type === "MemberExpression" &&
+    t.isMemberExpression(node.callee) &&
     !node.callee.computed &&
-    node.callee.property.type === "Identifier" &&
-    node.callee.property.name === "defaultMarker"
+    t.isIdentifier(node.callee.property, { name: "defaultMarker" })
   );
 }
 
-// ── Helpers ───────────────────────────────────────────────────────────
+// ── Literal evaluation ────────────────────────────────────────────────
 
 /**
  * Try to evaluate a literal AST node to a CSS property value.
  * For incremented entries, also evaluates `maybeInc(literal)` (web: calc on `--t-spacing`).
  * Custom property names (`--token` / `Tokens.X`) are wrapped as `var(--token)`.
  */
-function tryEvaluatePropertyLiteral(
-  node: t.Expression | t.SpreadElement,
-  mapping: TrussMapping,
-  incremented: boolean,
-): string | null {
-  if (node.type === "NumericLiteral") {
-    if (incremented) {
-      return incrementCssValue(node.value);
-    }
-    return String(node.value);
-  }
-  if (node.type === "UnaryExpression" && node.operator === "-" && node.argument.type === "NumericLiteral") {
-    const val = -node.argument.value;
-    if (incremented) {
-      return incrementCssValue(val);
-    }
-    return String(val);
+function tryEvaluatePropertyLiteral(node: t.Expression, mapping: TrussMapping, incremented: boolean): string | null {
+  const numeric = tryNumericLiteral(node);
+  if (numeric !== null) {
+    return incremented ? incrementCssValue(numeric) : String(numeric);
   }
   const raw = tryResolveValueLiteral(node, mapping);
-  if (raw !== null) {
-    return maybeCssVar(raw);
-  }
-  return null;
+  return raw === null ? null : maybeCssVar(raw);
 }
 
-/** Try to evaluate a Px delegate argument (always a number → `${n}px`). */
-function tryEvaluatePxLiteral(node: t.Expression | t.SpreadElement): string | null {
-  if (node.type === "NumericLiteral") {
-    return `${node.value}px`;
-  }
-  return null;
+/** True when the argument names a CSS custom property, i.e. `"--token"` or `Tokens.x`. */
+function isCustomPropertyLiteral(node: t.Expression, mapping: TrussMapping): boolean {
+  const raw = tryResolveValueLiteral(node, mapping);
+  return raw !== null && isCustomPropertyName(raw);
 }
 
-/** Resolve ifContainer({ gt, lt, name? }) to a container query pseudo key. */
-function containerSelectorFromCall(node: CallChainNode): string {
-  if (node.args.length !== 1) {
-    throw new UnsupportedPatternError(`ifContainer() expects exactly 1 argument, got ${node.args.length}`);
+/** Resolve a literal value without wrapping (for setVar values, etc.). */
+function tryResolveValueLiteral(node: t.Expression, mapping?: TrussMapping): string | null {
+  if (mapping) {
+    const token = tryResolveTokensMember(node, mapping);
+    if (token !== null) return token;
   }
-
-  const arg = node.args[0];
-  if (!arg || arg.type !== "ObjectExpression") {
-    throw new UnsupportedPatternError("ifContainer() expects an object literal argument");
-  }
-
-  let lt: number | undefined;
-  let gt: number | undefined;
-  let name: string | undefined;
-
-  for (const prop of arg.properties) {
-    if (prop.type === "SpreadElement") {
-      throw new UnsupportedPatternError("ifContainer() does not support spread properties");
-    }
-    if (prop.type !== "ObjectProperty" || prop.computed) {
-      throw new UnsupportedPatternError("ifContainer() expects plain object properties");
-    }
-
-    const key = objectPropertyName(prop.key);
-    if (!key) {
-      throw new UnsupportedPatternError("ifContainer() only supports identifier/string keys");
-    }
-
-    const valueNode = prop.value as t.Expression | t.SpreadElement;
-
-    if (key === "lt") {
-      lt = numericLiteralValue(valueNode, "ifContainer().lt must be a numeric literal");
-      continue;
-    }
-    if (key === "gt") {
-      gt = numericLiteralValue(valueNode, "ifContainer().gt must be a numeric literal");
-      continue;
-    }
-    if (key === "name") {
-      name = stringLiteralValue(valueNode, "ifContainer().name must be a string literal");
-      continue;
-    }
-
-    throw new UnsupportedPatternError(`ifContainer() does not support property "${key}"`);
-  }
-
-  if (lt === undefined && gt === undefined) {
-    throw new UnsupportedPatternError('ifContainer() requires at least one of "lt" or "gt"');
-  }
-
-  const parts: string[] = [];
-  if (gt !== undefined) {
-    parts.push(`(min-width: ${gt + 1}px)`);
-  }
-  if (lt !== undefined) {
-    parts.push(`(max-width: ${lt}px)`);
-  }
-
-  const query = parts.join(" and ");
-  const namePrefix = name ? `${name} ` : "";
-  return `@container ${namePrefix}${query}`;
-}
-
-function objectPropertyName(node: t.Expression | t.Identifier | t.PrivateName): string | null {
-  if (node.type === "Identifier") return node.name;
-  if (node.type === "StringLiteral") return node.value;
-  return null;
-}
-
-/** Unwrap TS/paren wrappers so nested `when({ ... })` values can be validated uniformly. */
-function unwrapExpression(node: t.Expression): t.Expression {
-  let current = node;
-
-  while (true) {
-    if (
-      current.type === "ParenthesizedExpression" ||
-      current.type === "TSAsExpression" ||
-      current.type === "TSTypeAssertion" ||
-      current.type === "TSNonNullExpression" ||
-      current.type === "TSSatisfiesExpression"
-    ) {
-      current = current.expression;
-      continue;
-    }
-
-    return current;
-  }
-}
-
-function numericLiteralValue(node: t.Expression | t.SpreadElement, errorMessage: string): number {
-  if (node.type === "NumericLiteral") {
+  if (t.isStringLiteral(node)) {
     return node.value;
   }
-  if (node.type === "UnaryExpression" && node.operator === "-" && node.argument.type === "NumericLiteral") {
+  const numeric = tryNumericLiteral(node);
+  return numeric === null ? null : String(numeric);
+}
+
+/** I.e. `12` → 12 and `-12` → -12; null for anything but a (negated) numeric literal. */
+function tryNumericLiteral(node: t.Expression): number | null {
+  if (t.isNumericLiteral(node)) {
+    return node.value;
+  }
+  if (t.isUnaryExpression(node, { operator: "-" }) && t.isNumericLiteral(node.argument)) {
     return -node.argument.value;
   }
-  throw new UnsupportedPatternError(errorMessage);
+  return null;
 }
 
-function stringLiteralValue(node: t.Expression | t.SpreadElement, errorMessage: string): string {
-  if (node.type === "StringLiteral") {
+/** Resolve `Tokens.Member` / `Tokens["Member"]` to a `--` custom property name. */
+function tryResolveTokensMember(node: t.Expression, mapping: TrussMapping): string | null {
+  if (!t.isMemberExpression(node) || !t.isIdentifier(node.object, { name: "Tokens" })) return null;
+  const memberName = memberPropertyName(node);
+  if (memberName === null) return null;
+
+  const tokenMap = mapping.tokens;
+  if (!tokenMap) {
+    throw new UnsupportedPatternError(`Tokens.* requires config.tokens`);
+  }
+  if (!(memberName in tokenMap)) {
+    throw new UnsupportedPatternError(`Unknown token "${memberName}" - add it to config.tokens`);
+  }
+  return tokenMap[memberName];
+}
+
+// ── Argument and object-literal validation ────────────────────────────
+
+/** The single argument of `label()`, rejecting missing, extra, and spread arguments. */
+function singleArg(node: CallChainNode, label: string): t.Expression {
+  if (node.args.length !== 1) {
+    throw new UnsupportedPatternError(`${label}() expects exactly 1 argument, got ${node.args.length}`);
+  }
+  const arg = node.args[0];
+  if (t.isSpreadElement(arg)) {
+    throw new UnsupportedPatternError(`${label}() does not support spread arguments`);
+  }
+  return arg;
+}
+
+/** The `key: value` pairs of an object literal, rejecting spreads, methods, computed keys, and non-static keys. */
+function plainObjectEntries(obj: t.ObjectExpression, label: string): Array<{ key: string; value: t.Expression }> {
+  return obj.properties.map((prop) => {
+    if (t.isSpreadElement(prop)) {
+      throw new UnsupportedPatternError(`${label} does not support spread properties`);
+    }
+    if (!t.isObjectProperty(prop) || prop.computed) {
+      throw new UnsupportedPatternError(`${label} only supports plain object properties`);
+    }
+    const key = staticPropertyName(prop.key);
+    if (key === null) {
+      throw new UnsupportedPatternError(`${label} only supports identifier/string keys`);
+    }
+    return { key, value: prop.value as t.Expression };
+  });
+}
+
+function numericLiteralValue(node: t.Expression, errorMessage: string): number {
+  const numeric = tryNumericLiteral(node);
+  if (numeric === null) {
+    throw new UnsupportedPatternError(errorMessage);
+  }
+  return numeric;
+}
+
+function stringLiteralValue(node: t.Expression, errorMessage: string): string {
+  if (t.isStringLiteral(node)) {
     return node.value;
   }
-  if (node.type === "TemplateLiteral" && node.expressions.length === 0 && node.quasis.length === 1) {
+  if (t.isTemplateLiteral(node) && node.expressions.length === 0 && node.quasis.length === 1) {
     return node.quasis[0].value.cooked ?? "";
   }
   throw new UnsupportedPatternError(errorMessage);
 }
 
-function mediaQueryForBreakpointName(mapping: TrussMapping, bpName: string): string | null {
-  if (!mapping.breakpoints) return null;
-  const key = `if${pascalCase(bpName)}`;
-  return mapping.breakpoints[key] ?? null;
+/** A string/number literal value, unwrapping TS/paren wrappers first. */
+function requireValueLiteral(node: t.Expression, errorMessage: string): string {
+  const value = tryResolveValueLiteral(unwrapExpression(node));
+  if (value === null) {
+    throw new UnsupportedPatternError(errorMessage);
+  }
+  return value;
 }
 
-/**
- * Base class-name fragment for a setVar segment: leading `--` on the custom property becomes `__`,
- * then the name is sanitized for use in a CSS class (same rules as value sanitization elsewhere).
- */
-function setVarClassBaseFromCssVarName(cssVarName: string): string {
-  const body = (cssVarName.startsWith("--") ? cssVarName.slice(2) : cssVarName)
-    .replace(/[^a-zA-Z0-9]/g, "_")
-    .replace(/_+/g, "_")
-    .replace(/^_|_$/g, "");
-  return `__${body}`;
+// ── Container queries ─────────────────────────────────────────────────
+
+interface ContainerBounds {
+  lt?: number;
+  gt?: number;
+  name?: string;
 }
 
-function containerQueryStringFromBounds(name: string | undefined, gt: number | undefined, lt: number | undefined): string {
+/** Resolve ifContainer({ gt, lt, name? }) to an `@container` query string. */
+function containerQueryFromCall(node: CallChainNode): string {
+  const arg = singleArg(node, "ifContainer");
+  if (!t.isObjectExpression(arg)) {
+    throw new UnsupportedPatternError("ifContainer() expects an object literal argument");
+  }
+
+  const bounds: ContainerBounds = {};
+  for (const { key, value } of plainObjectEntries(arg, "ifContainer()")) {
+    if (!readContainerBound(bounds, key, value, "ifContainer().")) {
+      throw new UnsupportedPatternError(`ifContainer() does not support property "${key}"`);
+    }
+  }
+
+  if (bounds.lt === undefined && bounds.gt === undefined) {
+    throw new UnsupportedPatternError('ifContainer() requires at least one of "lt" or "gt"');
+  }
+
+  return containerQueryString(bounds);
+}
+
+/** Read one `lt`/`gt`/`name` bound into `bounds`; false when `key` is not a bound. */
+function readContainerBound(bounds: ContainerBounds, key: string, value: t.Expression, label: string): boolean {
+  if (key === "lt") {
+    bounds.lt = numericLiteralValue(value, `${label}lt must be a numeric literal`);
+    return true;
+  }
+  if (key === "gt") {
+    bounds.gt = numericLiteralValue(value, `${label}gt must be a numeric literal`);
+    return true;
+  }
+  if (key === "name") {
+    bounds.name = stringLiteralValue(value, `${label}name must be a string literal`);
+    return true;
+  }
+  return false;
+}
+
+/** I.e. `{ gt: 400, lt: 800, name: "card" }` → `@container card (min-width: 401px) and (max-width: 800px)`. */
+function containerQueryString(bounds: ContainerBounds): string {
   const parts: string[] = [];
-  if (gt !== undefined) {
-    parts.push(`(min-width: ${gt + 1}px)`);
+  if (bounds.gt !== undefined) {
+    parts.push(`(min-width: ${bounds.gt + 1}px)`);
   }
-  if (lt !== undefined) {
-    parts.push(`(max-width: ${lt}px)`);
+  if (bounds.lt !== undefined) {
+    parts.push(`(max-width: ${bounds.lt}px)`);
   }
-  const query = parts.join(" and ");
-  const namePrefix = name ? `${name} ` : "";
-  return `@container ${namePrefix}${query}`;
+  const namePrefix = bounds.name ? `${bounds.name} ` : "";
+  return `@container ${namePrefix}${parts.join(" and ")}`;
 }
 
+// ── setVar(...) ───────────────────────────────────────────────────────
+
+/** CSS custom properties as atomic classes, i.e. `Css.setVar({ [Tokens.x]: "1px" }).$`. */
+function resolveSetVarCall(
+  node: CallChainNode,
+  mapping: TrussMapping,
+  context: ResolvedConditionContext,
+): ResolvedSegment[] {
+  const arg = singleArg(node, "setVar");
+  if (!t.isObjectExpression(arg)) {
+    throw new UnsupportedPatternError(`setVar() requires an object literal argument`);
+  }
+
+  const segments: ResolvedSegment[] = [];
+  for (const prop of arg.properties) {
+    if (t.isSpreadElement(prop)) {
+      throw new UnsupportedPatternError(`setVar() does not support spread properties`);
+    }
+    if (!t.isObjectProperty(prop)) {
+      throw new UnsupportedPatternError(`setVar() only supports object properties`);
+    }
+    const cssVarName = resolveSetVarPropertyKey(prop, mapping);
+    // I.e. `--theme-accent` → `__theme_accent`, which emit-truss extends with the value, i.e. `__theme_accent_blue`.
+    const abbr = `__${sanitizeClassNameToken(cssVarName.replace(/^--/, ""))}`;
+    for (const leaf of expandSetVarValueToLeaves(prop.value as t.Expression, mapping, context)) {
+      segments.push(
+        segmentWithConditionContext(
+          { abbr, defs: { [cssVarName]: leaf.literal }, argResolved: leaf.literal },
+          leaf.context,
+        ),
+      );
+    }
+  }
+
+  return segments;
+}
+
+/** The `--var-name` a setVar key refers to: a `"--literal"` string key or a `[Tokens.Name]` member. */
 function resolveSetVarPropertyKey(prop: t.ObjectProperty, mapping: TrussMapping): string {
   const key = prop.key;
   if (!prop.computed) {
-    if (key.type === "StringLiteral") {
+    if (t.isStringLiteral(key)) {
       if (key.value.startsWith("--")) {
         return key.value;
       }
@@ -1594,7 +1277,7 @@ function resolveSetVarPropertyKey(prop: t.ObjectProperty, mapping: TrussMapping)
         `setVar() string keys must be CSS variables starting with "--" - got ${JSON.stringify(key.value)}`,
       );
     }
-    if (key.type === "Identifier") {
+    if (t.isIdentifier(key)) {
       throw new UnsupportedPatternError(
         `setVar() requires computed keys like [Tokens.Name] or string keys "--my-var", not bare property names`,
       );
@@ -1602,31 +1285,30 @@ function resolveSetVarPropertyKey(prop: t.ObjectProperty, mapping: TrussMapping)
     throw new UnsupportedPatternError(`setVar() property keys must be string literals or [Tokens.*] members`);
   }
 
-  if (key.type === "MemberExpression") {
-    const mem = key;
-    const memberName =
-      !mem.computed && mem.property.type === "Identifier"
-        ? mem.property.name
-        : mem.computed && mem.property.type === "StringLiteral"
-          ? mem.property.value
-          : null;
-    if (memberName == null) {
-      throw new UnsupportedPatternError(
-        `setVar() [Tokens.name] keys must use a plain .member or ["string"] member access`,
-      );
-    }
-    const tokenMap = mapping.tokens;
-    if (!tokenMap || !(memberName in tokenMap)) {
-      throw new UnsupportedPatternError(
-        tokenMap
-          ? `Unknown token "${memberName}" - add it to config.tokens or use a "--" string literal key`
-          : `setVar() [Tokens.*] requires config.tokens; use "--" string literal keys only`,
-      );
-    }
-    return tokenMap[memberName];
+  if (!t.isMemberExpression(key)) {
+    throw new UnsupportedPatternError(`setVar() computed keys must be Tokens.*-style members`);
   }
+  const memberName = memberPropertyName(key);
+  if (memberName === null) {
+    throw new UnsupportedPatternError(
+      `setVar() [Tokens.name] keys must use a plain .member or ["string"] member access`,
+    );
+  }
+  const tokenMap = mapping.tokens;
+  if (!tokenMap || !(memberName in tokenMap)) {
+    throw new UnsupportedPatternError(
+      tokenMap
+        ? `Unknown token "${memberName}" - add it to config.tokens or use a "--" string literal key`
+        : `setVar() [Tokens.*] requires config.tokens; use "--" string literal keys only`,
+    );
+  }
+  return tokenMap[memberName];
+}
 
-  throw new UnsupportedPatternError(`setVar() computed keys must be Tokens.*-style members`);
+/** One concrete value for a setVar custom property, together with the condition it applies under. */
+interface SetVarLeaf {
+  literal: string;
+  context: ResolvedConditionContext;
 }
 
 /**
@@ -1637,7 +1319,8 @@ function resolveSetVarPropertyKey(prop: t.ObjectProperty, mapping: TrussMapping)
  *
  * Output: each leaf is a concrete literal plus a condition context (viewport `mediaQuery`,
  * `@container` string in `mediaQuery`, or base). `resolveSetVarCall` turns each leaf into
- * a `ResolvedSegment` with `defs: { [cssVarName]: literal }`.
+ * a `ResolvedSegment` with `defs: { [cssVarName]: literal }`. Leaves are emitted in the order
+ * default, media, container regardless of the source property order.
  *
  * I.e. `"8px"` → one leaf with the inherited context (often unconditional).
  *
@@ -1650,145 +1333,51 @@ function resolveSetVarPropertyKey(prop: t.ObjectProperty, mapping: TrussMapping)
 function expandSetVarValueToLeaves(
   valueNode: t.Expression,
   mapping: TrussMapping,
-  baseCtx: ResolvedConditionContext,
-): Array<{ literal: string; ctx: ResolvedConditionContext }> {
+  baseContext: ResolvedConditionContext,
+): SetVarLeaf[] {
   const unwrapped = unwrapExpression(valueNode);
   const scalar = tryResolveValueLiteral(unwrapped);
   if (scalar !== null) {
-    return [{ literal: scalar, ctx: cloneConditionContext(baseCtx) }];
+    return [setVarLeaf(scalar, baseContext)];
   }
 
-  if (unwrapped.type !== "ObjectExpression") {
+  if (!t.isObjectExpression(unwrapped)) {
     throw new UnsupportedPatternError(
       `setVar() values must be string/number literals or a { default?, media?, container? } object`,
     );
   }
 
-  let defaultLit: string | undefined;
-  let mediaObj: t.ObjectExpression | undefined;
-  let containerArr: t.ArrayExpression | undefined;
+  let defaultLiteral: string | undefined;
+  let mediaObject: t.ObjectExpression | undefined;
+  let containerArray: t.ArrayExpression | undefined;
 
-  for (const prop of unwrapped.properties) {
-    if (prop.type === "SpreadElement") {
-      throw new UnsupportedPatternError(`setVar() responsive object does not support spread properties`);
-    }
-    if (prop.type !== "ObjectProperty" || prop.computed) {
-      throw new UnsupportedPatternError(`setVar() responsive object only supports plain data properties`);
-    }
-    const name = objectPropertyName(prop.key);
-    if (!name) {
-      throw new UnsupportedPatternError(`setVar() responsive object: invalid property key`);
-    }
-    if (name === "default") {
-      const v = tryResolveValueLiteral(unwrapExpression(prop.value as t.Expression));
-      if (v === null) {
-        throw new UnsupportedPatternError(`setVar().default must be a string or number literal`);
-      }
-      defaultLit = v;
-      continue;
-    }
-    if (name === "media") {
-      if (prop.value.type !== "ObjectExpression") {
+  for (const { key, value } of plainObjectEntries(unwrapped, "setVar() responsive object")) {
+    if (key === "default") {
+      defaultLiteral = requireValueLiteral(value, `setVar().default must be a string or number literal`);
+    } else if (key === "media") {
+      if (!t.isObjectExpression(value)) {
         throw new UnsupportedPatternError(`setVar().media must be an object literal`);
       }
-      mediaObj = prop.value;
-      continue;
-    }
-    if (name === "container") {
-      if (prop.value.type !== "ArrayExpression") {
+      mediaObject = value;
+    } else if (key === "container") {
+      if (!t.isArrayExpression(value)) {
         throw new UnsupportedPatternError(`setVar().container must be an array literal`);
       }
-      containerArr = prop.value;
-      continue;
-    }
-    throw new UnsupportedPatternError(`setVar() responsive object does not support property "${name}"`);
-  }
-
-  const leaves: Array<{ literal: string; ctx: ResolvedConditionContext }> = [];
-
-  if (defaultLit !== undefined) {
-    leaves.push({ literal: defaultLit, ctx: cloneConditionContext(baseCtx) });
-  }
-
-  if (mediaObj) {
-    for (const mprop of mediaObj.properties) {
-      if (mprop.type === "SpreadElement") {
-        throw new UnsupportedPatternError(`setVar().media does not support spread properties`);
-      }
-      if (mprop.type !== "ObjectProperty" || mprop.computed) {
-        throw new UnsupportedPatternError(`setVar().media only supports plain identifier or string keys`);
-      }
-      const bpName = objectPropertyName(mprop.key);
-      if (!bpName) {
-        throw new UnsupportedPatternError(`setVar().media: invalid breakpoint key`);
-      }
-      const mq = mediaQueryForBreakpointName(mapping, bpName);
-      if (!mq) {
-        throw new UnsupportedPatternError(
-          `Unknown breakpoint "${bpName}" in setVar().media - use a Breakpoint name from truss-config`,
-        );
-      }
-      const v = tryResolveValueLiteral(unwrapExpression(mprop.value as t.Expression));
-      if (v === null) {
-        throw new UnsupportedPatternError(`setVar().media[${bpName}] must be a string or number literal`);
-      }
-      const ctx = cloneConditionContext(baseCtx);
-      ctx.mediaQuery = mq;
-      leaves.push({ literal: v, ctx });
+      containerArray = value;
+    } else {
+      throw new UnsupportedPatternError(`setVar() responsive object does not support property "${key}"`);
     }
   }
 
-  if (containerArr) {
-    for (const elt of containerArr.elements) {
-      if (elt === null) {
-        continue;
-      }
-      if (elt.type !== "ObjectExpression") {
-        throw new UnsupportedPatternError(`setVar().container entries must be object literals`);
-      }
-      let rowValue: string | undefined;
-      let cname: string | undefined;
-      let lt: number | undefined;
-      let gt: number | undefined;
-      for (const rprop of elt.properties) {
-        if (rprop.type === "SpreadElement") {
-          throw new UnsupportedPatternError(`setVar().container row does not support spread`);
-        }
-        if (rprop.type !== "ObjectProperty" || rprop.computed) {
-          throw new UnsupportedPatternError(`setVar().container row: use plain properties only`);
-        }
-        const rk = objectPropertyName(rprop.key);
-        if (!rk) {
-          continue;
-        }
-        const rv = rprop.value as t.Expression;
-        if (rk === "value") {
-          const lit = tryResolveValueLiteral(unwrapExpression(rv));
-          if (lit === null) {
-            throw new UnsupportedPatternError(`setVar().container row "value" must be a string or number literal`);
-          }
-          rowValue = lit;
-        } else if (rk === "name") {
-          cname = stringLiteralValue(rv, `setVar().container name must be a string literal`);
-        } else if (rk === "lt") {
-          lt = numericLiteralValue(rv, `setVar().container lt must be a numeric literal`);
-        } else if (rk === "gt") {
-          gt = numericLiteralValue(rv, `setVar().container gt must be a numeric literal`);
-        } else {
-          throw new UnsupportedPatternError(`setVar().container row does not support property "${rk}"`);
-        }
-      }
-      if (rowValue === undefined) {
-        throw new UnsupportedPatternError(`setVar().container row requires a "value" property`);
-      }
-      if (lt === undefined && gt === undefined) {
-        throw new UnsupportedPatternError(`setVar().container row requires at least one of gt or lt`);
-      }
-      const containerMq = containerQueryStringFromBounds(cname, gt, lt);
-      const ctx = cloneConditionContext(baseCtx);
-      ctx.mediaQuery = containerMq;
-      leaves.push({ literal: rowValue, ctx });
-    }
+  const leaves: SetVarLeaf[] = [];
+  if (defaultLiteral !== undefined) {
+    leaves.push(setVarLeaf(defaultLiteral, baseContext));
+  }
+  if (mediaObject) {
+    leaves.push(...setVarMediaLeaves(mediaObject, mapping, baseContext));
+  }
+  if (containerArray) {
+    leaves.push(...setVarContainerLeaves(containerArray, baseContext));
   }
 
   if (leaves.length === 0) {
@@ -1800,59 +1389,61 @@ function expandSetVarValueToLeaves(
   return leaves;
 }
 
-function resolveSetVarCall(
-  node: CallChainNode,
+/** I.e. `{ sm: "green" }` → one leaf per breakpoint, each under that breakpoint's media query. */
+function setVarMediaLeaves(
+  mediaObject: t.ObjectExpression,
   mapping: TrussMapping,
-  mediaQuery: string | null,
-  pseudoClass: string | null,
-  pseudoElement: string | null,
-  whenPseudo: WhenCondition | null,
-): ResolvedSegment[] {
-  if (node.args.length !== 1) {
-    throw new UnsupportedPatternError(`setVar() requires exactly 1 argument (an object literal)`);
-  }
-  const arg = node.args[0];
-  if (arg.type === "SpreadElement") {
-    throw new UnsupportedPatternError(`setVar() does not support spread arguments`);
-  }
-  if (arg.type !== "ObjectExpression") {
-    throw new UnsupportedPatternError(`setVar() requires an object literal argument`);
-  }
-
-  const baseContext: ResolvedConditionContext = {
-    mediaQuery,
-    pseudoClass,
-    pseudoElement,
-    whenPseudo,
-  };
-
-  const segments: ResolvedSegment[] = [];
-
-  for (const prop of arg.properties) {
-    if (prop.type === "SpreadElement") {
-      throw new UnsupportedPatternError(`setVar() does not support spread properties`);
-    }
-    if (prop.type !== "ObjectProperty") {
-      throw new UnsupportedPatternError(`setVar() only supports object properties`);
-    }
-    const cssVarName = resolveSetVarPropertyKey(prop, mapping);
-    const leaves = expandSetVarValueToLeaves(prop.value as t.Expression, mapping, baseContext);
-    for (const leaf of leaves) {
-      const abbr = setVarClassBaseFromCssVarName(cssVarName);
-      segments.push(
-        segmentWithConditionContext(
-          {
-            abbr,
-            defs: { [cssVarName]: leaf.literal },
-            argResolved: leaf.literal,
-          },
-          leaf.ctx,
-        ),
+  baseContext: ResolvedConditionContext,
+): SetVarLeaf[] {
+  return plainObjectEntries(mediaObject, "setVar().media").map(({ key: breakpointName, value }) => {
+    const mediaQuery = mapping.breakpoints?.[`if${pascalCase(breakpointName)}`] ?? null;
+    if (mediaQuery === null) {
+      throw new UnsupportedPatternError(
+        `Unknown breakpoint "${breakpointName}" in setVar().media - use a Breakpoint name from truss-config`,
       );
     }
-  }
+    const literal = requireValueLiteral(value, `setVar().media[${breakpointName}] must be a string or number literal`);
+    return setVarLeaf(literal, baseContext, mediaQuery);
+  });
+}
 
-  return segments;
+/** I.e. `[{ gt: 400, value: "10px" }]` → one leaf per row, each under its `@container` query. */
+function setVarContainerLeaves(containerArray: t.ArrayExpression, baseContext: ResolvedConditionContext): SetVarLeaf[] {
+  const leaves: SetVarLeaf[] = [];
+  for (const element of containerArray.elements) {
+    if (element === null) {
+      continue;
+    }
+    if (!t.isObjectExpression(element)) {
+      throw new UnsupportedPatternError(`setVar().container entries must be object literals`);
+    }
+    let rowValue: string | undefined;
+    const bounds: ContainerBounds = {};
+    for (const { key, value } of plainObjectEntries(element, "setVar().container row")) {
+      if (key === "value") {
+        rowValue = requireValueLiteral(value, `setVar().container row "value" must be a string or number literal`);
+      } else if (!readContainerBound(bounds, key, value, "setVar().container ")) {
+        throw new UnsupportedPatternError(`setVar().container row does not support property "${key}"`);
+      }
+    }
+    if (rowValue === undefined) {
+      throw new UnsupportedPatternError(`setVar().container row requires a "value" property`);
+    }
+    if (bounds.lt === undefined && bounds.gt === undefined) {
+      throw new UnsupportedPatternError(`setVar().container row requires at least one of gt or lt`);
+    }
+    leaves.push(setVarLeaf(rowValue, baseContext, containerQueryString(bounds)));
+  }
+  return leaves;
+}
+
+/** A leaf in the base context, or under `mediaQuery` when given. */
+function setVarLeaf(literal: string, baseContext: ResolvedConditionContext, mediaQuery?: string): SetVarLeaf {
+  const context = cloneConditionContext(baseContext);
+  if (mediaQuery !== undefined) {
+    context.mediaQuery = mediaQuery;
+  }
+  return { literal, context };
 }
 
 // ── Chain node types (parsed from AST) ────────────────────────────────
@@ -1870,14 +1461,23 @@ export interface CallChainNode {
 
 export interface IfChainNode {
   type: "if";
-  conditionNode: t.Expression | t.SpreadElement;
+  conditionNode: t.Expression;
 }
 
 export interface ElseChainNode {
   type: "else";
 }
 
-export type ChainNode = GetterChainNode | CallChainNode | IfChainNode | ElseChainNode;
+/**
+ * A media query context switch. Never produced by `extractChain`; `resolveFullChain` synthesizes
+ * it for `if("@media ...")`, breakpoint getters, and the inverted query of a media `else` branch.
+ */
+export interface MediaQueryChainNode {
+  type: "mediaQuery";
+  mediaQuery: string;
+}
+
+export type ChainNode = GetterChainNode | CallChainNode | IfChainNode | ElseChainNode | MediaQueryChainNode;
 
 export class UnsupportedPatternError extends Error {
   constructor(message: string) {

--- a/packages/truss/src/plugin/rewrite-sites.ts
+++ b/packages/truss/src/plugin/rewrite-sites.ts
@@ -1,10 +1,10 @@
 import type { NodePath } from "@babel/traverse";
 import * as t from "@babel/types";
-import type { TrussMapping } from "./types";
+import { hasCondition, isStyleSegment, type ResolvedSegment, type TrussMapping } from "./types";
 import type { ResolvedChain } from "./resolve-chain";
 import { buildStyleHashProperties, markerClassName } from "./emit-truss";
-import type { ResolvedSegment } from "./types";
 import { generate, traverse } from "./babel-utils";
+import { isCssMethodCall, staticPropertyName } from "./ast-utils";
 import { TRUSS_CUSTOM_CLASS_PREFIX, TRUSS_INLINE_STYLE_PREFIX, TRUSS_MARKER_KEY } from "../style-metadata";
 
 export interface ExpressionSite {
@@ -12,23 +12,34 @@ export interface ExpressionSite {
   resolvedChain: ResolvedChain;
 }
 
+/** The `@homebound/truss/runtime` exports the rewritten code may call. */
+export type RuntimeHelperName = "trussProps" | "mergeProps" | "TrussDebugInfo" | "maybeCssVar";
+
+export interface RuntimeHelpers {
+  /**
+   * The local identifier for a runtime export, marking it as used so the import gets added.
+   *
+   * I.e. `use("mergeProps")` → `"mergeProps"`, or `"mergeProps13"` when the module already
+   * has `import { mergeProps as mergeProps13 } from "@homebound/truss/runtime"`.
+   */
+  use(name: RuntimeHelperName): string;
+}
+
 export interface RewriteSitesOptions {
   ast: t.File;
   sites: ExpressionSite[];
-  cssBindingName: string;
+  /** Null when the file only has JSX `css=` attributes and no `Css` binding. */
+  cssBindingName: string | null;
   filename: string;
   debug: boolean;
   mapping: TrussMapping;
   maybeIncHelperName: string | null;
   maybeCssVarHelperName: string | null;
-  mergePropsHelperName: string;
-  needsMergePropsHelper: { current: boolean };
-  trussPropsHelperName: string;
-  needsTrussPropsHelper: { current: boolean };
-  trussDebugInfoName: string;
-  needsTrussDebugInfo: { current: boolean };
+  runtime: RuntimeHelpers;
   runtimeLookupNames: Map<string, string>;
 }
+
+type StyleHashMember = t.ObjectProperty | t.SpreadElement;
 
 /**
  * Rewrite collected `Css...$` expression sites into Truss-native style hash objects.
@@ -58,9 +69,7 @@ export function rewriteExpressionSites(options: RewriteSitesOptions): void {
       }
     } else {
       // Non-JSX position → plain object expression with optional debug info
-      if (options.debug && line !== null) {
-        injectDebugInfo(styleHash, line, options);
-      }
+      injectDebugInfo(styleHash, line, options);
       site.path.replaceWith(styleHash);
     }
   }
@@ -90,7 +99,7 @@ function getCssAttributePath(path: NodePath<t.MemberExpression>): NodePath<t.JSX
 
 /** Build an ObjectExpression from a ResolvedChain, handling conditionals. */
 function buildStyleHashFromChain(chain: ResolvedChain, options: RewriteSitesOptions): t.ObjectExpression {
-  const members: (t.ObjectProperty | t.SpreadElement)[] = [];
+  const members: StyleHashMember[] = [];
   const previousProperties = new Map<string, t.ObjectProperty>();
   const pendingUnconditionalSegments: ResolvedSegment[] = [];
 
@@ -111,9 +120,7 @@ function buildStyleHashFromChain(chain: ResolvedChain, options: RewriteSitesOpti
   }
 
   if (chain.markers.length > 0) {
-    const markerClasses = chain.markers.map((marker) => {
-      return markerClassName(marker.markerNode);
-    });
+    const markerClasses = chain.markers.map((marker) => markerClassName(marker.markerNode));
     members.push(t.objectProperty(t.identifier(TRUSS_MARKER_KEY), t.stringLiteral(markerClasses.join(" "))));
   }
 
@@ -153,11 +160,8 @@ function buildStyleHashFromChain(chain: ResolvedChain, options: RewriteSitesOpti
  * Special segments (styleArrayArg, typographyLookup, classNameArg, styleArg) produce
  * spread members or reserved metadata properties.
  */
-function buildStyleHashMembers(
-  segments: ResolvedSegment[],
-  options: RewriteSitesOptions,
-): (t.ObjectProperty | t.SpreadElement)[] {
-  const members: (t.ObjectProperty | t.SpreadElement)[] = [];
+function buildStyleHashMembers(segments: ResolvedSegment[], options: RewriteSitesOptions): StyleHashMember[] {
+  const members: StyleHashMember[] = [];
   const normalSegs: ResolvedSegment[] = [];
   const classNameArgs: t.Expression[] = [];
   const styleKeyCounts = new Map<string, number>();
@@ -181,13 +185,13 @@ function buildStyleHashMembers(
 
     if (seg.classNameArg) {
       // I.e. `Css.className(cls).df.$` becomes `className_cls: cls` in the style hash.
-      classNameArgs.push(t.cloneNode(seg.classNameArg, true) as t.Expression);
+      classNameArgs.push(t.cloneNode(seg.classNameArg, true));
       continue;
     }
 
     if (seg.styleArg) {
       flushNormal();
-      members.push(buildInlineStyleMember(seg.styleArg as t.Expression, styleKeyCounts));
+      members.push(buildMetadataMember(TRUSS_INLINE_STYLE_PREFIX, seg.styleArg, styleKeyCounts));
       continue;
     }
 
@@ -196,7 +200,7 @@ function buildStyleHashMembers(
       if (seg.isAddCss && t.isObjectExpression(seg.styleArrayArg)) {
         members.push(...buildAddCssObjectMembers(seg.styleArrayArg));
       } else {
-        members.push(t.spreadElement(seg.styleArrayArg as t.Expression));
+        members.push(t.spreadElement(seg.styleArrayArg));
       }
       continue;
     }
@@ -206,11 +210,7 @@ function buildStyleHashMembers(
       const lookupName = options.runtimeLookupNames.get(seg.typographyLookup.lookupKey);
       if (lookupName) {
         // I.e. `{ ...(__typography[key] ?? {}) }`
-        const lookupAccess = t.memberExpression(
-          t.identifier(lookupName),
-          seg.typographyLookup.argNode as t.Expression,
-          true,
-        );
+        const lookupAccess = t.memberExpression(t.identifier(lookupName), seg.typographyLookup.argNode, true);
         members.push(t.spreadElement(t.logicalExpression("??", lookupAccess, t.objectExpression([]))));
       }
       continue;
@@ -219,7 +219,7 @@ function buildStyleHashMembers(
     // In debug mode, add the abbreviation name as a marker className for multi-property
     // segments so engineers can see the origin in the DOM. I.e. `Css.bb.$` adds "bb"
     // alongside "bbs_solid bbw_1px", and `Css.lineClamp(n).$` adds "lineClamp".
-    if (options.debug && !seg.classNameArg && !seg.styleArg && !seg.styleArrayArg && !seg.typographyLookup) {
+    if (options.debug) {
       const isMultiProp = Object.keys(seg.defs).length > 1;
       const hasExtraDefs = seg.variableExtraDefs && Object.keys(seg.variableExtraDefs).length > 0;
       if (isMultiProp || hasExtraDefs) {
@@ -235,23 +235,15 @@ function buildStyleHashMembers(
     // Prepend so markers/custom classes appear first in the DOM,
     // I.e. `className="bb bbs_solid bbw_1px"` rather than at the end.
     // Uses unique `className_${key}` keys so spreading preserves all entries.
-    members.unshift(...buildCustomClassNameMembers(classNameArgs));
+    const classNameKeyCounts = new Map<string, number>();
+    members.unshift(
+      ...classNameArgs.map((arg) => buildMetadataMember(TRUSS_CUSTOM_CLASS_PREFIX, arg, classNameKeyCounts)),
+    );
   }
   return members;
 }
 
-function buildCustomClassNameMembers(classNameArgs: t.Expression[]): t.ObjectProperty[] {
-  const counts = new Map<string, number>();
-
-  return classNameArgs.map((arg) => {
-    return buildMetadataMember(TRUSS_CUSTOM_CLASS_PREFIX, arg, counts);
-  });
-}
-
-function buildInlineStyleMember(arg: t.Expression, counts: Map<string, number>): t.ObjectProperty {
-  return buildMetadataMember(TRUSS_INLINE_STYLE_PREFIX, arg, counts);
-}
-
+/** I.e. `className_my_btn: "my-btn"`, with `_2`, `_3` suffixes for repeated keys. */
 function buildMetadataMember(prefix: string, arg: t.Expression, counts: Map<string, number>): t.ObjectProperty {
   const baseKey = `${prefix}${sanitizeMetadataKey(arg)}`;
   const count = (counts.get(baseKey) ?? 0) + 1;
@@ -275,12 +267,16 @@ function sanitizeMetadataKey(arg: t.Expression): string {
   return sanitized || "value";
 }
 
-function buildAddCssObjectMembers(styleObject: t.ObjectExpression): (t.ObjectProperty | t.SpreadElement)[] {
-  const members: (t.ObjectProperty | t.SpreadElement)[] = [];
+/**
+ * Spread an `with({ height, ...rest })` object literal member by member, skipping identifier and
+ * member-expression values that are `undefined` at runtime so they do not clobber earlier styles.
+ */
+function buildAddCssObjectMembers(styleObject: t.ObjectExpression): StyleHashMember[] {
+  const members: StyleHashMember[] = [];
 
   for (const property of styleObject.properties) {
     if (t.isSpreadElement(property)) {
-      members.push(t.spreadElement(t.cloneNode(property.argument, true) as t.Expression));
+      members.push(t.spreadElement(t.cloneNode(property.argument, true)));
       continue;
     }
 
@@ -291,6 +287,7 @@ function buildAddCssObjectMembers(styleObject: t.ObjectExpression): (t.ObjectPro
 
     const value = property.value;
     if (t.isIdentifier(value) || t.isMemberExpression(value) || t.isOptionalMemberExpression(value)) {
+      // I.e. `...(height === undefined ? {} : { height })`
       members.push(
         t.spreadElement(
           t.conditionalExpression(
@@ -317,22 +314,16 @@ function buildAddCssObjectMembers(styleObject: t.ObjectExpression): (t.ObjectPro
  * but `bgWhite` → `backgroundColor` is a plain replacement (should NOT merge).
  */
 function collectConditionalOnlyProps(segments: ResolvedSegment[]): Set<string> {
-  const allProps = new Map<string, boolean>();
+  const conditionalOnly = new Map<string, boolean>();
   for (const seg of segments) {
-    if (seg.error || seg.styleArrayArg || seg.typographyLookup || seg.classNameArg || seg.styleArg) continue;
-    const hasCondition = !!(seg.pseudoClass || seg.mediaQuery || seg.pseudoElement || seg.whenPseudo);
-    const props = seg.variableProps ?? Object.keys(seg.defs);
-    for (const prop of props) {
-      const current = allProps.get(prop);
+    if (!isStyleSegment(seg)) continue;
+    const segHasCondition = hasCondition(seg);
+    for (const prop of seg.variableProps ?? Object.keys(seg.defs)) {
       // If any segment for this property is unconditional, it's not conditional-only
-      allProps.set(prop, current === undefined ? hasCondition : current && hasCondition);
+      conditionalOnly.set(prop, (conditionalOnly.get(prop) ?? true) && segHasCondition);
     }
   }
-  const result = new Set<string>();
-  for (const [prop, isConditionalOnly] of allProps) {
-    if (isConditionalOnly) result.add(prop);
-  }
-  return result;
+  return new Set([...conditionalOnly].filter(([, isConditionalOnly]) => isConditionalOnly).map(([prop]) => prop));
 }
 
 /**
@@ -342,10 +333,10 @@ function collectConditionalOnlyProps(segments: ResolvedSegment[]): Set<string> {
  * override the base when the condition is true.
  */
 function mergeConditionalBranchMembers(
-  members: (t.ObjectProperty | t.SpreadElement)[],
+  members: StyleHashMember[],
   previousProperties: Map<string, t.ObjectProperty>,
   conditionalOnlyProps: Set<string>,
-): (t.ObjectProperty | t.SpreadElement)[] {
+): StyleHashMember[] {
   return members.map((member) => {
     if (!t.isObjectProperty(member)) {
       return member;
@@ -364,6 +355,7 @@ function mergeConditionalBranchMembers(
   });
 }
 
+/** Combine a base value and a conditional overlay value for one CSS property, in either string or tuple form. */
 function mergePropertyValues(previousValue: t.Expression, currentValue: t.Expression): t.Expression {
   if (t.isStringLiteral(previousValue) && t.isStringLiteral(currentValue)) {
     return t.stringLiteral(`${previousValue.value} ${currentValue.value}`);
@@ -385,6 +377,7 @@ function mergePropertyValues(previousValue: t.Expression, currentValue: t.Expres
   return t.cloneNode(currentValue, true);
 }
 
+/** I.e. `["mt_var", vars]` plus `"black"` → `["black mt_var", vars]`, merging `previousVars` into the vars object when given. */
 function mergeTupleValue(
   tuple: t.ArrayExpression,
   classNames: string,
@@ -395,11 +388,9 @@ function mergeTupleValue(
   const mergedClassNames = prependClassNames
     ? `${classNames} ${currentClassNames}`
     : `${currentClassNames} ${classNames}`;
-  const varsExpr = tuple.elements[1];
+  const currentVars = arrayElementExpression(tuple.elements[1]);
   const mergedVars =
-    previousVars && arrayElementExpression(varsExpr)
-      ? mergeVarsObject(previousVars, arrayElementExpression(varsExpr)!)
-      : (arrayElementExpression(varsExpr) ?? previousVars ?? null);
+    previousVars && currentVars ? mergeVarsObject(previousVars, currentVars) : (currentVars ?? previousVars);
 
   return t.arrayExpression([
     t.stringLiteral(mergedClassNames),
@@ -418,27 +409,16 @@ function arrayElementExpression(element: t.Expression | t.SpreadElement | null |
 
 function mergeVarsObject(previousVars: t.Expression, currentVars: t.Expression): t.Expression {
   if (t.isObjectExpression(previousVars) && t.isObjectExpression(currentVars)) {
-    return t.objectExpression([
-      ...previousVars.properties.map((property) => {
-        return t.cloneNode(property, true);
-      }),
-      ...currentVars.properties.map((property) => {
-        return t.cloneNode(property, true);
-      }),
-    ]);
+    return t.objectExpression(
+      [...previousVars.properties, ...currentVars.properties].map((property) => t.cloneNode(property, true)),
+    );
   }
 
   return t.cloneNode(currentVars, true);
 }
 
 function propertyName(key: t.Expression | t.Identifier | t.PrivateName): string {
-  if (t.isIdentifier(key)) {
-    return key.name;
-  }
-  if (t.isStringLiteral(key)) {
-    return key.value;
-  }
-  return generate(key).code;
+  return staticPropertyName(key) ?? generate(key).code;
 }
 
 function clonePropertyKey(key: t.Expression | t.Identifier | t.PrivateName): t.Expression | t.Identifier {
@@ -453,36 +433,26 @@ function clonePropertyKey(key: t.Expression | t.Identifier | t.PrivateName): t.E
 // ---------------------------------------------------------------------------
 
 /**
- * Inject debug info into the first property of a style hash ObjectExpression.
+ * Inject debug info into the first style property of a style hash ObjectExpression.
  *
  * For static values, promotes `"df"` to `["df", new TrussDebugInfo("...")]`.
  * For variable tuples, appends the debug info as a third element.
+ * No-op outside debug mode, without a source line, or for non-object hashes.
  */
 function injectDebugInfo(
-  expr: t.ObjectExpression,
-  line: number,
-  options: Pick<RewriteSitesOptions, "debug" | "trussDebugInfoName" | "needsTrussDebugInfo" | "filename">,
+  styleHash: t.Expression,
+  line: number | null,
+  options: Pick<RewriteSitesOptions, "debug" | "filename" | "runtime">,
 ): void {
-  if (!options.debug) return;
+  if (!options.debug || line === null || !t.isObjectExpression(styleHash)) return;
 
-  // Find the first real style property (skip SpreadElements and __marker metadata)
-  const firstProp = expr.properties.find((p) => {
-    return (
-      t.isObjectProperty(p) &&
-      !(
-        (t.isIdentifier(p.key) && p.key.name.startsWith(TRUSS_CUSTOM_CLASS_PREFIX)) ||
-        (t.isStringLiteral(p.key) && p.key.value.startsWith(TRUSS_CUSTOM_CLASS_PREFIX)) ||
-        (t.isIdentifier(p.key) && p.key.name.startsWith(TRUSS_INLINE_STYLE_PREFIX)) ||
-        (t.isStringLiteral(p.key) && p.key.value.startsWith(TRUSS_INLINE_STYLE_PREFIX)) ||
-        (t.isIdentifier(p.key) && p.key.name === TRUSS_MARKER_KEY) ||
-        (t.isStringLiteral(p.key) && p.key.value === TRUSS_MARKER_KEY)
-      )
-    );
-  }) as t.ObjectProperty | undefined;
+  // Find the first real style property (skip SpreadElements and metadata like __marker / className_*)
+  const firstProp = styleHash.properties.find((p): p is t.ObjectProperty => {
+    return t.isObjectProperty(p) && !isMetadataKey(propertyName(p.key));
+  });
   if (!firstProp) return;
 
-  options.needsTrussDebugInfo.current = true;
-  const debugExpr = t.newExpression(t.identifier(options.trussDebugInfoName), [
+  const debugExpr = t.newExpression(t.identifier(options.runtime.use("TrussDebugInfo")), [
     t.stringLiteral(`${options.filename}:${line}`),
   ]);
 
@@ -495,11 +465,25 @@ function injectDebugInfo(
   }
 }
 
+/** I.e. `__marker`, `className_foo`, and `style_vars` carry runtime metadata rather than CSS classes. */
+function isMetadataKey(name: string): boolean {
+  return (
+    name === TRUSS_MARKER_KEY ||
+    name.startsWith(TRUSS_CUSTOM_CLASS_PREFIX) ||
+    name.startsWith(TRUSS_INLINE_STYLE_PREFIX)
+  );
+}
+
 // ---------------------------------------------------------------------------
 // JSX css= attribute handling
 // ---------------------------------------------------------------------------
 
-/** Build the spread attribute for a JSX `css=` attribute. */
+/**
+ * Build the spread attribute for a JSX `css=` attribute.
+ *
+ * I.e. `{...trussProps(hash)}`, or `{...mergeProps(className, style, hash)}` when the element
+ * also has `className`/`style` attributes (which are removed and folded in).
+ */
 function buildCssSpreadAttribute(
   path: NodePath<t.JSXAttribute>,
   styleHash: t.Expression,
@@ -509,35 +493,19 @@ function buildCssSpreadAttribute(
   const existingClassNameExpr = removeExistingAttribute(path, "className");
   const existingStyleExpr = removeExistingAttribute(path, "style");
 
+  injectDebugInfo(styleHash, line, options);
+
   if (!existingClassNameExpr && !existingStyleExpr) {
-    return t.jsxSpreadAttribute(buildPropsCall(styleHash, line, options));
-  }
-
-  // mergeProps(className, style, hash)
-  options.needsMergePropsHelper.current = true;
-
-  if (options.debug && line !== null && t.isObjectExpression(styleHash)) {
-    injectDebugInfo(styleHash, line, options);
+    return t.jsxSpreadAttribute(t.callExpression(t.identifier(options.runtime.use("trussProps")), [styleHash]));
   }
 
   return t.jsxSpreadAttribute(
-    t.callExpression(t.identifier(options.mergePropsHelperName), [
+    t.callExpression(t.identifier(options.runtime.use("mergeProps")), [
       existingClassNameExpr ?? t.identifier("undefined"),
       existingStyleExpr ?? t.identifier("undefined"),
       styleHash,
     ]),
   );
-}
-
-/** Emit `trussProps(hash)` call. In debug mode, injects debug info into the hash first. */
-function buildPropsCall(styleHash: t.Expression, line: number | null, options: RewriteSitesOptions): t.CallExpression {
-  options.needsTrussPropsHelper.current = true;
-
-  if (options.debug && line !== null && t.isObjectExpression(styleHash)) {
-    injectDebugInfo(styleHash, line, options);
-  }
-
-  return t.callExpression(t.identifier(options.trussPropsHelperName), [styleHash]);
 }
 
 /** Remove a sibling JSX attribute and return its expression. */
@@ -576,22 +544,23 @@ function rewriteCssPropsAndCssAttributes(options: RewriteSitesOptions): void {
   traverse(options.ast, {
     // -- Css.props(expr) → trussProps(expr) or mergeProps(...) --
     CallExpression(path: NodePath<t.CallExpression>) {
-      if (!isCssPropsCall(path.node, options.cssBindingName)) return;
+      if (!options.cssBindingName || !isCssMethodCall(path.node, options.cssBindingName, "props")) return;
 
       const arg = path.node.arguments[0];
       if (!arg || t.isSpreadElement(arg) || !t.isExpression(arg) || path.node.arguments.length !== 1) return;
 
-      options.needsTrussPropsHelper.current = true;
-
       // Check for a sibling `className` property in the parent object literal
       const classNameExpr = extractSiblingClassName(path);
       if (classNameExpr) {
-        options.needsMergePropsHelper.current = true;
         path.replaceWith(
-          t.callExpression(t.identifier(options.mergePropsHelperName), [classNameExpr, t.identifier("undefined"), arg]),
+          t.callExpression(t.identifier(options.runtime.use("mergeProps")), [
+            classNameExpr,
+            t.identifier("undefined"),
+            arg,
+          ]),
         );
       } else {
-        path.replaceWith(t.callExpression(t.identifier(options.trussPropsHelperName), [arg]));
+        path.replaceWith(t.callExpression(t.identifier(options.runtime.use("trussProps")), [arg]));
       }
     },
     // -- Remaining css={expr} JSX attributes → {...trussProps(expr)} spreads --
@@ -606,20 +575,6 @@ function rewriteCssPropsAndCssAttributes(options: RewriteSitesOptions): void {
       path.replaceWith(buildCssSpreadAttribute(path, value.expression, path.node.loc?.start.line ?? null, options));
     },
   });
-}
-
-// ---------------------------------------------------------------------------
-// Utility helpers
-// ---------------------------------------------------------------------------
-
-/** Match `Css.props(...)` calls. */
-function isCssPropsCall(expr: t.CallExpression, cssBindingName: string): boolean {
-  return (
-    t.isMemberExpression(expr.callee) &&
-    !expr.callee.computed &&
-    t.isIdentifier(expr.callee.object, { name: cssBindingName }) &&
-    t.isIdentifier(expr.callee.property, { name: "props" })
-  );
 }
 
 /**
@@ -638,7 +593,7 @@ function extractSiblingClassName(callPath: NodePath<t.CallExpression>): t.Expres
   for (let i = 0; i < properties.length; i++) {
     const prop = properties[i];
     if (!t.isObjectProperty(prop)) continue;
-    if (!isMatchingPropertyName(prop.key, "className")) continue;
+    if (staticPropertyName(prop.key) !== "className") continue;
     if (!t.isExpression(prop.value)) continue;
 
     const classNameExpr = prop.value;
@@ -649,11 +604,7 @@ function extractSiblingClassName(callPath: NodePath<t.CallExpression>): t.Expres
   return null;
 }
 
-/** Match static object property names. */
-function isMatchingPropertyName(key: t.Expression | t.Identifier | t.PrivateName, name: string): boolean {
-  return (t.isIdentifier(key) && key.name === name) || (t.isStringLiteral(key) && key.value === name);
-}
-
+/** `<RuntimeStyle css={...}>` takes real declarations, not a style hash, so it is left for the runtime. */
 function isRuntimeStyleCssAttribute(path: NodePath<t.JSXAttribute>): boolean {
   const openingElementPath = path.parentPath;
   if (!openingElementPath || !openingElementPath.isJSXOpeningElement()) return false;
@@ -666,11 +617,7 @@ function isRuntimeStyleCssAttribute(path: NodePath<t.JSXAttribute>): boolean {
 
 /** Check whether a style hash has only static string values (no spreads, no tuples). */
 function isFullyStaticStyleHash(hash: t.ObjectExpression): boolean {
-  for (const prop of hash.properties) {
-    if (!t.isObjectProperty(prop)) return false;
-    if (!t.isStringLiteral(prop.value)) return false;
-  }
-  return true;
+  return hash.properties.every((prop) => t.isObjectProperty(prop) && t.isStringLiteral(prop.value));
 }
 
 /** Extract all static class names from a fully-static style hash, joined with spaces. */

--- a/packages/truss/src/plugin/transform-css.ts
+++ b/packages/truss/src/plugin/transform-css.ts
@@ -1,7 +1,7 @@
 import * as t from "@babel/types";
 import type { TrussMapping } from "./types";
 import { resolveFullChain } from "./resolve-chain";
-import { extractChain, findCssImportBinding } from "./ast-utils";
+import { extractDollarChain, findCssImportBinding, unwrapExpression } from "./ast-utils";
 import { collectStaticStringBindings, resolveStaticString } from "./css-ts-utils";
 import { camelToKebab } from "./emit-truss";
 import { parseModule } from "./babel-utils";
@@ -100,18 +100,12 @@ function findNamedCssExportObject(ast: t.File): t.ObjectExpression | null {
     if (!t.isVariableDeclaration(node.declaration)) continue;
 
     for (const declarator of node.declaration.declarations) {
-      if (!t.isIdentifier(declarator.id, { name: "css" })) continue;
-      const value = unwrapObjectExpression(declarator.init);
-      if (value) return value;
+      if (!t.isIdentifier(declarator.id, { name: "css" }) || !declarator.init) continue;
+      // I.e. also accept `export const css = { ... } satisfies Record<string, ...>`
+      const value = unwrapExpression(declarator.init);
+      if (t.isObjectExpression(value)) return value;
     }
   }
-  return null;
-}
-
-function unwrapObjectExpression(node: t.Expression | null | undefined): t.ObjectExpression | null {
-  if (!node) return null;
-  if (t.isObjectExpression(node)) return node;
-  if (t.isTSAsExpression(node) || t.isTSSatisfiesExpression(node)) return unwrapObjectExpression(node.expression);
   return null;
 }
 
@@ -169,14 +163,10 @@ function resolveCssExpression(
   mapping: TrussMapping,
   filename: string,
 ): CssResolution | CssError {
-  // The expression must end with `.$`
-  if (!t.isMemberExpression(node) || node.computed || !t.isIdentifier(node.property, { name: "$" })) {
-    return { error: "value must be a Css.*.$  expression" };
-  }
-
-  const chain = extractChain(node.object, cssBindingName);
+  // The expression must be a `Css.*.$` chain rooted at the Css import
+  const chain = extractDollarChain(node, cssBindingName);
   if (!chain) {
-    return { error: "could not extract Css chain from expression" };
+    return { error: "value must be a Css.*.$ expression" };
   }
 
   // Validate: no if/else nodes

--- a/packages/truss/src/plugin/transform.test.ts
+++ b/packages/truss/src/plugin/transform.test.ts
@@ -1589,7 +1589,7 @@ describe("transform", () => {
       }
     `).toHaveTrussOutput(
       `
-      import { trussProps, mergeProps } from "@homebound/truss/runtime";
+      import { mergeProps } from "@homebound/truss/runtime";
       function Button({ asLink, navLink }) {
         const attrs = {
           ...mergeProps(asLink ? navLink : undefined, undefined, { display: "df", alignItems: "aic" })
@@ -1625,7 +1625,7 @@ describe("transform", () => {
       }
     `).toHaveTrussOutput(
       `
-      import { trussProps, mergeProps } from "@homebound/truss/runtime";
+      import { mergeProps } from "@homebound/truss/runtime";
       function Button({ asLink, navLink, baseStyles, active, hoverStyles }) {
         const attrs = {
           ...mergeProps(asLink ? navLink : undefined, undefined, { ...{ display: "df" }, ...baseStyles, ...(active && hoverStyles) })

--- a/packages/truss/src/plugin/transform.ts
+++ b/packages/truss/src/plugin/transform.ts
@@ -2,27 +2,37 @@ import type { NodePath } from "@babel/traverse";
 import * as t from "@babel/types";
 import { basename } from "path";
 import type { TrussMapping, ResolvedSegment } from "./types";
-import { resolveFullChain, type CssChainReferenceResolver, type ResolvedChain } from "./resolve-chain";
+import { chainSegments, resolveFullChain, type CssChainReferenceResolver, type ResolvedChain } from "./resolve-chain";
 import { generate, parseModule, traverse } from "./babel-utils";
 import {
-  collectTopLevelBindings,
-  reservePreferredName,
-  findCssImportBinding,
-  findCssBuilderBinding,
-  removeCssImport,
-  findNamedImportBinding,
-  findImportDeclaration,
-  replaceCssImportWithNamedImports,
-  upsertNamedImports,
   extractChain,
+  extractDollarChain,
+  findCssBuilderBinding,
+  findCssImportBinding,
+  findImportDeclaration,
+  findNamedImportBinding,
+  insertAfterLeadingImports,
+  isCssMethodCall,
+  removeCssImport,
+  replaceCssImportWithNamedImports,
+  reservePreferredName,
+  unwrapExpression,
+  upsertNamedImports,
+  type NamedImport,
 } from "./ast-utils";
 import {
   collectAtomicRules,
   generateCssText,
   buildMaybeIncDeclaration,
   buildRuntimeLookupDeclaration,
+  type AtomicRule,
 } from "./emit-truss";
-import { rewriteExpressionSites, type ExpressionSite } from "./rewrite-sites";
+import {
+  rewriteExpressionSites,
+  type ExpressionSite,
+  type RuntimeHelperName,
+  type RuntimeHelpers,
+} from "./rewrite-sites";
 
 export interface TransformResult {
   code: string;
@@ -30,7 +40,7 @@ export interface TransformResult {
   /** The generated CSS text for this file's Truss usages. */
   css: string;
   /** The atomic CSS rules collected during this transform, keyed by class name. */
-  rules: Map<string, import("./emit-truss").AtomicRule>;
+  rules: Map<string, AtomicRule>;
 }
 
 export interface TransformTrussOptions {
@@ -38,6 +48,11 @@ export interface TransformTrussOptions {
   /** When true, inject `__injectTrussCSS(cssText)` call for jsdom/test environments. */
   injectCss?: boolean;
 }
+
+const RUNTIME_MODULE = "@homebound/truss/runtime";
+
+/** Runtime imports are emitted in this order regardless of which helper the rewrite reached first. */
+const RUNTIME_HELPER_ORDER: RuntimeHelperName[] = ["trussProps", "mergeProps", "TrussDebugInfo", "maybeCssVar"];
 
 /**
  * The core transform function. Given a source file's code and the truss mapping,
@@ -61,22 +76,24 @@ export function transformTruss(
   // May be null when the file only has JSX css= attributes without importing Css.
   const cssImportBinding = findCssImportBinding(ast);
   const cssBindingName = cssImportBinding ?? findCssBuilderBinding(ast);
-  const cssIsImported = cssImportBinding !== null;
 
   // Step 2: Collect all Css.*.$  expression sites AND detect Css.props() / JSX css= in a single pass.
   const sites: ExpressionSite[] = [];
   const errorMessages: Array<{ message: string; line: number | null }> = [];
   let hasCssPropsCall = false;
   let hasBuildtimeJsxCssAttribute = false;
+  // Module-scope names, so injected helpers and imports can avoid collisions
+  let usedTopLevelNames = new Set<string>();
 
   traverse(ast, {
+    Program(path: NodePath<t.Program>) {
+      usedTopLevelNames = new Set(Object.keys(path.scope.bindings));
+    },
     // -- Css.*.$  chain collection --
     MemberExpression(path: NodePath<t.MemberExpression>) {
       if (!cssBindingName) return;
-      if (!t.isIdentifier(path.node.property, { name: "$" })) return;
-      if (path.node.computed) return;
 
-      const chain = extractChain(path.node.object, cssBindingName);
+      const chain = extractDollarChain(path.node, cssBindingName);
       if (!chain) return;
       if (isInsideWhenObjectValue(path, cssBindingName)) {
         return;
@@ -98,14 +115,7 @@ export function transformTruss(
     },
     // -- Css.props() detection (so we don't bail early when there are no Css.*.$ sites) --
     CallExpression(path: NodePath<t.CallExpression>) {
-      if (!cssBindingName || hasCssPropsCall) return;
-      const callee = path.node.callee;
-      if (
-        t.isMemberExpression(callee) &&
-        !callee.computed &&
-        t.isIdentifier(callee.object, { name: cssBindingName }) &&
-        t.isIdentifier(callee.property, { name: "props" })
-      ) {
+      if (cssBindingName && isCssMethodCall(path.node, cssBindingName, "props")) {
         hasCssPropsCall = true;
       }
     },
@@ -124,26 +134,14 @@ export function transformTruss(
   const cssText = generateCssText(rules);
 
   // Step 4: Reserve local names for injected helpers
-  const usedTopLevelNames = collectTopLevelBindings(ast);
+  const runtime = createRuntimeHelpers(ast, usedTopLevelNames);
   const maybeIncHelperName = needsMaybeInc ? reservePreferredName(usedTopLevelNames, "__maybeInc") : null;
-  const existingMaybeCssVarHelperName = findNamedImportBinding(ast, "@homebound/truss/runtime", "maybeCssVar");
-  const maybeCssVarHelperName = needsMaybeCssVar
-    ? (existingMaybeCssVarHelperName ?? reservePreferredName(usedTopLevelNames, "maybeCssVar"))
-    : null;
-  const existingMergePropsHelperName = findNamedImportBinding(ast, "@homebound/truss/runtime", "mergeProps");
-  const mergePropsHelperName = existingMergePropsHelperName ?? reservePreferredName(usedTopLevelNames, "mergeProps");
-  const needsMergePropsHelper = { current: false };
-  const existingTrussPropsHelperName = findNamedImportBinding(ast, "@homebound/truss/runtime", "trussProps");
-  const trussPropsHelperName = existingTrussPropsHelperName ?? reservePreferredName(usedTopLevelNames, "trussProps");
-  const needsTrussPropsHelper = { current: false };
-  const existingTrussDebugInfoName = findNamedImportBinding(ast, "@homebound/truss/runtime", "TrussDebugInfo");
-  const trussDebugInfoName = existingTrussDebugInfoName ?? reservePreferredName(usedTopLevelNames, "TrussDebugInfo");
-  const needsTrussDebugInfo = { current: false };
+  const maybeCssVarHelperName = needsMaybeCssVar ? runtime.use("maybeCssVar") : null;
 
   // Collect typography runtime lookups
-  const runtimeLookupNames = new Map<string, string>();
   const runtimeLookups = collectRuntimeLookups(chains);
-  for (const [lookupKey] of runtimeLookups) {
+  const runtimeLookupNames = new Map<string, string>();
+  for (const lookupKey of runtimeLookups.keys()) {
     runtimeLookupNames.set(lookupKey, reservePreferredName(usedTopLevelNames, `__${lookupKey}`));
   }
 
@@ -151,35 +149,18 @@ export function transformTruss(
   rewriteExpressionSites({
     ast,
     sites,
-    cssBindingName: cssBindingName ?? "",
+    cssBindingName,
     filename: basename(filename),
     debug: options.debug ?? false,
     mapping,
     maybeIncHelperName,
     maybeCssVarHelperName,
-    mergePropsHelperName,
-    needsMergePropsHelper,
-    trussPropsHelperName,
-    needsTrussPropsHelper,
-    trussDebugInfoName,
-    needsTrussDebugInfo,
+    runtime,
     runtimeLookupNames,
   });
 
   // Step 6: Prepare runtime imports before removing the Css import.
-  const runtimeImports: Array<{ importedName: string; localName: string }> = [];
-  if (needsTrussPropsHelper.current && !existingTrussPropsHelperName) {
-    runtimeImports.push({ importedName: "trussProps", localName: trussPropsHelperName });
-  }
-  if (needsMergePropsHelper.current && !existingMergePropsHelperName) {
-    runtimeImports.push({ importedName: "mergeProps", localName: mergePropsHelperName });
-  }
-  if (needsTrussDebugInfo.current && !existingTrussDebugInfoName) {
-    runtimeImports.push({ importedName: "TrussDebugInfo", localName: trussDebugInfoName });
-  }
-  if (needsMaybeCssVar && !existingMaybeCssVarHelperName && maybeCssVarHelperName) {
-    runtimeImports.push({ importedName: "maybeCssVar", localName: maybeCssVarHelperName });
-  }
+  const runtimeImports = runtime.imports();
   if (options.injectCss) {
     runtimeImports.push({ importedName: "__injectTrussCSS", localName: "__injectTrussCSS" });
   }
@@ -187,19 +168,19 @@ export function transformTruss(
   // Step 7: Remove/replace the Css import and inject runtime imports.
   // When Css comes from a local `new CssBuilder(...)` (tsup bundles), skip import removal.
   let reusedCssImportLine = false;
-  if (cssIsImported) {
+  if (cssImportBinding) {
     reusedCssImportLine =
       runtimeImports.length > 0 &&
-      findImportDeclaration(ast, "@homebound/truss/runtime") === null &&
-      replaceCssImportWithNamedImports(ast, cssImportBinding!, "@homebound/truss/runtime", runtimeImports);
+      findImportDeclaration(ast, RUNTIME_MODULE) === null &&
+      replaceCssImportWithNamedImports(ast, cssImportBinding, RUNTIME_MODULE, runtimeImports);
 
     if (!reusedCssImportLine) {
-      removeCssImport(ast, cssImportBinding!);
+      removeCssImport(ast, cssImportBinding);
     }
   }
 
-  if (runtimeImports.length > 0 && !reusedCssImportLine) {
-    upsertNamedImports(ast, "@homebound/truss/runtime", runtimeImports);
+  if (!reusedCssImportLine) {
+    upsertNamedImports(ast, RUNTIME_MODULE, runtimeImports);
   }
 
   // Step 8: Insert helper declarations after imports
@@ -208,10 +189,10 @@ export function transformTruss(
     declarationsToInsert.push(buildMaybeIncDeclaration(maybeIncHelperName));
   }
   // Insert runtime lookup tables for typography
-  for (const [lookupKey, lookup] of runtimeLookups) {
+  for (const [lookupKey, segmentsByName] of runtimeLookups) {
     const lookupName = runtimeLookupNames.get(lookupKey);
     if (!lookupName) continue;
-    declarationsToInsert.push(buildRuntimeLookupDeclaration(lookupName, lookup.segmentsByName, mapping));
+    declarationsToInsert.push(buildRuntimeLookupDeclaration(lookupName, segmentsByName, mapping));
   }
 
   // Inject __injectTrussCSS call if requested
@@ -234,12 +215,7 @@ export function transformTruss(
     );
   }
 
-  if (declarationsToInsert.length > 0) {
-    const insertIndex = ast.program.body.findIndex((node) => {
-      return !t.isImportDeclaration(node);
-    });
-    ast.program.body.splice(insertIndex === -1 ? ast.program.body.length : insertIndex, 0, ...declarationsToInsert);
-  }
+  insertAfterLeadingImports(ast, declarationsToInsert);
 
   const output = generate(ast, {
     sourceFileName: filename,
@@ -252,6 +228,41 @@ export function transformTruss(
   return { code: outputCode, map: output.map, css: cssText, rules };
 }
 
+/**
+ * Track which `@homebound/truss/runtime` helpers the rewrite ends up calling.
+ *
+ * `use()` reuses an existing import's local name when the module already imports the helper,
+ * otherwise reserves a collision-free local name; `imports()` lists the helpers that still
+ * need an import statement, in canonical order.
+ */
+function createRuntimeHelpers(
+  ast: t.File,
+  usedTopLevelNames: Set<string>,
+): RuntimeHelpers & { imports(): NamedImport[] } {
+  const localNames = new Map<RuntimeHelperName, string>();
+  const missingImports = new Map<RuntimeHelperName, NamedImport>();
+
+  return {
+    use(name) {
+      let localName = localNames.get(name);
+      if (localName === undefined) {
+        const existing = findNamedImportBinding(ast, name, RUNTIME_MODULE);
+        localName = existing ?? reservePreferredName(usedTopLevelNames, name);
+        if (!existing) missingImports.set(name, { importedName: name, localName });
+        localNames.set(name, localName);
+      }
+      return localName;
+    },
+    imports() {
+      return RUNTIME_HELPER_ORDER.flatMap((name) => {
+        const entry = missingImports.get(name);
+        return entry ? [entry] : [];
+      });
+    },
+  };
+}
+
+/** True when `path` sits inside the object literal of a `Css.…when({ ... })` call, whose values are resolved by the outer chain. */
 function isInsideWhenObjectValue(path: NodePath<t.MemberExpression>, cssBindingName: string): boolean {
   let current: NodePath<t.Node> | null = path.parentPath;
 
@@ -297,10 +308,10 @@ function resolveCssChainReference(
   cssBindingName: string,
   seen: Set<string>,
 ): ReturnType<typeof extractChain> {
-  const value = unwrapReferenceExpression(node);
+  const value = unwrapExpression(node);
 
-  if (t.isMemberExpression(value) && !value.computed && t.isIdentifier(value.property, { name: "$" })) {
-    return extractChain(value.object as t.Expression, cssBindingName);
+  if (t.isMemberExpression(value)) {
+    return extractDollarChain(value, cssBindingName);
   }
 
   if (!t.isIdentifier(value) || seen.has(value.name)) {
@@ -321,46 +332,18 @@ function resolveCssChainReference(
   return resolveCssChainReference(binding.path, init, cssBindingName, seen);
 }
 
-/** Strip TS/paren wrappers before checking whether a reference points at `Css.*.$`. */
-function unwrapReferenceExpression(node: t.Expression): t.Expression {
-  let current = node;
-
-  while (true) {
-    if (
-      t.isParenthesizedExpression(current) ||
-      t.isTSAsExpression(current) ||
-      t.isTSTypeAssertion(current) ||
-      t.isTSNonNullExpression(current) ||
-      t.isTSSatisfiesExpression(current)
-    ) {
-      current = current.expression;
-      continue;
-    }
-
-    return current;
-  }
-}
-
-/** Collect typography runtime lookups from all resolved chains. */
-function collectRuntimeLookups(
-  chains: ResolvedChain[],
-): Map<string, { segmentsByName: Record<string, ResolvedSegment[]> }> {
-  const lookups = new Map<string, { segmentsByName: Record<string, ResolvedSegment[]> }>();
-  for (const chain of chains) {
-    for (const part of chain.parts) {
-      const segs = part.type === "unconditional" ? part.segments : [...part.thenSegments, ...part.elseSegments];
-      for (const seg of segs) {
-        if (seg.typographyLookup && !lookups.has(seg.typographyLookup.lookupKey)) {
-          lookups.set(seg.typographyLookup.lookupKey, {
-            segmentsByName: seg.typographyLookup.segmentsByName,
-          });
-        }
-      }
+/** Collect typography runtime lookups from all resolved chains, keyed by lookup name. */
+function collectRuntimeLookups(chains: ResolvedChain[]): Map<string, Record<string, ResolvedSegment[]>> {
+  const lookups = new Map<string, Record<string, ResolvedSegment[]>>();
+  for (const seg of chains.flatMap((chain) => chainSegments(chain))) {
+    if (seg.typographyLookup && !lookups.has(seg.typographyLookup.lookupKey)) {
+      lookups.set(seg.typographyLookup.lookupKey, seg.typographyLookup.segmentsByName);
     }
   }
   return lookups;
 }
 
+/** Babel's generator drops the blank line after the import block; put it back when the source had one. */
 function preserveBlankLineAfterImports(input: string, output: string): string {
   const inputLines = input.split("\n");
   const outputLines = output.split("\n");

--- a/packages/truss/src/plugin/types.ts
+++ b/packages/truss/src/plugin/types.ts
@@ -1,3 +1,6 @@
+import type * as t from "@babel/types";
+import type { WhenRelationship } from "./when-relationships";
+
 /** The shape of the Css.json mapping file consumed by the Vite plugin. */
 export interface TrussMapping {
   increment: number;
@@ -11,8 +14,9 @@ export interface TrussMapping {
 /** A `when()` relationship selector context that can stack with other condition axes. */
 export interface WhenCondition {
   pseudo: string;
-  markerNode?: any;
-  relationship?: string;
+  /** The user's marker variable, i.e. `row` in `when(row, "ancestor", ":hover")`. Absent for the default marker. */
+  markerNode?: t.Identifier;
+  relationship: WhenRelationship;
 }
 
 /** The active modifier axes while resolving a Css chain. */
@@ -68,15 +72,15 @@ export interface ResolvedSegment {
   /** For variable entries: additional static defs applied alongside the variable value. */
   variableExtraDefs?: Record<string, unknown>;
   /** For variable entries: the AST node of the argument. */
-  argNode?: any;
-  /** For composed Css props inserted via `add(cssProp)`. */
-  styleArrayArg?: any;
+  argNode?: t.Expression;
+  /** For composed Css props inserted via `with(cssProp)`. */
+  styleArrayArg?: t.Expression;
   /** True when the composed style arg is an object literal that should skip undefined values. */
   isAddCss?: boolean;
   /** For custom class names inserted via `className(...)`. */
-  classNameArg?: any;
+  classNameArg?: t.Expression;
   /** For custom inline style objects inserted via `style(...)`. */
-  styleArg?: any;
+  styleArg?: t.Expression;
   /**
    * Compile-time resolved argument value.
    * For static folds: the CSS value baked into an atomic class (e.g. `"red"`).
@@ -87,7 +91,7 @@ export interface ResolvedSegment {
   typographyLookup?: {
     /** I.e. `"typography"` or `"typography__sm"` for `Css.typography(key).$` in a given condition context. */
     lookupKey: string;
-    argNode: any;
+    argNode: t.Expression;
     segmentsByName: Record<string, ResolvedSegment[]>;
   };
   /**
@@ -105,32 +109,22 @@ export interface ResolvedSegment {
 export interface MarkerSegment {
   type: "marker";
   /** If set, the AST node of the user-provided marker variable. Otherwise, default marker. */
-  markerNode?: any;
+  markerNode?: t.Expression;
 }
 
-// ── Shared longhand lookup ───────────────────────────────────────────
-
-const _longhandCache = new WeakMap<TrussMapping, Map<string, string>>();
-
 /**
- * Reverse lookup from `"cssProperty\0cssValue"` → canonical abbreviation name.
+ * True for segments that resolve to atomic CSS declarations.
  *
- * I.e. `{ paddingTop: "8px" }` → `"pt1"`, `{ borderStyle: "solid" }` → `"bss"`.
- * Cached per mapping via WeakMap.
+ * I.e. `Css.df.$` and `Css.mt(x).$` are style segments; `className(...)`, `style(...)`,
+ * `with(...)`, runtime `typography(key)`, and error placeholders are not.
  */
-export function getLonghandLookup(mapping: TrussMapping): Map<string, string> {
-  let lookup = _longhandCache.get(mapping);
-  if (lookup) return lookup;
-  lookup = new Map();
-  for (const [abbr, entry] of Object.entries(mapping.abbreviations)) {
-    if (entry.kind !== "static") continue;
-    const keys = Object.keys(entry.defs);
-    if (keys.length !== 1) continue;
-    const key = `${keys[0]}\0${entry.defs[keys[0]]}`;
-    // First match wins — if multiple abbreviations produce the same declaration,
-    // the one that appears first in the mapping is canonical.
-    if (!lookup.has(key)) lookup.set(key, abbr);
-  }
-  _longhandCache.set(mapping, lookup);
-  return lookup;
+export function isStyleSegment(seg: ResolvedSegment): boolean {
+  return !seg.error && !seg.styleArrayArg && !seg.classNameArg && !seg.styleArg && !seg.typographyLookup;
+}
+
+/** True when a segment or context sits under any modifier axis: media query, pseudo-class, pseudo-element, or `when()`. */
+export function hasCondition(
+  target: Pick<ResolvedSegment, "mediaQuery" | "pseudoClass" | "pseudoElement" | "whenPseudo">,
+): boolean {
+  return !!(target.mediaQuery || target.pseudoClass || target.pseudoElement || target.whenPseudo);
 }

--- a/packages/truss/src/plugin/when-relationships.ts
+++ b/packages/truss/src/plugin/when-relationships.ts
@@ -1,0 +1,70 @@
+/**
+ * The relationship kinds accepted by `when(marker, relationship, pseudo)`.
+ *
+ * Each kind owns its class-name fragment, its StyleX-style priority bump, and the
+ * selector shape that ties the marker element to the styled target element.
+ */
+export type WhenRelationship = "ancestor" | "descendant" | "anySibling" | "siblingBefore" | "siblingAfter";
+
+export interface WhenRelationshipSpec {
+  /** Class-name fragment, i.e. `"anc"` in `wh_anc_h_blue`. */
+  short: string;
+  /** Base priority added to rules that use this relationship, matching StyleX's relational selector system. */
+  priority: number;
+  /**
+   * Build the full rule selector.
+   *
+   * `marker` is the marker selector, i.e. `._row_mrk:hover`; `target` builds the styled element's
+   * selector and accepts an extra pseudo-class to splice in before any pseudo-element.
+   */
+  selector(marker: string, target: (extraPseudoClass?: string) => string): string;
+}
+
+/** Keyed in the order the error message for an unknown relationship lists them. */
+export const WHEN_RELATIONSHIPS: Readonly<Record<WhenRelationship, WhenRelationshipSpec>> = {
+  ancestor: {
+    short: "anc",
+    priority: 10,
+    /** I.e. `._mrk:hover .wh_anc_h_blue`. */
+    selector(marker, target) {
+      return `${marker} ${target()}`;
+    },
+  },
+  descendant: {
+    short: "desc",
+    priority: 15,
+    /** I.e. `.wh_desc_h_blue:has(._mrk:hover)`. */
+    selector(marker, target) {
+      return target(`:has(${marker})`);
+    },
+  },
+  anySibling: {
+    short: "anyS",
+    priority: 20,
+    /** I.e. `.wh_anyS_h_blue:has(~ ._mrk:hover), ._mrk:hover ~ .wh_anyS_h_blue`. */
+    selector(marker, target) {
+      return `${target(`:has(~ ${marker})`)}, ${marker} ~ ${target()}`;
+    },
+  },
+  siblingBefore: {
+    short: "sibB",
+    priority: 30,
+    /** I.e. `._mrk:hover ~ .wh_sibB_h_blue`. */
+    selector(marker, target) {
+      return `${marker} ~ ${target()}`;
+    },
+  },
+  siblingAfter: {
+    short: "sibA",
+    priority: 40,
+    /** I.e. `.wh_sibA_h_blue:has(~ ._mrk:hover)`. */
+    selector(marker, target) {
+      return target(`:has(~ ${marker})`);
+    },
+  },
+};
+
+/** True when `value` names one of the supported `when()` relationships. */
+export function isWhenRelationship(value: string): value is WhenRelationship {
+  return Object.hasOwn(WHEN_RELATIONSHIPS, value);
+}


### PR DESCRIPTION
This is all from just prompting Fable 5.1 to refactor / clean up the internals.

Scanning it all lgtm.
 
---


Thread one ResolvedConditionContext through the chain resolvers instead of four positional params, add a real mediaQuery ChainNode variant in place of the `as any` pseudo node, and put the five when() relationship kinds in one table shared by resolve-chain, priority, and emit-truss. Replace the needsX/helperName plumbing between transform and rewrite-sites with a small RuntimeHelpers registry, and read module-scope names from Babel's Program scope instead of a hand-rolled binding walk. Share the segment, expression, and property-name helpers that had two to four copies each, and type the AST-bearing fields that were `any`.

Behaviour changes: Css.props() with a sibling className no longer imports an unused trussProps; the Vite transform hook now refreshes the .css.ts registry even when the file has no Css token; spread arguments to variable, delegate, add, and typography calls are rejected; a few untested error messages were reworded where they were consolidated.