### PR TITLE
fix: Fold negative literals in Px delegates.

### DIFF
--- a/packages/truss/src/plugin/resolve-calls.ts
+++ b/packages/truss/src/plugin/resolve-calls.ts
@@ -11,7 +11,7 @@ import { staticPropertyName } from "./ast-utils";
 import { type CallChainNode, UnsupportedPatternError } from "./chain-nodes";
 import { cloneConditionContext } from "./condition-context";
 import { requireEntry, staticSegment } from "./resolve-entry";
-import { isCustomPropertyLiteral, singleArg, tryEvaluatePropertyLiteral } from "./resolve-literals";
+import { isCustomPropertyLiteral, singleArg, tryEvaluatePropertyLiteral, tryNumericLiteral } from "./resolve-literals";
 import { resolveSetVarCall } from "./resolve-setvar";
 import { resolveTypographyCall } from "./resolve-typography";
 
@@ -80,6 +80,8 @@ function resolveDelegateCall(
     throw new UnsupportedPatternError(`Delegate "${abbr}" targets "${entry.target}" which is not a variable entry`);
   }
   const arg = singleArg(node, abbr);
+  // I.e. `mtPx(12)` folds to `12px` and `mtPx(-4)` to `-4px`; anything else is a runtime value
+  const pixels = tryNumericLiteral(arg);
   // Use the target abbreviation name for delegate segments (i.e. mtPx → mt)
   return resolveLiteralOrVariableSegment({
     abbr: entry.target,
@@ -88,7 +90,7 @@ function resolveDelegateCall(
     appendPx: true,
     extraDefs: targetEntry.extraDefs,
     argAst: arg,
-    literalValue: t.isNumericLiteral(arg) ? `${arg.value}px` : null,
+    literalValue: pixels === null ? null : `${pixels}px`,
     mapping,
     context,
   });

--- a/packages/truss/src/plugin/transform.test.ts
+++ b/packages/truss/src/plugin/transform.test.ts
@@ -652,6 +652,47 @@ describe("transform", () => {
     );
   });
 
+  test("delegate with negative literal folds like a positive one: Css.mtPx(-4).$", () => {
+    expectTrussTransform(`
+      import { Css } from "./Css";
+      const s = Css.mtPx(-4).$;
+    `).toHaveTrussOutput(
+      `
+      const s = { marginTop: "mt_neg4px" };
+    `,
+      `
+      .mt_neg4px {
+        margin-top: -4px;
+      }
+    `,
+    );
+  });
+
+  test("delegate shorthand with negative literal folds every longhand: Css.mPx(-1).$", () => {
+    expectTrussTransform(`
+      import { Css } from "./Css";
+      const s = Css.mPx(-1).$;
+    `).toHaveTrussOutput(
+      `
+      const s = { marginTop: "mt_neg1px", marginBottom: "mb_neg1px", marginRight: "mr_neg1px", marginLeft: "ml_neg1px" };
+    `,
+      `
+      .mb_neg1px {
+        margin-bottom: -1px;
+      }
+      .ml_neg1px {
+        margin-left: -1px;
+      }
+      .mr_neg1px {
+        margin-right: -1px;
+      }
+      .mt_neg1px {
+        margin-top: -1px;
+      }
+    `,
+    );
+  });
+
   test("delegate shorthand with multiple props appends px: Css.pxPx(x).$", () => {
     expectTrussTransform(`
       import { Css } from "./Css";


### PR DESCRIPTION
`mtPx(12)` folded to the static `mt_12px` class, but `mtPx(-4)` became a runtime custom property because the fold only recognised a bare numeric literal, not the `-4` unary expression. Px delegates now use the same numeric literal check as every other literal fold, so `mPx(-1)` and `topPx(-10)` emit `mt_neg1px`-style static classes.