### PR TITLE
fix: Order overlapping media queries by width so the narrower query w…

### DIFF
--- a/packages/truss/src/plugin/merge-css.test.ts
+++ b/packages/truss/src/plugin/merge-css.test.ts
@@ -179,6 +179,54 @@ describe("mergeTrussCss", () => {
     expect(hoverIdx).toBeLessThan(mediaIdx);
   });
 
+  test("orders same-priority media rules by width across sources, wider query first", () => {
+    const library = parsedTrussCss({
+      rules: [
+        {
+          priority: 3200,
+          className: "lg_black",
+          cssText: "@media screen and (min-width: 960px) { .lg_black.lg_black { color: black; } }",
+        },
+      ],
+    });
+    const app = parsedTrussCss({
+      rules: [
+        {
+          priority: 3200,
+          className: "mdandup_white",
+          cssText: "@media screen and (min-width: 600px) { .mdandup_white.mdandup_white { color: white; } }",
+        },
+      ],
+    });
+
+    const merged = mergeTrussCss([library, app]);
+    const widerIdx = merged.indexOf(".mdandup_white.mdandup_white {");
+    const narrowerIdx = merged.indexOf(".lg_black.lg_black {");
+    expect(widerIdx).toBeLessThan(narrowerIdx);
+  });
+
+  test("media rules without a readable width sort after width-bounded ones", () => {
+    const source = parsedTrussCss({
+      rules: [
+        {
+          priority: 3200,
+          className: "print_white",
+          cssText: "@media print { .print_white.print_white { color: white; } }",
+        },
+        {
+          priority: 3200,
+          className: "sm_black",
+          cssText: "@media screen and (max-width: 599px) { .sm_black.sm_black { color: black; } }",
+        },
+      ],
+    });
+
+    const merged = mergeTrussCss([source]);
+    const boundedIdx = merged.indexOf(".sm_black.sm_black {");
+    const unboundedIdx = merged.indexOf(".print_white.print_white {");
+    expect(boundedIdx).toBeLessThan(unboundedIdx);
+  });
+
   test("deduplicates @property declarations by variable name", () => {
     const source1 = parsedTrussCss({
       rules: [{ priority: 4000.5, className: "mt_var", cssText: ".mt_var { margin-top: var(--marginTop); }" }],

--- a/packages/truss/src/plugin/merge-css.ts
+++ b/packages/truss/src/plugin/merge-css.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "fs";
-import { compareClassNames } from "./priority";
+import { compareRuleSortKeys, ruleSortKey } from "./priority";
 
 /** A parsed CSS rule extracted from an annotated truss.css file. */
 export interface ParsedCssRule {
@@ -136,7 +136,7 @@ export function annotateArbitraryCssBlock(cssText: string): string {
  *
  * Rules are deduplicated by class name (first occurrence wins, since
  * deterministic output means identical class names produce identical rules),
- * then sorted by priority ascending with alphabetical class name tiebreaker.
+ * then sorted with the same comparator emit-css uses: priority, then media-query width, then class name.
  * @property declarations are deduplicated by variable name and appended next.
  * Arbitrary CSS blocks are left opaque and appended in source order at the end.
  */
@@ -163,14 +163,17 @@ export function mergeTrussCss(sources: ParsedTrussCss[]): string {
     allArbitraryCssBlocks.push(...source.arbitraryCssBlocks);
   }
 
-  // Sort by priority ascending, tiebreak alphabetically by class name
-  allRules.sort((a, b) => a.priority - b.priority || compareClassNames(a.className, b.className));
+  // Sort exactly as emit-css does, so a merged stylesheet keeps the per-file cascade order
+  const decorated = allRules.map((rule) => {
+    return { rule, key: ruleSortKey(rule.priority, rule.className, atRulePrelude(rule.cssText)) };
+  });
+  decorated.sort((a, b) => compareRuleSortKeys(a.key, b.key));
 
   const lines: string[] = [];
 
-  for (const rule of allRules) {
-    lines.push(`/* @truss p:${rule.priority} c:${rule.className} */`);
-    lines.push(rule.cssText);
+  for (const entry of decorated) {
+    lines.push(`/* @truss p:${entry.rule.priority} c:${entry.rule.className} */`);
+    lines.push(entry.rule.cssText);
   }
 
   for (const prop of allProperties) {
@@ -183,4 +186,11 @@ export function mergeTrussCss(sources: ParsedTrussCss[]): string {
   }
 
   return lines.join("\n");
+}
+
+/** I.e. `"@media (min-width: 600px) { .a.a { color: red; } }"` → `"@media (min-width: 600px)"`, or undefined for a plain rule. */
+function atRulePrelude(cssText: string): string | undefined {
+  if (!cssText.startsWith("@")) return undefined;
+  const brace = cssText.indexOf("{");
+  return brace === -1 ? undefined : cssText.slice(0, brace).trim();
 }

--- a/packages/truss/src/plugin/priority.ts
+++ b/packages/truss/src/plugin/priority.ts
@@ -4,6 +4,10 @@
  * Priority is an additive sum: propertyPriority + pseudoPriority + atRulePriority + pseudoElementPriority.
  * Rules are sorted by this number before emission, guaranteeing longhands beat shorthands,
  * pseudo-classes follow LVFHA order, and at-rules override base styles — all deterministically.
+ *
+ * Rules that tie on priority, i.e. two `@media` rules for the same property, are ordered by the
+ * width interval their query matches, widest first, so the narrower query is emitted later and
+ * wins wherever both match. See `compareRuleSortKeys`.
  */
 
 import {
@@ -56,26 +60,121 @@ function isVariableRule(rule: AtomicRule): boolean {
 }
 
 /**
- * Pair each rule with its computed priority and sort ascending.
+ * The sort key shared by `emit-css` and `merge-css`, so a stylesheet merged from library CSS
+ * keeps the same rule order as the per-file output.
+ */
+export interface RuleSortKey {
+  priority: number;
+  className: string;
+  /** The px widths the rule's media or container query matches, or null when it has no readable interval. */
+  widthInterval: WidthInterval | null;
+}
+
+/** The inclusive px widths a query matches; `hi` is Infinity for a min-width-only query. */
+export interface WidthInterval {
+  lo: number;
+  hi: number;
+}
+
+/** I.e. `ruleSortKey(3200, "lg_black", "@media screen and (min-width: 960px)")` → `widthInterval: { lo: 960, hi: Infinity }`. */
+export function ruleSortKey(priority: number, className: string, atRulePrelude: string | undefined): RuleSortKey {
+  const widthInterval = atRulePrelude === undefined ? null : parseWidthInterval(atRulePrelude);
+  return { priority, className, widthInterval };
+}
+
+/**
+ * Order rules by priority, then by query width interval, then by class name.
  *
- * When two rules have the same priority (e.g. two different longhands both at 3000),
- * we tiebreak by class name so the output is fully deterministic regardless of
- * file processing order (which differs between dev HMR and production builds).
+ * Priority ties happen between rules in the same tier for the same property, i.e. two `@media`
+ * rules for `color`. Those are ordered widest interval first, so the narrower query is emitted
+ * later and wins in the cascade wherever both match. Equal widths go by lower bound ascending,
+ * and queries with no readable interval (`print`, `not`, comma lists, non-px units) come last,
+ * as they do in StyleX. For one-sided queries this is min-width ascending, then max-width descending.
  *
- * Priorities are computed once upfront so the O(n log n) comparisons are just
- * number/string compares, and callers can reuse them for the `@truss p:` annotations.
+ * The class-name tiebreak keeps the output fully deterministic regardless of file processing
+ * order, which differs between dev HMR and production builds.
+ *
+ * I.e. `(min-width: 600px)` → `(min-width: 960px)` → `(max-width: 1150px)` → `(max-width: 820px)`
+ * → `(min-width: 600px) and (max-width: 959px)` → `print`.
+ */
+export function compareRuleSortKeys(a: RuleSortKey, b: RuleSortKey): number {
+  return (
+    a.priority - b.priority ||
+    compareWidthIntervals(a.widthInterval, b.widthInterval) ||
+    compareClassNames(a.className, b.className)
+  );
+}
+
+/**
+ * Pair each rule with its computed priority and sort with `compareRuleSortKeys`.
+ *
+ * Priorities and width intervals are computed once upfront so the O(n log n) comparisons are just
+ * number/string compares, and callers can reuse the priorities for the `@truss p:` annotations.
  */
 export function sortRulesByPriority(rules: Iterable<AtomicRule>): Array<{ rule: AtomicRule; priority: number }> {
   const decorated = Array.from(rules, (rule) => {
-    return { rule, priority: computeRulePriority(rule) };
+    const priority = computeRulePriority(rule);
+    return { rule, priority, key: ruleSortKey(priority, rule.className, rule.mediaQuery) };
   });
-  decorated.sort((a, b) => {
-    return a.priority - b.priority || compareClassNames(a.rule.className, b.rule.className);
-  });
-  return decorated;
+  decorated.sort((a, b) => compareRuleSortKeys(a.key, b.key));
+  return decorated.map((d) => ({ rule: d.rule, priority: d.priority }));
 }
 
 /** Code-point order, so identical class sets sort identically in dev and production. */
 export function compareClassNames(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/**
+ * Parse the px width interval a `@media` or `@container` prelude matches.
+ *
+ * Only `and`-joined `(min-width: Npx)` / `(max-width: Npx)` terms are read. Other features such as
+ * `(orientation: landscape)` and media types such as `screen` add no bound, and repeated terms
+ * collapse to the effective bound. The result is exact for what it accepts, and null ("no interval")
+ * for a prelude with no width term or with anything it cannot read exactly: comma lists, `not`,
+ * `or`, range syntax, and non-px units.
+ *
+ * I.e. `"@media screen and (min-width: 600px) and (max-width: 959px)"` → `{ lo: 600, hi: 959 }`,
+ * `"@container grid (min-width: 601px)"` → `{ lo: 601, hi: Infinity }`, `"@media print"` → null.
+ */
+function parseWidthInterval(prelude: string): WidthInterval | null {
+  if (/,|\bnot\b|\bor\b|[<>]/.test(prelude)) return null;
+  const terms = Array.from(prelude.matchAll(/\((min|max)-width:\s*([^)]*)\)/g));
+  if (terms.length === 0) return null;
+  let lo = 0;
+  let hi = Infinity;
+  for (const term of terms) {
+    const px = parsePxLength(term[2]);
+    if (px === null) return null;
+    if (term[1] === "min") {
+      lo = Math.max(lo, px);
+    } else {
+      hi = Math.min(hi, px);
+    }
+  }
+  return { lo, hi };
+}
+
+/** I.e. `"600px"` → 600, `"0"` → 0, `"40rem"` → null. */
+function parsePxLength(value: string): number | null {
+  const match = value.trim().match(/^(\d+(?:\.\d+)?)(px)?$/);
+  if (!match) return null;
+  if (match[2] === undefined && Number(match[1]) !== 0) return null;
+  return Number(match[1]);
+}
+
+/**
+ * Widest interval first, equal widths by lower bound ascending, null last.
+ *
+ * I.e. `{ lo: 600, hi: Infinity }` (width Infinity) → `{ lo: 0, hi: 1150 }` (width 1150)
+ * → `{ lo: 600, hi: 959 }` (width 359) → null.
+ */
+function compareWidthIntervals(a: WidthInterval | null, b: WidthInterval | null): number {
+  if (a === null || b === null) {
+    return (a === null ? 1 : 0) - (b === null ? 1 : 0);
+  }
+  const widthA = a.hi - a.lo;
+  const widthB = b.hi - b.lo;
+  if (widthA !== widthB) return widthA > widthB ? -1 : 1;
+  return a.lo - b.lo;
 }

--- a/packages/truss/src/plugin/transform.test.ts
+++ b/packages/truss/src/plugin/transform.test.ts
@@ -3329,6 +3329,167 @@ describe("transform", () => {
     );
   });
 
+  test("overlapping breakpoints emit the wider query first so the narrower one wins", () => {
+    expectTrussTransform(`
+      import { Css } from "./Css";
+      const s = Css.ifMdAndUp.white.ifLg.black.$;
+    `).toHaveTrussOutput(
+      `
+      const s = { color: "mdandup_white lg_black" };
+    `,
+      `
+      @media screen and (min-width: 600px) {
+        .mdandup_white.mdandup_white {
+          color: #fcfcfa;
+        }
+      }
+      @media screen and (min-width: 960px) {
+        .lg_black.lg_black {
+          color: #353535;
+        }
+      }
+    `,
+    );
+  });
+
+  test("a two-sided breakpoint emits after the one-sided breakpoint it overlaps", () => {
+    expectTrussTransform(`
+      import { Css } from "./Css";
+      const s = Css.ifMdAndUp.white.ifMd.black.$;
+    `).toHaveTrussOutput(
+      `
+      const s = { color: "mdandup_white md_black" };
+    `,
+      `
+      @media screen and (min-width: 600px) {
+        .mdandup_white.mdandup_white {
+          color: #fcfcfa;
+        }
+      }
+      @media screen and (min-width: 600px) and (max-width: 959px) {
+        .md_black.md_black {
+          color: #353535;
+        }
+      }
+    `,
+    );
+  });
+
+  test("raw min-width queries emit ascending", () => {
+    expectTrussTransform(`
+      import { Css } from "./Css";
+      const s = Css.if("@media (min-width: 600px)").white.if("@media (min-width: 900px)").black.$;
+    `).toHaveTrussOutput(
+      `
+      const s = { color: "media_min_width_600px_white media_min_width_900px_black" };
+    `,
+      `
+      @media (min-width: 600px) {
+        .media_min_width_600px_white.media_min_width_600px_white {
+          color: #fcfcfa;
+        }
+      }
+      @media (min-width: 900px) {
+        .media_min_width_900px_black.media_min_width_900px_black {
+          color: #353535;
+        }
+      }
+    `,
+    );
+  });
+
+  test("raw max-width queries emit descending", () => {
+    expectTrussTransform(`
+      import { Css } from "./Css";
+      const s = Css.if("@media (max-width: 1150px)").white.if("@media (max-width: 820px)").black.$;
+    `).toHaveTrussOutput(
+      `
+      const s = { color: "media_max_width_1150px_white media_max_width_820px_black" };
+    `,
+      `
+      @media (max-width: 1150px) {
+        .media_max_width_1150px_white.media_max_width_1150px_white {
+          color: #fcfcfa;
+        }
+      }
+      @media (max-width: 820px) {
+        .media_max_width_820px_black.media_max_width_820px_black {
+          color: #353535;
+        }
+      }
+    `,
+    );
+  });
+
+  test("min-width queries emit before max-width queries", () => {
+    expectTrussTransform(`
+      import { Css } from "./Css";
+      const s = Css.if("@media (max-width: 1000px)").white.if("@media (min-width: 901px)").black.$;
+    `).toHaveTrussOutput(
+      `
+      const s = { color: "media_max_width_1000px_white media_min_width_901px_black" };
+    `,
+      `
+      @media (min-width: 901px) {
+        .media_min_width_901px_black.media_min_width_901px_black {
+          color: #353535;
+        }
+      }
+      @media (max-width: 1000px) {
+        .media_max_width_1000px_white.media_max_width_1000px_white {
+          color: #fcfcfa;
+        }
+      }
+    `,
+    );
+  });
+
+  test("queries without a readable width emit last", () => {
+    expectTrussTransform(`
+      import { Css } from "./Css";
+      const s = Css.ifPrint.white.ifLg.black.$;
+    `).toHaveTrussOutput(
+      `
+      const s = { color: "print_white lg_black" };
+    `,
+      `
+      @media screen and (min-width: 960px) {
+        .lg_black.lg_black {
+          color: #353535;
+        }
+      }
+      @media print {
+        .print_white.print_white {
+          color: #fcfcfa;
+        }
+      }
+    `,
+    );
+  });
+
+  test("container queries order by width like media queries", () => {
+    expectTrussTransform(`
+      import { Css } from "./Css";
+      const s = Css.ifContainer({ gt: 400 }).white.ifContainer({ gt: 600, lt: 960 }).black.$;
+    `).toHaveTrussOutput(
+      `
+      const s = { color: "container_min_width_401px_white container_min_width_601px_and_max_width_960px_black" };
+    `,
+      `
+      @container (min-width: 401px) {
+        .container_min_width_401px_white.container_min_width_401px_white {
+          color: #fcfcfa;
+        }
+      }
+      @container (min-width: 601px) and (max-width: 960px) {
+        .container_min_width_601px_and_max_width_960px_black.container_min_width_601px_and_max_width_960px_black {
+          color: #353535;
+        }
+      }
+    `,
+    );
+  });
+
   test("breakpoint after base style: Css.df.ifMd.blue.$", () => {
     expectTrussTransform(`
       import { Css } from "./Css";


### PR DESCRIPTION
…ins.

Rules that tie on StyleX priority, i.e. two `@media` rules for the same property, were ordered by class name alone, so which of two overlapping breakpoints won depended on what the breakpoints were called: `ifMdAndUp.white.ifLg.black` emitted `lg_black` first, and `mdandup_white` won at 960px and up. StyleX closed the same gap with a width-aware tiebreak in facebook/stylex#1652.

`sortRulesByPriority` and `mergeTrussCss` now share one comparator: priority, then the px width interval the query matches (widest first, so min-width ascending, then max-width descending, then two-sided ranges, then queries with no readable interval such as `print`, `not`, and comma lists), then class name. Container queries follow the same rule. Class-name order is only the final tiebreak, and the merged library stylesheet keeps the same cascade order as the per-file output.