### PR TITLE
fix: Avoid reparsing accumulated CSS in jsdom

### DIFF
--- a/packages/app/src/LibraryCss.test.tsx
+++ b/packages/app/src/LibraryCss.test.tsx
@@ -1,3 +1,4 @@
+import { __injectTrussCSS, useRuntimeStyle } from "@homebound/truss/runtime";
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, test } from "vitest";
 
@@ -8,5 +9,31 @@ describe("library css", () => {
     const r = render(<div className="beamStatic">beam</div>);
     const el = r.container.firstChild as HTMLElement;
     expect(el).toHaveStyle({ display: "flex" });
+    expect(document.querySelector("style[data-truss]")?.textContent).toBe("");
+    expect(document.querySelectorAll("style[data-truss-chunk]").length).toBeGreaterThan(0);
+  });
+
+  test("keeps runtime styles in place between injected chunks", () => {
+    __injectTrussCSS(".injection-order { color: red; }");
+    const r = render(<RuntimeStyleHarness />);
+    const el = r.container.firstChild as HTMLElement;
+    const runtimeStyle = document.querySelector("style[data-truss-runtime-style]") as HTMLStyleElement;
+    const sheet = runtimeStyle.sheet;
+    expect(el).toHaveStyle({ color: "rgb(0, 128, 0)" });
+
+    __injectTrussCSS(".injection-order { color: blue; }");
+
+    expect(runtimeStyle.previousElementSibling?.textContent).toBe(".injection-order { color: red; }");
+    expect(runtimeStyle.nextElementSibling?.textContent).toBe(".injection-order { color: blue; }");
+    expect(runtimeStyle.sheet).toBe(sheet);
+    expect(el).toHaveStyle({ color: "rgb(0, 0, 255)" });
+    r.unmount();
+    expect(runtimeStyle.isConnected).toBe(false);
   });
 });
+
+/** Mount a runtime rule between two module CSS chunks. */
+function RuntimeStyleHarness() {
+  useRuntimeStyle({ ".injection-order": { color: "green" } });
+  return <div className="injection-order">ordered</div>;
+}

--- a/packages/truss/package.json
+++ b/packages/truss/package.json
@@ -50,6 +50,7 @@
     "@types/babel__traverse": "^7.28.0",
     "@types/node": "^25.5.2",
     "@types/react": "^19.2.14",
+    "jsdom": "^29.0.2",
     "react": "^19.2.5",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",

--- a/packages/truss/src/runtime.test.ts
+++ b/packages/truss/src/runtime.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test, vi } from "vitest";
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { mergeProps, TrussDebugInfo, trussProps, __injectTrussCSS } from "./runtime";
 
 describe("trussProps", () => {
@@ -226,57 +227,82 @@ describe("mergeProps", () => {
   });
 });
 
-const hasDocument = typeof document !== "undefined";
+describe("__injectTrussCSS", () => {
+  beforeEach(removeTrussStyles);
+  afterEach(removeTrussStyles);
 
-describe.skipIf(!hasDocument)("__injectTrussCSS", () => {
-  test("creates a style tag and injects CSS", () => {
-    // Clean up any prior style tags
-    document.querySelectorAll("style[data-truss]").forEach((el) => el.remove());
+  test("parses each chunk into its own sheet without changing earlier sheets", () => {
+    const chunks = [".df { display: flex; }", ".aic { align-items: center; }", ".black { color: black; }"];
+    const sheets: CSSStyleSheet[] = [];
+    for (const chunk of chunks) {
+      __injectTrussCSS(chunk);
+      sheets.push(document.styleSheets[document.styleSheets.length - 1]);
+    }
 
-    __injectTrussCSS(".df { display: flex; }");
-
-    const style = document.querySelector("style[data-truss]") as HTMLStyleElement;
-    expect(style).not.toBeNull();
-    expect(style.textContent).toContain(".df { display: flex; }");
+    expect(document.querySelector("style[data-truss]")?.textContent).toBe("");
+    expect(Array.from(document.querySelectorAll("style[data-truss-chunk]"), (el) => el.textContent)).toEqual(chunks);
+    expect(document.querySelectorAll("style").length).toBe(chunks.length + 1);
+    expect(
+      Array.from(document.styleSheets).flatMap((sheet) => Array.from(sheet.cssRules, (rule) => rule.cssText)),
+    ).toEqual(chunks);
+    for (const sheet of sheets) {
+      expect(Array.from(document.styleSheets).includes(sheet)).toBe(true);
+      expect(sheet.cssRules.length).toBe(1);
+    }
   });
 
-  test("appends to existing style tag", () => {
-    document.querySelectorAll("style[data-truss]").forEach((el) => el.remove());
+  test("preserves injection order for competing rules", () => {
+    __injectTrussCSS(".target { color: red; }");
+    __injectTrussCSS(".target { color: blue; }");
 
-    __injectTrussCSS(".df { display: flex; }");
-    __injectTrussCSS(".aic { align-items: center; }");
-
-    const style = document.querySelector("style[data-truss]") as HTMLStyleElement;
-    expect(style.textContent).toContain(".df { display: flex; }");
-    expect(style.textContent).toContain(".aic { align-items: center; }");
+    expect(
+      Array.from(document.styleSheets).flatMap((sheet) => Array.from(sheet.cssRules, (rule) => rule.cssText)),
+    ).toEqual([".target { color: red; }", ".target { color: blue; }"]);
   });
 
   test("deduplicates identical CSS text", () => {
-    document.querySelectorAll("style[data-truss]").forEach((el) => el.remove());
-
     __injectTrussCSS(".df { display: flex; }");
     __injectTrussCSS(".df { display: flex; }");
 
-    const style = document.querySelector("style[data-truss]") as HTMLStyleElement;
     // Should only appear once
-    const count = (style.textContent?.match(/\.df/g) ?? []).length;
-    expect(count).toBe(1);
+    expect(document.querySelectorAll("style[data-truss-chunk]").length).toBe(1);
+    expect(document.querySelector("style[data-truss-chunk]")?.textContent).toBe(".df { display: flex; }");
   });
 
-  test("deduplicates repeated merged bootstrap CSS chunks", () => {
-    document.querySelectorAll("style[data-truss]").forEach((el) => el.remove());
-
+  test("deduplicates repeated merged bootstrap CSS chunks across runtime reloads", async () => {
     const cssText = "/* @truss p:3000 c:beamStatic */\n.beamStatic { display: flex; }";
     __injectTrussCSS(cssText);
-    __injectTrussCSS(cssText);
+    vi.resetModules();
+    const runtime = await import("./runtime");
+    runtime.__injectTrussCSS(cssText);
 
-    const style = document.querySelector("style[data-truss]") as HTMLStyleElement;
-    expect(style.textContent).toBe("/* @truss p:3000 c:beamStatic */\n.beamStatic { display: flex; }");
+    expect(document.querySelectorAll("style[data-truss]").length).toBe(1);
+    expect(document.querySelectorAll("style[data-truss-chunk]").length).toBe(1);
+    expect(document.querySelector("style[data-truss-chunk]")?.textContent).toBe(cssText);
+  });
+
+  test("does not treat a substring of an earlier chunk as a duplicate", () => {
+    __injectTrussCSS(".df { display: flex; }.aic { align-items: center; }");
+    __injectTrussCSS(".df { display: flex; }");
+    expect(document.querySelectorAll("style[data-truss-chunk]").length).toBe(2);
+  });
+
+  test("ignores empty CSS", () => {
+    __injectTrussCSS("");
+    expect(document.querySelectorAll("style").length).toBe(0);
+  });
+
+  test("ignores CSS when there is no document", () => {
+    vi.stubGlobal("document", undefined);
+    try {
+      expect(() => __injectTrussCSS(".df { display: flex; }")).not.toThrow();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+    expect(document.querySelectorAll("style").length).toBe(0);
   });
 
   test("recreates the cached style tag after removal", () => {
-    document.querySelectorAll("style[data-truss]").forEach((el) => el.remove());
-
     __injectTrussCSS(".df { display: flex; }");
     const firstStyle = document.querySelector("style[data-truss]") as HTMLStyleElement;
     firstStyle.remove();
@@ -284,6 +310,16 @@ describe.skipIf(!hasDocument)("__injectTrussCSS", () => {
     __injectTrussCSS(".aic { align-items: center; }");
 
     const style = document.querySelector("style[data-truss]") as HTMLStyleElement;
-    expect(style.textContent).toBe(".aic { align-items: center; }");
+    expect(style).not.toBe(firstStyle);
+    expect(style.textContent).toBe("");
+    expect(Array.from(document.querySelectorAll("style[data-truss-chunk]"), (el) => el.textContent)).toEqual([
+      ".df { display: flex; }",
+      ".aic { align-items: center; }",
+    ]);
   });
 });
+
+/** Clean up any prior style tags, including the dedupe anchor and injected chunks. */
+function removeTrussStyles(): void {
+  document.querySelectorAll("style[data-truss], style[data-truss-chunk]").forEach((el) => el.remove());
+}

--- a/packages/truss/src/runtime.ts
+++ b/packages/truss/src/runtime.ts
@@ -173,7 +173,17 @@ export function mergeProps(
 /**
  * Inject CSS text into the document for jsdom/test environments.
  *
- * In browser dev mode, CSS is served via the Vite virtual endpoint instead.
+ * A chunk is one transformed module's CSS or the test bootstrap's merged application
+ * and library CSS snapshot. Chunks are static, append-only, and live until the document
+ * is discarded; component unmounts do not remove them. Exact repeated chunks are skipped,
+ * but different chunks can contain overlapping rules. Injecting changed CSS does not
+ * replace old rules or remove declarations omitted from the new chunk.
+ *
+ * Each new chunk is appended in injection order, including after any mounted
+ * useRuntimeStyle elements. Normal cascade rules apply across these sheets.
+ * useRuntimeStyle owns its transient styles separately and removes them on effect cleanup.
+ * In browser dev mode, the Vite virtual stylesheet is replaced on updates instead;
+ * this helper is not an HMR replacement mechanism.
  */
 export function __injectTrussCSS(cssText: string): void {
   if (typeof document === "undefined" || cssText.length === 0) return;
@@ -183,13 +193,14 @@ export function __injectTrussCSS(cssText: string): void {
   // Track exact injected chunks on the style node so repeated execution of the
   // test bootstrap or transformed modules does not append duplicate CSS text.
   const injectedChunks = (style[TRUSS_CSS_CHUNKS] ??= new Set<string>());
-  if (injectedChunks.has(cssText) || style.textContent?.includes(cssText)) {
-    injectedChunks.add(cssText);
-    return;
-  }
+  if (injectedChunks.has(cssText)) return;
 
   injectedChunks.add(cssText);
-  style.textContent = (style.textContent ?? "") + cssText;
+  // Separate sheets let jsdom parse each chunk once instead of reparsing all prior chunks.
+  const chunkStyle = document.createElement("style");
+  chunkStyle.setAttribute("data-truss-chunk", "");
+  chunkStyle.textContent = cssText;
+  document.head.appendChild(chunkStyle);
 }
 
 export interface RuntimeStyleProps {

--- a/yarn.lock
+++ b/yarn.lock
@@ -568,6 +568,7 @@ __metadata:
     change-case: "npm:^5.4.4"
     csstype: "npm:^3.2.3"
     jiti: "npm:^2.6.1"
+    jsdom: "npm:^29.0.2"
     react: "npm:^19.2.5"
     ts-poet: "npm:^6.12.0"
     tsup: "npm:^8.5.1"


### PR DESCRIPTION
## Why this is slow

Every transformed module can inject a CSS chunk during tests. Previously, each injection appended text to one shared `<style>` element. Updating that element makes jsdom parse the entire stylesheet again, including every chunk it already parsed.

Think of loading 161 chunks: instead of parsing chunks 1 through 161 once each, we parse chunk 1, then 1+2, then 1+2+3, and so on. That repeated work grows quadratically and is paid again in each isolated Vitest test file.

The consumer measurements motivating this fix were taken in beam with jsdom 29: 161 chunks totaling roughly 224 KB took 1,514 ms with the shared sheet versus 30 ms with one sheet per chunk. Applying the same strategy in beam reduced its full suite from 128 s to 68 s, with all 1,447 tests passing. These are the reported consumer measurements, not a new benchmark run in this PR.

## What changes

- Give each distinct chunk its own `<style data-truss-chunk>` so jsdom parses it once without reparsing earlier sheets.
- Keep the empty `<style data-truss>` anchor as the owner of the exact-text dedupe Set, preserving dedupe across repeated bootstrap and runtime module reloads.
- Remove the redundant full-sheet substring scan. Dedupe is by whole chunk, not individual rule.
- Document what chunks contain and their lifecycle: static module CSS or a merged test-bootstrap snapshot, retained for the document lifetime. Changed payloads append; they do not replace old definitions.
- Leave browser dev HMR on its separate replacement-based virtual stylesheet. No production or HMR injection changes are needed.

## Ordering and lifecycle

Chunks append in injection order. Existing `useRuntimeStyle` elements stay in place and retain their separate effect-cleanup lifecycle. A chunk injected after a runtime style now appears after it in the cascade; previously, it was appended inside the earlier shared sheet. An integration test explicitly covers this ordering.

Only runtime tests read the test anchor as the whole sheet; those assertions now inspect chunk elements and `document.styleSheets`. No new full-CSS accessor is needed.

## Verification

- Enable jsdom for `runtime.test.ts` so its DOM tests run in the default suite rather than being skipped.
- Cover separate sheets, stable earlier sheet identities, complete CSSOM rules and ordering, exact dedupe across runtime reloads, overlapping chunks, empty input, missing document, and anchor recreation. Structural checks avoid a flaky timing threshold.
- Verify the actual plugin test-mode bootstrap and runtime-style ordering in the app integration tests, including an isolated run of `LibraryCss.test.tsx`.
- `yarn test`: 483 passed, 1 existing skipped; all 374 Truss tests passed.
- `yarn workspace app test src/LibraryCss.test.tsx`: 2 passed.
- `yarn tsc --build`: passed.
- Prettier checks: passed.