### PR TITLE
fix: Match test CSS ordering to production

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -161,7 +161,11 @@ The Vite plugin (`packages/truss/src/plugin/index.ts`) orchestrates transform an
 
 The plugin serves collected CSS via a virtual endpoint (`/virtual:truss.css`) and uses Vite's HMR to push updates. A virtual runtime script creates a `<style>` tag and re-fetches CSS on `truss:css-update` events. No per-file CSS injection is needed in the browser.
 
-For jsdom tests, the plugin passes `injectCss: true`, which injects `__injectTrussCSS(cssText)` calls into each transformed file so `document.styleSheets` reflects the rules.
+For jsdom tests, the plugin passes `injectCss: true`, which injects `__injectTrussCSS(cssText)` calls into each transformed file. The runtime deduplicates annotated atomic rules by class and inserts them into one CSSOM stylesheet with the same priority, query-width, and class-name ordering as production. A late module can add an earlier-priority rule without reparsing existing rules or moving static CSS after mounted runtime styles.
+
+A virtual test bootstrap supplies library CSS and the root spacing variable. Application modules and `.css.ts` files deliver their own CSS when loaded, including dynamic imports; the bootstrap does not need to discover the entire module graph. Arbitrary CSS follows atomic rules and property declarations: library blocks retain configured library order, and application blocks use canonical source-path order in both tests and production. This makes application block precedence independent of import order.
+
+The static registry lives on the style element for the document lifetime and survives runtime module reloads. Component unmounts only remove their transient `useRuntimeStyle` sheets. The injection helper accepts the plugin's annotated CSS payloads, with spacing passed explicitly as a prelude; unannotated CSS is ignored. Arbitrary selectors remain supported through annotated `.css.ts` and library blocks. The runtime also refreshes jsdom's computed-style cache after CSSOM changes and tolerates its unsupported `@property` declarations, which text-based stylesheet parsing already ignores.
 
 ### Production mode
 
@@ -169,7 +173,7 @@ The plugin accumulates all atomic rules across files during transform. In `gener
 
 ### Library CSS merging
 
-Each CSS rule in the output is annotated with its priority: `/* @truss p:<priority> c:<className> */`. When `libraries` are configured, the plugin parses these annotations from each library's `truss.css`, combines them with the app's own rules, deduplicates by class name (same class name = same rule, since output is deterministic), and sorts them with the same comparator the per-file emitter uses: priority, then media-query width, then class name. `@property` declarations are deduplicated by variable name and appended at the end.
+Each CSS rule in the output is annotated with its priority: `/* @truss p:<priority> c:<className> */`. When `libraries` are configured, the plugin parses these annotations from each library's `truss.css`, combines them with the app's own rules, deduplicates by class name (same class name = same rule, since output is deterministic), and sorts them with the same comparator the per-file emitter uses: priority, then media-query width, then class name. Library definitions take precedence if a class conflicts with an application definition. `@property` declarations are deduplicated by variable name and appended before arbitrary CSS blocks.
 
 ## CSS Generation
 

--- a/packages/app/src/LibraryCss.test.tsx
+++ b/packages/app/src/LibraryCss.test.tsx
@@ -1,38 +1,102 @@
 import { __injectTrussCSS, useRuntimeStyle } from "@homebound/truss/runtime";
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, test } from "vitest";
+import { Css } from "./Css";
+import "./test-fixtures/BuildOnly.css";
 
 afterEach(cleanup);
 
 describe("library css", () => {
+  test("compiles side-effect-only CSS without executing build-only expressions", () => {
+    // Given the side-effect fixture uses Css.setVar, which cannot execute in CssBuilder
+    const r = render(<div className="build-only-css">compiled</div>);
+    const el = r.container.firstChild as HTMLElement;
+    expect(el).toHaveStyle({ display: "flex" });
+    expect(getComputedStyle(el).getPropertyValue("--test-color")).toBe("red");
+  });
+
   test("automatically includes library css file", () => {
     const r = render(<div className="beamStatic">beam</div>);
     const el = r.container.firstChild as HTMLElement;
     expect(el).toHaveStyle({ display: "flex" });
-    expect(document.querySelector("style[data-truss]")?.textContent).toBe("");
-    expect(document.querySelectorAll("style[data-truss-chunk]").length).toBeGreaterThan(0);
+    const staticStyle = document.querySelector("style[data-truss]") as HTMLStyleElement;
+    expect(staticStyle.textContent).toBe("");
+    expect(
+      Array.from(staticStyle.sheet!.cssRules)
+        .filter((rule) => (rule as CSSStyleRule).selectorText === ".beamStatic")
+        .map((rule) => rule.cssText),
+    ).toEqual([".beamStatic { display: flex; }"]);
+    expect(document.querySelectorAll("style[data-truss]").length).toBe(1);
+    expect(document.styleSheets.length).toBe(1);
   });
 
-  test("keeps runtime styles in place between injected chunks", () => {
-    __injectTrussCSS(".injection-order { color: red; }");
+  test("keeps the library's conflicting atomic rule over application delivery", () => {
+    // Given library bootstrap defines mt_137px as margin-top: 23px
+    // And this application module compiles the same class with margin-top: 137px
+    const r = render(<div css={Css.mtPx(137).$}>conflicting</div>);
+    const el = r.container.firstChild as HTMLElement;
+    expect(el.className).toBe("mt_137px");
+    expect(el).toHaveStyle({ marginTop: "23px" });
+  });
+
+  test("keeps runtime styles after the fixed static sheet during late injection", () => {
+    __injectTrussCSS("/* @truss p:3000 c:injection-order-red */\n.injection-order { color: red; }");
     const r = render(<RuntimeStyleHarness />);
     const el = r.container.firstChild as HTMLElement;
     const runtimeStyle = document.querySelector("style[data-truss-runtime-style]") as HTMLStyleElement;
     const sheet = runtimeStyle.sheet;
+    const staticStyle = document.querySelector("style[data-truss]") as HTMLStyleElement;
+    const staticSheet = staticStyle.sheet;
     expect(el).toHaveStyle({ color: "rgb(0, 128, 0)" });
 
-    __injectTrussCSS(".injection-order { color: blue; }");
+    __injectTrussCSS("/* @truss p:3001 c:injection-order-blue */\n.injection-order { color: blue; }");
 
-    expect(runtimeStyle.previousElementSibling?.textContent).toBe(".injection-order { color: red; }");
-    expect(runtimeStyle.nextElementSibling?.textContent).toBe(".injection-order { color: blue; }");
+    expect(runtimeStyle.previousElementSibling).toBe(staticStyle);
+    expect(runtimeStyle.nextElementSibling).toBeNull();
+    expect(staticStyle.sheet).toBe(staticSheet);
+    expect(
+      Array.from(staticSheet!.cssRules)
+        .filter((rule) => (rule as CSSStyleRule).selectorText === ".injection-order")
+        .map((rule) => rule.cssText),
+    ).toEqual([".injection-order { color: red; }", ".injection-order { color: blue; }"]);
     expect(runtimeStyle.sheet).toBe(sheet);
-    expect(el).toHaveStyle({ color: "rgb(0, 0, 255)" });
+    expect(el).toHaveStyle({ color: "rgb(0, 128, 0)" });
     r.unmount();
     expect(runtimeStyle.isConnected).toBe(false);
   });
+
+  test("delivers dynamically imported arbitrary CSS after bootstrap", async () => {
+    // Given bootstrap has already created the static sheet without the late selector
+    const staticStyle = document.querySelector("style[data-truss]") as HTMLStyleElement;
+    const sheet = staticStyle.sheet;
+    expect(
+      Array.from(sheet!.cssRules).filter((rule) => (rule as CSSStyleRule).selectorText === ".late-library-css"),
+    ).toEqual([]);
+    // And a mounted element uses the selector before its module is evaluated
+    const r = render(<div className="late-library-css">late</div>);
+    const el = r.container.firstChild as HTMLElement;
+    expect(getComputedStyle(el).display).toBe("block");
+
+    const late = await import("./test-fixtures/LateLibrary.css");
+
+    expect(late.lateClassName).toBe("late-library-css");
+    expect(el).toHaveStyle({ display: "flex" });
+    // And a named import adds the virtual side effect for the same canonical source
+    const named = await import("./test-fixtures/LateLibraryImport");
+    expect(named.lateClassName).toBe("late-library-css");
+    expect(
+      Array.from(sheet!.cssRules)
+        .filter((rule) => (rule as CSSStyleRule).selectorText === ".late-library-css")
+        .map((rule) => rule.cssText),
+    ).toEqual([".late-library-css { display: flex; }"]);
+    expect(staticStyle.sheet).toBe(sheet);
+    expect(staticStyle.textContent).toBe("");
+    expect(document.querySelectorAll("style[data-truss]").length).toBe(1);
+    expect(document.styleSheets.length).toBe(1);
+  });
 });
 
-/** Mount a runtime rule between two module CSS chunks. */
+/** Mount a runtime rule before late static CSS delivery. */
 function RuntimeStyleHarness() {
   useRuntimeStyle({ ".injection-order": { color: "green" } });
   return <div className="injection-order">ordered</div>;

--- a/packages/app/src/test-fixtures/BuildOnly.css.ts
+++ b/packages/app/src/test-fixtures/BuildOnly.css.ts
@@ -1,0 +1,5 @@
+import { Css } from "../Css";
+
+export const css = {
+  ".build-only-css": Css.setVar({ "--test-color": "red" }).df.$,
+};

--- a/packages/app/src/test-fixtures/LateLibrary.css.ts
+++ b/packages/app/src/test-fixtures/LateLibrary.css.ts
@@ -1,0 +1,7 @@
+import { Css } from "../Css";
+
+export const lateClassName = "late-library-css";
+
+export const css = {
+  [`.${lateClassName}`]: Css.df.$,
+};

--- a/packages/app/src/test-fixtures/LateLibraryImport.ts
+++ b/packages/app/src/test-fixtures/LateLibraryImport.ts
@@ -1,0 +1,3 @@
+import { lateClassName } from "./LateLibrary.css";
+
+export { lateClassName };

--- a/packages/app/src/test-fixtures/beam-truss.css
+++ b/packages/app/src/test-fixtures/beam-truss.css
@@ -1,2 +1,4 @@
 /* @truss p:3000 c:beamStatic */
 .beamStatic { display: flex; }
+/* @truss p:3500.5 c:mt_137px */
+.mt_137px { margin-top: 23px; }

--- a/packages/truss/src/css-order.ts
+++ b/packages/truss/src/css-order.ts
@@ -1,0 +1,111 @@
+/**
+ * The sort key shared by `emit-css` and `merge-css`, so a stylesheet merged from library CSS
+ * keeps the same rule order as the per-file output.
+ */
+export interface RuleSortKey {
+  priority: number;
+  className: string;
+  /** The px widths the rule's media or container query matches, or null when it has no readable interval. */
+  widthInterval: WidthInterval | null;
+}
+
+/** The inclusive px widths a query matches; `hi` is Infinity for a min-width-only query. */
+export interface WidthInterval {
+  lo: number;
+  hi: number;
+}
+
+/** I.e. `ruleSortKey(3200, "lg_black", "@media screen and (min-width: 960px)")` → `widthInterval: { lo: 960, hi: Infinity }`. */
+export function ruleSortKey(priority: number, className: string, atRulePrelude: string | undefined): RuleSortKey {
+  const widthInterval = atRulePrelude === undefined ? null : parseWidthInterval(atRulePrelude);
+  return { priority, className, widthInterval };
+}
+
+/**
+ * Order rules by priority, then by query width interval, then by class name.
+ *
+ * Priority ties happen between rules in the same tier for the same property, i.e. two `@media`
+ * rules for `color`. Those are ordered widest interval first, so the narrower query is emitted
+ * later and wins in the cascade wherever both match. Equal widths go by lower bound ascending,
+ * and queries with no readable interval (`print`, `not`, comma lists, non-px units) come last,
+ * as they do in StyleX. For one-sided queries this is min-width ascending, then max-width descending.
+ *
+ * The class-name tiebreak keeps the output fully deterministic regardless of file processing
+ * order, which differs between dev HMR and production builds.
+ *
+ * I.e. `(min-width: 600px)` → `(min-width: 960px)` → `(max-width: 1150px)` → `(max-width: 820px)`
+ * → `(min-width: 600px) and (max-width: 959px)` → `print`.
+ */
+export function compareRuleSortKeys(a: RuleSortKey, b: RuleSortKey): number {
+  return (
+    a.priority - b.priority ||
+    compareWidthIntervals(a.widthInterval, b.widthInterval) ||
+    compareClassNames(a.className, b.className)
+  );
+}
+
+/** Code-point order, so identical class sets sort identically in dev and production. */
+export function compareClassNames(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/** I.e. `"@media (min-width: 600px) { .a.a { color: red; } }"` → `"@media (min-width: 600px)"`, or undefined for a plain rule. */
+export function atRulePrelude(cssText: string): string | undefined {
+  if (!cssText.startsWith("@")) return undefined;
+  const brace = cssText.indexOf("{");
+  return brace === -1 ? undefined : cssText.slice(0, brace).trim();
+}
+
+/**
+ * Parse the px width interval a `@media` or `@container` prelude matches.
+ *
+ * Only `and`-joined `(min-width: Npx)` / `(max-width: Npx)` terms are read. Other features such as
+ * `(orientation: landscape)` and media types such as `screen` add no bound, and repeated terms
+ * collapse to the effective bound. The result is exact for what it accepts, and null ("no interval")
+ * for a prelude with no width term or with anything it cannot read exactly: comma lists, `not`,
+ * `or`, range syntax, and non-px units.
+ *
+ * I.e. `"@media screen and (min-width: 600px) and (max-width: 959px)"` → `{ lo: 600, hi: 959 }`,
+ * `"@container grid (min-width: 601px)"` → `{ lo: 601, hi: Infinity }`, `"@media print"` → null.
+ */
+function parseWidthInterval(prelude: string): WidthInterval | null {
+  if (/,|\bnot\b|\bor\b|[<>]/.test(prelude)) return null;
+  const terms = Array.from(prelude.matchAll(/\((min|max)-width:\s*([^)]*)\)/g));
+  if (terms.length === 0) return null;
+  let lo = 0;
+  let hi = Infinity;
+  for (const term of terms) {
+    const px = parsePxLength(term[2]);
+    if (px === null) return null;
+    if (term[1] === "min") {
+      lo = Math.max(lo, px);
+    } else {
+      hi = Math.min(hi, px);
+    }
+  }
+  return { lo, hi };
+}
+
+/** I.e. `"600px"` → 600, `"0"` → 0, `"40rem"` → null. */
+function parsePxLength(value: string): number | null {
+  const match = value.trim().match(/^(\d+(?:\.\d+)?)(px)?$/);
+  if (!match) return null;
+  if (match[2] === undefined && Number(match[1]) !== 0) return null;
+  return Number(match[1]);
+}
+
+/**
+ * Widest interval first, equal widths by lower bound ascending, null last.
+ *
+ * I.e. `{ lo: 600, hi: Infinity }` (width Infinity) → `{ lo: 0, hi: 1150 }` (width 1150)
+ * → `{ lo: 600, hi: 959 }` (width 359) → null.
+ */
+function compareWidthIntervals(a: WidthInterval | null, b: WidthInterval | null): number {
+  if (a === null || b === null) {
+    return (a === null ? 1 : 0) - (b === null ? 1 : 0);
+  }
+  const widthA = a.hi - a.lo;
+  const widthB = b.hi - b.lo;
+  if (widthA !== widthB) return widthA > widthB ? -1 : 1;
+  return a.lo - b.lo;
+}

--- a/packages/truss/src/plugin/index.test.ts
+++ b/packages/truss/src/plugin/index.test.ts
@@ -107,18 +107,21 @@ describe("trussPlugin", () => {
       n(`
         import { __injectTrussCSS } from "@homebound/truss/runtime";
 
-        __injectTrussCSS(":root { --t-spacing: 8px; }\\n/* @truss p:3000 c:beamStatic */\\n.beamStatic { display: flex; }");
+        __injectTrussCSS("/* @truss p:3000 c:beamStatic */\\n.beamStatic { display: flex; }", {"source":"libraries","order":0,"prelude":":root { --t-spacing: 8px; }"});
       `),
     );
   });
 
-  test("test mode relies on the bootstrap module instead of per-file CSS injection", () => {
+  test("test mode keeps conflicting library CSS separate from per-file application CSS", () => {
+    // Given an application mapping that defines df as display: flex
     const root = createTempRoot();
     writeMapping(join(root, "src", "Css.json"), {
       df: { kind: "static", defs: { display: "flex" } },
     });
-    writeLibraryCss(root, ["/* @truss p:3000 c:beamStatic */", ".beamStatic { display: flex; }"]);
+    // And the library's df class deliberately differs from the application's flex rule
+    writeLibraryCss(root, ["/* @truss p:3000 c:df */", ".df { display: grid; }"]);
 
+    // And a test-mode plugin configured with that conflicting library
     const plugin = trussPlugin({
       mapping: "./src/Css.json",
       libraries: ["./node_modules/@company/library/dist/truss.css"],
@@ -148,8 +151,140 @@ describe("trussPlugin", () => {
       n(`
         import { __injectTrussCSS } from "@homebound/truss/runtime";
 
-        __injectTrussCSS(":root { --t-spacing: 8px; }\\n/* @truss p:3000 c:beamStatic */\\n.beamStatic { display: flex; }\\n/* @truss p:3000 c:df */\\n.df { display: flex; }");
+        __injectTrussCSS("/* @truss p:3000 c:df */\\n.df { display: grid; }", {"source":"libraries","order":0,"prelude":":root { --t-spacing: 8px; }"});
       `),
+    );
+  });
+
+  test("test mode bootstraps spacing without libraries or local CSS", () => {
+    // Given an application mapping with no libraries
+    const root = createTempRoot();
+    writeMapping(join(root, "src", "Css.json"), {});
+    // And a test-mode plugin before any application CSS is transformed
+    const plugin = trussPlugin({ mapping: "./src/Css.json" });
+    invokeHook(plugin.configResolved, {}, { root, command: "serve", mode: "test" });
+    invokeHook(plugin.buildStart, {});
+    const result = runTransform(plugin, "export const value = 1;", join(root, "src", "plain.ts"));
+    expect(result?.code).toBe('export const value = 1;\nimport "virtual:truss:test-css";');
+    expect(n(getTestCssModule(plugin))).toBe(
+      n(`
+      import { __injectTrussCSS } from "@homebound/truss/runtime";
+      __injectTrussCSS("", {"source":"libraries","order":0,"prelude":":root { --t-spacing: 8px; }"});
+    `),
+    );
+  });
+
+  test("test mode delivers late arbitrary CSS at module evaluation without import collisions", () => {
+    // Given an application mapping with a flex rule
+    const root = createTempRoot();
+    writeMapping(join(root, "src", "Css.json"), { df: { kind: "static", defs: { display: "flex" } } });
+    // And a bootstrap already loaded before the arbitrary file is discovered
+    const plugin = trussPlugin({ mapping: "./src/Css.json" });
+    invokeHook(plugin.configResolved, {}, { root, command: "serve", mode: "test" });
+    invokeHook(plugin.buildStart, {});
+    const bootstrap = getTestCssModule(plugin);
+    // And a late file whose exports occupy the usual injection helper names
+    const sourcePath = join(root, "src", "Late.css.ts");
+    const code = `import { Css } from "./Css";
+      export const _injectTrussCSS = "occupied";
+      export const __injectTrussCSS = "also occupied";
+      export const css = { ".late": Css.df.$ };`;
+    writeFileSync(sourcePath, code);
+    const result = runTransform(plugin, code, `/@fs/${sourcePath}?v=1`);
+    expect(n(result?.code ?? "")).toBe(
+      n(`
+      import { __injectTrussCSS as _injectTrussCSS2 } from "@homebound/truss/runtime";
+      import { Css } from "./Css";
+      export const _injectTrussCSS = "occupied";
+      export const __injectTrussCSS = "also occupied";
+      export const css = { ".late": Css.df.$ };
+      import "virtual:truss:test-css";
+      _injectTrussCSS2("/* @truss arbitrary:start */\\n.late {\\n  display: flex;\\n}\\n/* @truss arbitrary:end */", { source: ${JSON.stringify(sourcePath)} });
+    `),
+    );
+    expect(getTestCssModule(plugin)).toBe(bootstrap);
+    const resolvedId = invokeHook(plugin.resolveId, {}, "./Late.css.ts?truss-css", join(root, "src", "App.tsx"));
+    expect(resolvedId).toBe("\0truss-test-css:" + sourcePath);
+    expect(n(invokeHook(plugin.load, {}, resolvedId) as string)).toBe(
+      n(`
+      import "virtual:truss:test-css";
+      import { __injectTrussCSS } from "@homebound/truss/runtime";
+      __injectTrussCSS("/* @truss arbitrary:start */\\n.late {\\n  display: flex;\\n}\\n/* @truss arbitrary:end */", {"source":${JSON.stringify(sourcePath)}});
+    `),
+    );
+  });
+
+  test("test mode compiles side-effect-only CSS without evaluating build-only expressions", () => {
+    // Given a CSS file with a setVar expression that cannot execute in CssBuilder
+    const root = createTempRoot();
+    writeMapping(join(root, "src", "Css.json"), {});
+    const sourcePath = join(root, "src", "BuildOnly.css.ts");
+    writeFileSync(
+      sourcePath,
+      'import { Css } from "./Css"; export const css = { ".build-only": Css.setVar({ "--test-color": "red" }).$ };',
+    );
+    // And a test-mode plugin receiving a side-effect-only import
+    const plugin = trussPlugin({ mapping: "./src/Css.json" });
+    invokeHook(plugin.configResolved, {}, { root, command: "serve", mode: "test" });
+    invokeHook(plugin.buildStart, {});
+    const importer = join(root, "src", "App.tsx");
+    const result = runTransform(plugin, 'import "./BuildOnly.css";', importer);
+    expect(result?.code).toBe('import "./BuildOnly.css.ts?truss-css";\nimport "virtual:truss:test-css";');
+    const resolvedId = invokeHook(plugin.resolveId, {}, "./BuildOnly.css.ts?truss-css", importer);
+    expect(resolvedId).toBe("\0truss-test-css:" + sourcePath);
+    const loaded = invokeHook(plugin.load, {}, resolvedId) as string;
+    expect(n(loaded)).toBe(
+      n(`
+      import "virtual:truss:test-css";
+      import { __injectTrussCSS } from "@homebound/truss/runtime";
+      __injectTrussCSS("/* @truss arbitrary:start */\\n.build-only {\\n  --test-color: red;\\n}\\n/* @truss arbitrary:end */", {"source":${JSON.stringify(sourcePath)}});
+    `),
+    );
+    expect(runTransform(plugin, loaded, resolvedId as string)).toBeNull();
+  });
+
+  test("production arbitrary CSS follows codepoint source order instead of discovery order", () => {
+    // Given an application mapping with a flex rule
+    const root = createTempRoot();
+    writeMapping(join(root, "src", "Css.json"), { df: { kind: "static", defs: { display: "flex" } } });
+    // And arbitrary files discovered in reverse codepoint order
+    const plugin = trussPlugin({ mapping: "./src/Css.json" });
+    invokeHook(plugin.configResolved, {}, { root, command: "build", mode: "production" });
+    invokeHook(plugin.buildStart, {});
+    runTransform(
+      plugin,
+      'import { Css } from "./Css"; export const css = { ".lower": Css.df.$ };',
+      join(root, "src", "a.css.ts"),
+    );
+    runTransform(
+      plugin,
+      'import { Css } from "./Css"; export const css = { ".upper": Css.df.$ };',
+      join(root, "src", "Z.css.ts"),
+    );
+    let css = "";
+    invokeHook(
+      plugin.generateBundle,
+      {
+        emitFile(asset: { source: string }) {
+          css = asset.source;
+        },
+      },
+      {},
+      {},
+    );
+    expect(css).toBe(
+      [
+        ":root { --t-spacing: 8px; }",
+        "/* @truss arbitrary:start */",
+        ".upper {",
+        "  display: flex;",
+        "}",
+        "",
+        ".lower {",
+        "  display: flex;",
+        "}",
+        "/* @truss arbitrary:end */",
+      ].join("\n"),
     );
   });
 
@@ -163,9 +298,9 @@ describe("trussPlugin", () => {
     invokeHook(plugin.configResolved, {} as any, { root, command: "serve", mode: "development" } as any);
 
     const html = invokeHook(plugin.transformIndexHtml, {} as any, "<html><head></head><body></body></html>") as any;
-    expect(html).toBeTypeOf("string");
-    expect(html.includes('<script type="module" src="/virtual:truss:runtime"></script>')).toBe(true);
-    expect(html.includes("/virtual:truss.css")).toBe(false);
+    expect(html).toBe(
+      '<html><head>    <script type="module" src="/virtual:truss:runtime"></script>\n  </head><body></body></html>',
+    );
   });
 
   test("production html injects a placeholder stylesheet link for truss.css", () => {
@@ -198,8 +333,9 @@ describe("trussPlugin", () => {
       {} as any,
       '<html><head>\n    <link rel="stylesheet" href="/virtual:truss.css" />\n  </head><body></body></html>',
     ) as any;
-    expect(html).not.toContain("virtual:truss.css");
-    expect(html).toContain("__TRUSS_CSS_HASH__");
+    expect(html).toBe(
+      '<html><head>\n      <link rel="stylesheet" href="__TRUSS_CSS_HASH__">\n  </head><body></body></html>',
+    );
   });
 
   test("production html is idempotent across multiple builds (e.g. Storybook)", () => {
@@ -219,8 +355,9 @@ describe("trussPlugin", () => {
     ].join("\n");
     const html = invokeHook(plugin.transformIndexHtml, {} as any, alreadyPatched) as any;
     // The old hashed link should be stripped and replaced with a single placeholder
-    expect(html).not.toContain("truss-abcd1234.css");
-    expect(html).toContain("__TRUSS_CSS_HASH__");
+    expect(html).toBe(
+      '<html><head>\n      <link rel="stylesheet" href="__TRUSS_CSS_HASH__">\n  </head><body></body></html>',
+    );
     // Only one truss CSS link should exist (the placeholder)
     const linkCount = (html.match(/<link[^>]*TRUSS_CSS_HASH/g) || []).length;
     expect(linkCount).toBe(1);

--- a/packages/truss/src/plugin/index.ts
+++ b/packages/truss/src/plugin/index.ts
@@ -3,6 +3,10 @@ import { resolve, dirname, isAbsolute, join } from "path";
 import { createHash } from "crypto";
 import { rewriteCssTsImports } from "./rewrite-css-ts-imports";
 import { createTrussTransformSession } from "./transform-session";
+import { annotateArbitraryCssBlock } from "./merge-css";
+import { rootSpacingPreludeCss } from "../spacing-css-var";
+import { generate, parseModule, traverse } from "./babel-utils";
+import * as t from "@babel/types";
 
 export interface TrussPluginOptions {
   /** Path to the Css.json mapping file used for transforming files (relative to project root or absolute). */
@@ -30,6 +34,7 @@ export interface TrussVitePlugin {
 
 /** Prefix for virtual CSS module IDs generated from .css.ts files. */
 const VIRTUAL_CSS_PREFIX = "\0truss-css:";
+const VIRTUAL_TEST_CSS_PREFIX = "\0truss-test-css:";
 const CSS_TS_QUERY = "?truss-css";
 
 /** Placeholder injected into HTML during build; replaced with the hashed CSS filename in generateBundle. */
@@ -39,8 +44,8 @@ const TRUSS_CSS_PLACEHOLDER = "__TRUSS_CSS_HASH__";
 const VIRTUAL_CSS_ENDPOINT = "/virtual:truss.css";
 const VIRTUAL_RUNTIME_ID = "virtual:truss:runtime";
 const RESOLVED_VIRTUAL_RUNTIME_ID = "\0" + VIRTUAL_RUNTIME_ID;
-// Test-only bootstrap that injects the same merged collectCss() output used by
-// /virtual:truss.css, but as a virtual module side effect instead of an HTTP
+// Test-only bootstrap that injects merged library CSS and the spacing prelude
+// as a virtual module side effect instead of an HTTP
 // fetch. In dev, the browser reaches /virtual:truss.css via transformIndexHtml
 // -> virtual:truss:runtime -> fetch("/virtual:truss.css") -> configureServer.
 // Vitest/jsdom does not boot from index.html or run that browser fetch/HMR path;
@@ -179,6 +184,9 @@ export function trussPlugin(opts: TrussPluginOptions): TrussVitePlugin {
       // Only handle it if the .css.ts file actually exists
       if (!existsSync(absolutePath)) return null;
 
+      // Compile test side effects without evaluating build-only CssBuilder expressions.
+      if (isTest) return VIRTUAL_TEST_CSS_PREFIX + absolutePath;
+
       // Return a virtual CSS module ID that maps back to the source .css.ts file.
       // Strip the trailing `.ts` so the ID ends in `.css` — this tells Vite to
       // route the loaded content through its CSS pipeline.
@@ -217,13 +225,30 @@ export function trussPlugin(opts: TrussPluginOptions): TrussVitePlugin {
 `;
       }
       if (id === RESOLVED_VIRTUAL_TEST_CSS_ID) {
-        // Vitest/jsdom has no dev server stylesheet fetch, so inject the full
-        // merged CSS payload once via a virtual side-effect module.
-        const css = session.collectCss();
+        // Vitest/jsdom has no dev server stylesheet fetch, so inject libraries
+        // once; application modules deliver CSS when they evaluate.
+        const css = session.collectTestCss();
+        const options = {
+          source: "libraries",
+          order: 0,
+          prelude: rootSpacingPreludeCss(session.ensureMapping().increment),
+        };
         return `
 import { __injectTrussCSS } from "@homebound/truss/runtime";
 
-__injectTrussCSS(${JSON.stringify(css)});
+__injectTrussCSS(${JSON.stringify(css)}, ${JSON.stringify(options)});
+`;
+      }
+
+      if (id.startsWith(VIRTUAL_TEST_CSS_PREFIX)) {
+        const sourcePath = resolve(id.slice(VIRTUAL_TEST_CSS_PREFIX.length)).replace(/\\/g, "/");
+        session.updateArbitraryCssRegistry(sourcePath, readFileSync(sourcePath, "utf8"));
+        const css = annotateArbitraryCssBlock(session.getArbitraryCss(sourcePath));
+        return `
+import "${VIRTUAL_TEST_CSS_ID}";
+import { __injectTrussCSS } from "@homebound/truss/runtime";
+
+__injectTrussCSS(${JSON.stringify(css)}, ${JSON.stringify({ source: sourcePath })});
 `;
       }
 
@@ -245,6 +270,8 @@ __injectTrussCSS(${JSON.stringify(css)});
     },
 
     transform(code: string, id: string) {
+      // The virtual test module already contains compiled CSS, not source TypeScript.
+      if (id.startsWith(VIRTUAL_TEST_CSS_PREFIX)) return null;
       // Only process JS/TS/JSX/TSX files outside node_modules
       if (!/\.[cm]?[jt]sx?(\?|$)/.test(id)) return null;
       const fileId = stripQueryAndHash(id);
@@ -254,13 +281,13 @@ __injectTrussCSS(${JSON.stringify(css)});
 
       // In tests, we do not boot through index.html and the dev runtime fetch path
       // (`virtual:truss:runtime` -> fetch("/virtual:truss.css")), so we inject the
-      // merged application + library CSS through a virtual module side effect instead.
+      // library CSS and spacing through a virtual module side effect instead.
       //
       // We add `import "virtual:truss:test-css"` to each eligible transformed module,
       // but ESM module caching should evaluate that virtual module only once per test
       // module graph. Transformed files may still emit per-file `__injectTrussCSS`
-      // calls; exact repeated chunks are deduped in the runtime helper.
-      const shouldBootstrapTestCss = isTest && libraryPaths.length > 0;
+      // calls; atomic classes are deduped in the runtime helper.
+      const shouldBootstrapTestCss = isTest;
       const transformedCode = shouldBootstrapTestCss
         ? `${rewrittenImports.code}\nimport "${VIRTUAL_TEST_CSS_ID}";`
         : rewrittenImports.code;
@@ -270,13 +297,40 @@ __injectTrussCSS(${JSON.stringify(css)});
 
       if (fileId.endsWith(".css.ts")) {
         // Keep `.css.ts` modules as normal TS so named exports like class-name
-        // constants still work at runtime; only return code when we injected the
-        // companion `?truss-css` side-effect import.
+        // constants still work at runtime. Tests also inject their CSS at evaluation.
         //
         // Also update the arbitrary CSS registry so HMR picks up changes —
         // the load hook only runs on first resolve, so edits need to refresh
         // the registry here where Vite re-transforms changed files.
         session.updateArbitraryCssRegistry(fileId, code);
+        if (isTest) {
+          const css = annotateArbitraryCssBlock(session.getArbitraryCss(fileId));
+          const ast = parseModule(transformedCode, fileId);
+          traverse(ast, {
+            Program(path) {
+              const inject = path.scope.generateUidIdentifier("injectTrussCSS");
+              path.unshiftContainer(
+                "body",
+                t.importDeclaration(
+                  [t.importSpecifier(inject, t.identifier("__injectTrussCSS"))],
+                  t.stringLiteral("@homebound/truss/runtime"),
+                ),
+              );
+              path.pushContainer(
+                "body",
+                t.expressionStatement(
+                  t.callExpression(inject, [
+                    t.stringLiteral(css),
+                    t.objectExpression([
+                      t.objectProperty(t.identifier("source"), t.stringLiteral(resolve(fileId).replace(/\\/g, "/"))),
+                    ]),
+                  ]),
+                ),
+              );
+            },
+          });
+          return { code: generate(ast, { sourceFileName: fileId }).code, map: null };
+        }
         return importsOnlyResult;
       }
 

--- a/packages/truss/src/plugin/merge-css.ts
+++ b/packages/truss/src/plugin/merge-css.ts
@@ -1,116 +1,10 @@
 import { readFileSync } from "fs";
-import { compareRuleSortKeys, ruleSortKey } from "./priority";
+import { atRulePrelude, compareRuleSortKeys, ruleSortKey } from "../css-order";
+import { annotateArbitraryCssBlock, parseTrussCss } from "../truss-css";
+import type { ParsedArbitraryCssBlock, ParsedCssRule, ParsedPropertyDeclaration, ParsedTrussCss } from "../truss-css";
 
-/** A parsed CSS rule extracted from an annotated truss.css file. */
-export interface ParsedCssRule {
-  priority: number;
-  className: string;
-  cssText: string;
-}
-
-/** A parsed @property declaration extracted from an annotated truss.css file. */
-export interface ParsedPropertyDeclaration {
-  cssText: string;
-  /** The variable name, i.e. `--marginTop`. */
-  varName: string;
-}
-
-/** A parsed arbitrary CSS block extracted from an annotated truss.css file. */
-export interface ParsedArbitraryCssBlock {
-  cssText: string;
-}
-
-/** The result of parsing an annotated truss.css file. */
-export interface ParsedTrussCss {
-  rules: ParsedCssRule[];
-  properties: ParsedPropertyDeclaration[];
-  arbitraryCssBlocks: ParsedArbitraryCssBlock[];
-}
-
-/** Regex matching `/* @truss p:<priority> c:<className> *\/` annotations. */
-const RULE_ANNOTATION_RE = /^\/\* @truss p:([\d.]+) c:(\S+) \*\/$/;
-
-/** Regex matching `/* @truss @property *\/` annotations. */
-const PROPERTY_ANNOTATION_RE = /^\/\* @truss @property \*\/$/;
-
-/** Regex matching the start of an annotated arbitrary CSS block. */
-const ARBITRARY_START_RE = /^\/\* @truss arbitrary:start \*\/$/;
-
-/** Regex matching the end of an annotated arbitrary CSS block. */
-const ARBITRARY_END_RE = /^\/\* @truss arbitrary:end \*\/$/;
-
-/** Regex to extract the variable name from `@property --foo { ... }`. */
-const PROPERTY_VAR_RE = /^@property\s+(--\S+)/;
-
-/**
- * Parse an annotated truss.css file into rules, @property declarations,
- * and arbitrary CSS blocks.
- *
- * The file must contain `/* @truss p:<priority> c:<className> *\/` comments
- * before each CSS rule, and `/* @truss @property *\/` before each @property declaration.
- */
-export function parseTrussCss(cssText: string): ParsedTrussCss {
-  const lines = cssText.split("\n");
-  const rules: ParsedCssRule[] = [];
-  const properties: ParsedPropertyDeclaration[] = [];
-  const arbitraryCssBlocks: ParsedArbitraryCssBlock[] = [];
-
-  let i = 0;
-
-  /** Advance past the current annotation line and any blank lines to the annotated content line. */
-  function takeAnnotatedLine(): string | null {
-    i++;
-    while (i < lines.length && lines[i].trim() === "") i++;
-    return i < lines.length ? lines[i].trim() : null;
-  }
-
-  while (i < lines.length) {
-    const line = lines[i].trim();
-
-    // Check for rule annotation
-    const ruleMatch = RULE_ANNOTATION_RE.exec(line);
-    if (ruleMatch) {
-      const cssText = takeAnnotatedLine();
-      if (cssText !== null) {
-        rules.push({ priority: parseFloat(ruleMatch[1]), className: ruleMatch[2], cssText });
-      }
-      i++;
-      continue;
-    }
-
-    // Check for @property annotation
-    if (PROPERTY_ANNOTATION_RE.test(line)) {
-      const propLine = takeAnnotatedLine();
-      const varMatch = propLine === null ? null : PROPERTY_VAR_RE.exec(propLine);
-      if (propLine !== null && varMatch) {
-        properties.push({ cssText: propLine, varName: varMatch[1] });
-      }
-      i++;
-      continue;
-    }
-
-    if (ARBITRARY_START_RE.test(line)) {
-      i++;
-      const blockLines: string[] = [];
-      while (i < lines.length && !ARBITRARY_END_RE.test(lines[i].trim())) {
-        blockLines.push(lines[i]);
-        i++;
-      }
-      const blockText = blockLines.join("\n").trim();
-      if (blockText.length > 0) {
-        arbitraryCssBlocks.push({ cssText: blockText });
-      }
-      if (i < lines.length && ARBITRARY_END_RE.test(lines[i].trim())) {
-        i++;
-      }
-      continue;
-    }
-
-    i++;
-  }
-
-  return { rules, properties, arbitraryCssBlocks };
-}
+export { annotateArbitraryCssBlock, parseTrussCss } from "../truss-css";
+export type { ParsedArbitraryCssBlock, ParsedCssRule, ParsedPropertyDeclaration, ParsedTrussCss } from "../truss-css";
 
 /**
  * Read and parse an annotated truss.css file from disk.
@@ -120,15 +14,6 @@ export function parseTrussCss(cssText: string): ParsedTrussCss {
 export function readTrussCss(filePath: string): ParsedTrussCss {
   const content = readFileSync(filePath, "utf8");
   return parseTrussCss(content);
-}
-
-/** Wrap an arbitrary CSS block in annotations so it survives later Truss merges. */
-export function annotateArbitraryCssBlock(cssText: string): string {
-  const trimmed = cssText.trim();
-  if (trimmed.length === 0) {
-    return "";
-  }
-  return ["/* @truss arbitrary:start */", trimmed, "/* @truss arbitrary:end */"].join("\n");
 }
 
 /**
@@ -186,11 +71,4 @@ export function mergeTrussCss(sources: ParsedTrussCss[]): string {
   }
 
   return lines.join("\n");
-}
-
-/** I.e. `"@media (min-width: 600px) { .a.a { color: red; } }"` → `"@media (min-width: 600px)"`, or undefined for a plain rule. */
-function atRulePrelude(cssText: string): string | undefined {
-  if (!cssText.startsWith("@")) return undefined;
-  const brace = cssText.indexOf("{");
-  return brace === -1 ? undefined : cssText.slice(0, brace).trim();
 }

--- a/packages/truss/src/plugin/priority.ts
+++ b/packages/truss/src/plugin/priority.ts
@@ -10,6 +10,7 @@
  * wins wherever both match. See `compareRuleSortKeys`.
  */
 
+import { compareRuleSortKeys, ruleSortKey } from "../css-order";
 import {
   getPropertyPriority,
   getPseudoClassPriority,
@@ -18,6 +19,9 @@ import {
 } from "./property-priorities";
 import { WHEN_RELATIONSHIPS } from "./when-relationships";
 import type { AtomicRule } from "./emit-css";
+
+export { compareClassNames, compareRuleSortKeys, ruleSortKey } from "../css-order";
+export type { RuleSortKey, WidthInterval } from "../css-order";
 
 /**
  * Compute the numeric priority for a single AtomicRule.
@@ -60,52 +64,6 @@ function isVariableRule(rule: AtomicRule): boolean {
 }
 
 /**
- * The sort key shared by `emit-css` and `merge-css`, so a stylesheet merged from library CSS
- * keeps the same rule order as the per-file output.
- */
-export interface RuleSortKey {
-  priority: number;
-  className: string;
-  /** The px widths the rule's media or container query matches, or null when it has no readable interval. */
-  widthInterval: WidthInterval | null;
-}
-
-/** The inclusive px widths a query matches; `hi` is Infinity for a min-width-only query. */
-export interface WidthInterval {
-  lo: number;
-  hi: number;
-}
-
-/** I.e. `ruleSortKey(3200, "lg_black", "@media screen and (min-width: 960px)")` → `widthInterval: { lo: 960, hi: Infinity }`. */
-export function ruleSortKey(priority: number, className: string, atRulePrelude: string | undefined): RuleSortKey {
-  const widthInterval = atRulePrelude === undefined ? null : parseWidthInterval(atRulePrelude);
-  return { priority, className, widthInterval };
-}
-
-/**
- * Order rules by priority, then by query width interval, then by class name.
- *
- * Priority ties happen between rules in the same tier for the same property, i.e. two `@media`
- * rules for `color`. Those are ordered widest interval first, so the narrower query is emitted
- * later and wins in the cascade wherever both match. Equal widths go by lower bound ascending,
- * and queries with no readable interval (`print`, `not`, comma lists, non-px units) come last,
- * as they do in StyleX. For one-sided queries this is min-width ascending, then max-width descending.
- *
- * The class-name tiebreak keeps the output fully deterministic regardless of file processing
- * order, which differs between dev HMR and production builds.
- *
- * I.e. `(min-width: 600px)` → `(min-width: 960px)` → `(max-width: 1150px)` → `(max-width: 820px)`
- * → `(min-width: 600px) and (max-width: 959px)` → `print`.
- */
-export function compareRuleSortKeys(a: RuleSortKey, b: RuleSortKey): number {
-  return (
-    a.priority - b.priority ||
-    compareWidthIntervals(a.widthInterval, b.widthInterval) ||
-    compareClassNames(a.className, b.className)
-  );
-}
-
-/**
  * Pair each rule with its computed priority and sort with `compareRuleSortKeys`.
  *
  * Priorities and width intervals are computed once upfront so the O(n log n) comparisons are just
@@ -118,63 +76,4 @@ export function sortRulesByPriority(rules: Iterable<AtomicRule>): Array<{ rule: 
   });
   decorated.sort((a, b) => compareRuleSortKeys(a.key, b.key));
   return decorated.map((d) => ({ rule: d.rule, priority: d.priority }));
-}
-
-/** Code-point order, so identical class sets sort identically in dev and production. */
-export function compareClassNames(a: string, b: string): number {
-  return a < b ? -1 : a > b ? 1 : 0;
-}
-
-/**
- * Parse the px width interval a `@media` or `@container` prelude matches.
- *
- * Only `and`-joined `(min-width: Npx)` / `(max-width: Npx)` terms are read. Other features such as
- * `(orientation: landscape)` and media types such as `screen` add no bound, and repeated terms
- * collapse to the effective bound. The result is exact for what it accepts, and null ("no interval")
- * for a prelude with no width term or with anything it cannot read exactly: comma lists, `not`,
- * `or`, range syntax, and non-px units.
- *
- * I.e. `"@media screen and (min-width: 600px) and (max-width: 959px)"` → `{ lo: 600, hi: 959 }`,
- * `"@container grid (min-width: 601px)"` → `{ lo: 601, hi: Infinity }`, `"@media print"` → null.
- */
-function parseWidthInterval(prelude: string): WidthInterval | null {
-  if (/,|\bnot\b|\bor\b|[<>]/.test(prelude)) return null;
-  const terms = Array.from(prelude.matchAll(/\((min|max)-width:\s*([^)]*)\)/g));
-  if (terms.length === 0) return null;
-  let lo = 0;
-  let hi = Infinity;
-  for (const term of terms) {
-    const px = parsePxLength(term[2]);
-    if (px === null) return null;
-    if (term[1] === "min") {
-      lo = Math.max(lo, px);
-    } else {
-      hi = Math.min(hi, px);
-    }
-  }
-  return { lo, hi };
-}
-
-/** I.e. `"600px"` → 600, `"0"` → 0, `"40rem"` → null. */
-function parsePxLength(value: string): number | null {
-  const match = value.trim().match(/^(\d+(?:\.\d+)?)(px)?$/);
-  if (!match) return null;
-  if (match[2] === undefined && Number(match[1]) !== 0) return null;
-  return Number(match[1]);
-}
-
-/**
- * Widest interval first, equal widths by lower bound ascending, null last.
- *
- * I.e. `{ lo: 600, hi: Infinity }` (width Infinity) → `{ lo: 0, hi: 1150 }` (width 1150)
- * → `{ lo: 600, hi: 959 }` (width 359) → null.
- */
-function compareWidthIntervals(a: WidthInterval | null, b: WidthInterval | null): number {
-  if (a === null || b === null) {
-    return (a === null ? 1 : 0) - (b === null ? 1 : 0);
-  }
-  const widthA = a.hi - a.lo;
-  const widthB = b.hi - b.lo;
-  if (widthA !== widthB) return widthA > widthB ? -1 : 1;
-  return a.lo - b.lo;
 }

--- a/packages/truss/src/plugin/transform-session.ts
+++ b/packages/truss/src/plugin/transform-session.ts
@@ -12,6 +12,7 @@ import {
 import { loadMapping } from "./mapping-utils";
 import type { TrussMapping } from "./types";
 import { rootSpacingPreludeCss } from "../spacing-css-var";
+import { compareClassNames } from "../css-order";
 
 export interface TrussTransformSessionOptions {
   mappingPath: () => string;
@@ -52,6 +53,7 @@ export function createTrussTransformSession(options: TrussTransformSessionOption
   }
 
   function updateArbitraryCssRegistry(sourcePath: string, sourceCode: string): void {
+    sourcePath = resolve(sourcePath).replace(/\\/g, "/");
     const css = transformCssTs(sourceCode, sourcePath, ensureMapping()).trim();
     if (css.length > 0) {
       const prev = arbitraryCssRegistry.get(sourcePath);
@@ -90,7 +92,10 @@ export function createTrussTransformSession(options: TrussTransformSessionOption
   function collectCss(): string {
     const mapping = ensureMapping();
     const appCssParts = [generateCssText(cssRegistry)];
-    const allArbitrary = Array.from(arbitraryCssRegistry.values()).join("\n\n");
+    const allArbitrary = Array.from(arbitraryCssRegistry.entries())
+      .sort((a, b) => compareClassNames(a[0], b[0]))
+      .map((entry) => entry[1])
+      .join("\n\n");
     appCssParts.push(annotateArbitraryCssBlock(allArbitrary));
     const appCss = appCssParts.filter((part) => part.length > 0).join("\n");
     const libs = loadLibraries();
@@ -103,8 +108,20 @@ export function createTrussTransformSession(options: TrussTransformSessionOption
     return cssRegistry.size > 0 || arbitraryCssRegistry.size > 0 || libraryPaths.length > 0;
   }
 
+  /** Collect only libraries; application modules deliver their own CSS in tests. */
+  function collectTestCss(): string {
+    return mergeTrussCss(loadLibraries());
+  }
+
+  /** Read the transformed arbitrary CSS for one canonical source file. */
+  function getArbitraryCss(sourcePath: string): string {
+    return arbitraryCssRegistry.get(resolve(sourcePath).replace(/\\/g, "/")) ?? "";
+  }
+
   return {
     collectCss,
+    collectTestCss,
+    getArbitraryCss,
     ensureMapping,
     hasCss,
     reset,
@@ -115,6 +132,8 @@ export function createTrussTransformSession(options: TrussTransformSessionOption
 
 export interface TrussTransformSession {
   collectCss: () => string;
+  collectTestCss: () => string;
+  getArbitraryCss: (sourcePath: string) => string;
   ensureMapping: () => TrussMapping;
   hasCss: () => boolean;
   reset: () => void;

--- a/packages/truss/src/runtime-css.ts
+++ b/packages/truss/src/runtime-css.ts
@@ -1,0 +1,178 @@
+import { atRulePrelude, compareClassNames, compareRuleSortKeys, ruleSortKey, type RuleSortKey } from "./css-order";
+import { parseTrussCss } from "./truss-css";
+
+interface InjectionOptions {
+  /** Canonical source path for ordering and deduplicating application arbitrary CSS. */
+  source?: string;
+  /** Libraries use 0 and application modules use 1, matching the production merge. */
+  order?: number;
+  prelude?: string;
+}
+
+interface InstalledRule {
+  id: string;
+  cssText: string;
+  /** Prelude, atomic rules, property declarations, then arbitrary CSS. */
+  section: 0 | 1 | 2 | 3;
+  key: RuleSortKey | null;
+  order: number;
+  source: string;
+  sequence: number;
+  position: number;
+}
+
+interface InjectionState {
+  sheet: CSSStyleSheet;
+  rules: InstalledRule[];
+  byId: Map<string, InstalledRule>;
+  chunks: Set<string>;
+  sources: Map<string, number>;
+}
+
+type TrussStyleElement = HTMLStyleElement & { __trussCssState__?: InjectionState };
+let trussStyleElement: TrussStyleElement | null = null;
+
+/**
+ * Register annotated module or library CSS in the document's ordered test stylesheet.
+ *
+ * Annotated atomic rules are deduplicated by class and inserted with the production
+ * comparator, regardless of module execution order. Library definitions take precedence
+ * over application definitions of the same class. Arbitrary blocks stay after atomics,
+ * in library order followed by canonical application source path order. The plugin
+ * supplies spacing explicitly through options.prelude; unannotated CSS is ignored.
+ *
+ * Rules live until the document is discarded, not until a component unmounts. Repeated
+ * imports reuse state on the style element. This is not HMR: within one source rank,
+ * the first definition wins and omitted rules are not removed. Browser dev HMR replaces
+ * its separate virtual stylesheet; useRuntimeStyle owns transient sheets after this one.
+ *
+ * Only new or replaced rules are parsed by CSSOM. I.e. a late priority-1000 shorthand
+ * is inserted before an existing priority-4000 longhand without reparsing that longhand.
+ */
+export function __injectTrussCSS(cssText: string, options: InjectionOptions = {}): void {
+  if (typeof document === "undefined" || (!cssText && !options.prelude)) return;
+  const style = getOrCreateTrussStyleElement();
+  const sheet = style.sheet;
+  if (!sheet) throw new Error("Truss could not create its test stylesheet.");
+  // A removed and reattached style element has a new CSSOM sheet, even in the same document.
+  if (style.__trussCssState__?.sheet !== sheet) {
+    style.__trussCssState__ = { sheet, rules: [], byId: new Map(), chunks: new Set(), sources: new Map() };
+  }
+  const state = style.__trussCssState__!;
+  const chunkId = JSON.stringify([options.source, options.order, options.prelude, cssText]);
+  if (state.chunks.has(chunkId)) return;
+  const sourceId = options.source ?? cssText;
+  if (!state.sources.has(sourceId)) state.sources.set(sourceId, state.sources.size);
+  const base = {
+    order: options.order ?? 1,
+    source: options.source ?? "",
+    sequence: state.sources.get(sourceId)!,
+    position: 0,
+    key: null,
+  };
+  const parsed = parseTrussCss(cssText);
+  try {
+    if (options.prelude) {
+      installRule(state, { ...base, id: "prelude", section: 0, cssText: options.prelude });
+    }
+    for (const rule of parsed.rules) {
+      installRule(state, {
+        ...base,
+        id: `class:${rule.className}`,
+        section: 1,
+        cssText: rule.cssText,
+        key: ruleSortKey(rule.priority, rule.className, atRulePrelude(rule.cssText)),
+      });
+    }
+    for (const property of parsed.properties) {
+      installRule(state, { ...base, id: `property:${property.varName}`, section: 2, cssText: property.cssText });
+    }
+    let position = 0;
+    for (const block of parsed.arbitraryCssBlocks) {
+      for (const text of parseArbitraryRules(block.cssText)) {
+        installRule(state, {
+          ...base,
+          id: `arbitrary:${base.sequence}:${position}`,
+          section: 3,
+          position: position++,
+          cssText: text,
+        });
+      }
+    }
+    state.chunks.add(chunkId);
+  } finally {
+    // jsdom 29 does not invalidate computed styles after insertRule/deleteRule. An attribute
+    // mutation clears that cache without replacing the sheet or reparsing its previous rules.
+    style.setAttribute("data-truss", "");
+  }
+}
+
+/** Insert a unique rule at its production sort position; lower source ranks can replace it. */
+function installRule(state: InjectionState, rule: InstalledRule): void {
+  const previous = state.byId.get(rule.id);
+  if (previous && previous.order <= rule.order) return;
+  let lo = 0;
+  let hi = state.rules.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (compareInstalledRules(state.rules[mid], rule) <= 0) lo = mid + 1;
+    else hi = mid;
+  }
+  try {
+    state.sheet.insertRule(rule.cssText, lo);
+  } catch (error) {
+    // jsdom silently skips @property when parsing style text, but insertRule throws.
+    // Do not swallow errors for atomic rules or corrupt the installed-rule indexes.
+    if (
+      rule.section === 2 &&
+      typeof error === "object" &&
+      error !== null &&
+      "name" in error &&
+      error.name === "SyntaxError"
+    )
+      return;
+    throw error;
+  }
+  state.rules.splice(lo, 0, rule);
+  state.byId.set(rule.id, rule);
+  if (previous) {
+    const oldIndex = state.rules.indexOf(previous);
+    state.sheet.deleteRule(oldIndex);
+    state.rules.splice(oldIndex, 1);
+  }
+}
+
+/** Use the production atomic comparator and preserve source order within opaque blocks. */
+function compareInstalledRules(a: InstalledRule, b: InstalledRule): number {
+  if (a.section !== b.section) return a.section - b.section;
+  if (a.key && b.key) return compareRuleSortKeys(a.key, b.key);
+  return (
+    a.order - b.order || compareClassNames(a.source, b.source) || a.sequence - b.sequence || a.position - b.position
+  );
+}
+
+/** Parse only the new opaque block, preserving CSS parser recovery for unsupported rules. */
+function parseArbitraryRules(cssText: string): string[] {
+  // jsdom does not create sheets in detached documents. Remove this temporary sheet
+  // synchronously before returning; no earlier static rules are reparsed.
+  const style = document.createElement("style");
+  style.textContent = cssText;
+  document.head.appendChild(style);
+  try {
+    return Array.from(style.sheet?.cssRules ?? [], (rule) => rule.cssText);
+  } finally {
+    style.remove();
+  }
+}
+
+/** Keep one static sheet before transient runtime styles, and recover after document replacement. */
+export function getOrCreateTrussStyleElement(): TrussStyleElement {
+  if (trussStyleElement?.ownerDocument === document && trussStyleElement.isConnected) return trussStyleElement;
+  const style = document.querySelector<TrussStyleElement>("style[data-truss]") ?? document.createElement("style");
+  if (!style.isConnected) {
+    style.setAttribute("data-truss", "");
+    document.head.insertBefore(style, document.head.querySelector("style[data-truss-runtime-style]"));
+  }
+  trussStyleElement = style;
+  return style;
+}

--- a/packages/truss/src/runtime.test.ts
+++ b/packages/truss/src/runtime.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { mergeProps, TrussDebugInfo, trussProps, __injectTrussCSS } from "./runtime";
+import { mergeTrussCss } from "./plugin/merge-css";
+import { annotateArbitraryCssBlock, parseTrussCss } from "./truss-css";
 
 describe("trussProps", () => {
   test("merges static style hashes", () => {
@@ -229,62 +231,110 @@ describe("mergeProps", () => {
 
 describe("__injectTrussCSS", () => {
   beforeEach(removeTrussStyles);
-  afterEach(removeTrussStyles);
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    removeTrussStyles();
+  });
 
-  test("parses each chunk into its own sheet without changing earlier sheets", () => {
-    const chunks = [".df { display: flex; }", ".aic { align-items: center; }", ".black { color: black; }"];
-    const sheets: CSSStyleSheet[] = [];
-    for (const chunk of chunks) {
-      __injectTrussCSS(chunk);
-      sheets.push(document.styleSheets[document.styleSheets.length - 1]);
+  test.each(["original", "reversed", "shuffled", "bootstrap subset"])(
+    "matches production CSSOM for %s annotated input",
+    (order) => {
+      const chunks = [
+        atomicCss(4000, "top", ".top { margin-top: 12px; }"),
+        atomicCss(1000, "margin", ".margin { margin: 4px; }"),
+        atomicCss(3200, "zMin600", "@media (min-width: 600px) { .zMin600 { color: red; } }"),
+        atomicCss(3200, "aMin960", "@media (min-width: 960px) { .aMin960 { color: blue; } }"),
+        atomicCss(3200, "zMax1150", "@media (max-width: 1150px) { .zMax1150 { color: green; } }"),
+        atomicCss(3200, "aMax820", "@media (max-width: 820px) { .aMax820 { color: black; } }"),
+        atomicCss(3200, "range", "@media (min-width: 600px) and (max-width: 959px) { .range { color: gray; } }"),
+        atomicCss(3200, "print", "@media print { .print { color: purple; } }"),
+        atomicCss(3200, "bMin600", "@media (min-width: 600px) { .bMin600 { color: yellow; } }"),
+      ];
+      const expected = productionRules(chunks);
+      const indices =
+        order === "reversed"
+          ? [8, 7, 6, 5, 4, 3, 2, 1, 0]
+          : order === "shuffled"
+            ? [5, 0, 8, 3, 1, 7, 4, 2, 6]
+            : [0, 1, 2, 3, 4, 5, 6, 7, 8];
+      if (order === "bootstrap subset") {
+        __injectTrussCSS(mergeTrussCss([parseTrussCss(chunks[0]), parseTrussCss(chunks[4])]));
+      }
+      for (const index of indices) __injectTrussCSS(chunks[index]);
+
+      // Media evaluation is not supported by jsdom; compare its parsed rules instead.
+      expect(sheetRules(trussStyle().sheet!)).toEqual(expected);
+      expect(document.querySelectorAll("style[data-truss]").length).toBe(1);
+      expect(document.styleSheets.length).toBe(1);
+      expect(trussStyle().textContent).toBe("");
+    },
+  );
+
+  test("parses only new atomics and retains earlier CSSRule identities when inserting before them", () => {
+    const top = atomicCss(4000, "top", ".top { margin-top: 12px; }");
+    const margin = atomicCss(1000, "margin", ".margin { margin: 4px; }");
+    __injectTrussCSS(top);
+    const style = trussStyle();
+    const sheet = style.sheet!;
+    const firstRule = sheet.cssRules[0];
+    const insert = vi.spyOn(sheet, "insertRule");
+
+    __injectTrussCSS(mergeTrussCss([parseTrussCss(top), parseTrussCss(margin)]));
+    expect(insert.mock.calls).toEqual([[".margin { margin: 4px; }", 0]]);
+    expect(trussStyle()).toBe(style);
+    expect(style.sheet).toBe(sheet);
+    expect(sheet.cssRules[1]).toBe(firstRule);
+    expect(sheetRules(sheet)).toEqual(productionRules([top, margin]));
+  });
+
+  test("invalidates computed styles after late rules without replacing the sheet", () => {
+    const top = atomicCss(4000, "top", ".top { margin-top: 12px; }");
+    const margin = atomicCss(1000, "margin", ".margin { margin: 4px; }");
+    const color = atomicCss(3000, "color", ".color { color: red; }");
+    __injectTrussCSS(top);
+    const style = trussStyle();
+    const sheet = style.sheet;
+    const attribute = vi.spyOn(style, "setAttribute");
+    const target = document.createElement("div");
+    target.className = "top margin color";
+    document.body.appendChild(target);
+    try {
+      expect(getComputedStyle(target).marginTop).toBe("12px");
+      expect(getComputedStyle(target).marginRight).toBe("0px");
+      const previousColor = getComputedStyle(target).color;
+      __injectTrussCSS(`${margin}\n${color}`);
+      expect(attribute.mock.calls).toEqual([["data-truss", ""]]);
+      expect(style.sheet).toBe(sheet);
+      expect(getComputedStyle(target).marginTop).toBe("12px");
+      expect(getComputedStyle(target).marginRight).toBe("4px");
+      expect(getComputedStyle(target).color).not.toBe(previousColor);
+      expect(getComputedStyle(target).color).toBe("rgb(255, 0, 0)");
+    } finally {
+      target.remove();
     }
-
-    expect(document.querySelector("style[data-truss]")?.textContent).toBe("");
-    expect(Array.from(document.querySelectorAll("style[data-truss-chunk]"), (el) => el.textContent)).toEqual(chunks);
-    expect(document.querySelectorAll("style").length).toBe(chunks.length + 1);
-    expect(
-      Array.from(document.styleSheets).flatMap((sheet) => Array.from(sheet.cssRules, (rule) => rule.cssText)),
-    ).toEqual(chunks);
-    for (const sheet of sheets) {
-      expect(Array.from(document.styleSheets).includes(sheet)).toBe(true);
-      expect(sheet.cssRules.length).toBe(1);
-    }
   });
 
-  test("preserves injection order for competing rules", () => {
-    __injectTrussCSS(".target { color: red; }");
-    __injectTrussCSS(".target { color: blue; }");
-
-    expect(
-      Array.from(document.styleSheets).flatMap((sheet) => Array.from(sheet.cssRules, (rule) => rule.cssText)),
-    ).toEqual([".target { color: red; }", ".target { color: blue; }"]);
-  });
-
-  test("deduplicates identical CSS text", () => {
-    __injectTrussCSS(".df { display: flex; }");
-    __injectTrussCSS(".df { display: flex; }");
-
-    // Should only appear once
-    expect(document.querySelectorAll("style[data-truss-chunk]").length).toBe(1);
-    expect(document.querySelector("style[data-truss-chunk]")?.textContent).toBe(".df { display: flex; }");
-  });
-
-  test("deduplicates repeated merged bootstrap CSS chunks across runtime reloads", async () => {
-    const cssText = "/* @truss p:3000 c:beamStatic */\n.beamStatic { display: flex; }";
+  test("deduplicates exact chunks and merged bootstrap CSS across runtime reloads on the same anchor", async () => {
+    const cssText = mergeTrussCss([parseTrussCss(atomicCss(3000, "df", ".df { display: flex; }"))]);
+    __injectTrussCSS(cssText);
+    const style = trussStyle();
+    const sheet = style.sheet!;
+    const rule = sheet.cssRules[0];
+    const insert = vi.spyOn(sheet, "insertRule");
     __injectTrussCSS(cssText);
     vi.resetModules();
     const runtime = await import("./runtime");
     runtime.__injectTrussCSS(cssText);
 
+    expect(insert.mock.calls).toEqual([]);
+    expect(trussStyle()).toBe(style);
+    expect(style.sheet).toBe(sheet);
+    expect(sheet.cssRules[0]).toBe(rule);
+    expect(sheetRules(sheet)).toEqual(productionRules([cssText]));
     expect(document.querySelectorAll("style[data-truss]").length).toBe(1);
-    expect(document.querySelectorAll("style[data-truss-chunk]").length).toBe(1);
-    expect(document.querySelector("style[data-truss-chunk]")?.textContent).toBe(cssText);
-  });
-
-  test("does not treat a substring of an earlier chunk as a duplicate", () => {
-    __injectTrussCSS(".df { display: flex; }.aic { align-items: center; }");
-    __injectTrussCSS(".df { display: flex; }");
-    expect(document.querySelectorAll("style[data-truss-chunk]").length).toBe(2);
+    runtime.__injectTrussCSS(atomicCss(1000, "aic", ".aic { align-items: center; }"));
+    expect(sheet.cssRules[1]).toBe(rule);
   });
 
   test("ignores empty CSS", () => {
@@ -293,33 +343,197 @@ describe("__injectTrussCSS", () => {
   });
 
   test("ignores CSS when there is no document", () => {
+    const css = atomicCss(3000, "df", ".df { display: flex; }");
     vi.stubGlobal("document", undefined);
     try {
-      expect(() => __injectTrussCSS(".df { display: flex; }")).not.toThrow();
+      expect(() => __injectTrussCSS(css)).not.toThrow();
     } finally {
       vi.unstubAllGlobals();
     }
     expect(document.querySelectorAll("style").length).toBe(0);
+    __injectTrussCSS(css);
+    expect(sheetRules(trussStyle().sheet!)).toEqual(productionRules([css]));
   });
 
-  test("recreates the cached style tag after removal", () => {
-    __injectTrussCSS(".df { display: flex; }");
-    const firstStyle = document.querySelector("style[data-truss]") as HTMLStyleElement;
-    firstStyle.remove();
+  test.each(["app first", "library first"])("uses the lower-order library class definition: %s", (order) => {
+    const app = atomicCss(4000, "target", ".target { color: blue; }");
+    const library = atomicCss(1000, "target", ".target { color: red; }");
+    const other = atomicCss(3000, "other", ".other { display: flex; }");
+    __injectTrussCSS(other);
+    const sheet = trussStyle().sheet!;
+    const otherRule = sheet.cssRules[0];
+    if (order === "app first") __injectTrussCSS(app, { source: "/app.ts", order: 1 });
+    __injectTrussCSS(library, { source: "/library.css", order: 0 });
+    const libraryRule = sheet.cssRules[0];
+    const insert = vi.spyOn(sheet, "insertRule");
+    __injectTrussCSS(app, { source: "/late-app.ts", order: 1 });
+    expect(insert.mock.calls).toEqual([]);
+    expect(sheetRules(sheet)).toEqual(productionRules([library, app, other]));
+    expect(sheet.cssRules[0]).toBe(libraryRule);
+    expect(sheet.cssRules[1]).toBe(otherRule);
+  });
 
-    __injectTrussCSS(".aic { align-items: center; }");
+  test("orders arbitrary library CSS before canonical app sources and preserves opaque block order and duplicates", () => {
+    const duplicate = ".duplicate { color: red; }";
+    const appA = annotateArbitraryCssBlock(
+      `${duplicate}\n@media (min-width: 600px) { @supports (display: grid) { .nested { display: grid; } } }\n${duplicate}`,
+    );
+    const appZ = annotateArbitraryCssBlock(duplicate);
+    const libraryB = annotateArbitraryCssBlock(".libraryB { color: blue; }");
+    const libraryA = annotateArbitraryCssBlock(".libraryA { color: green; }");
+    const atomic = atomicCss(3000, "df", ".df { display: flex; }");
+    __injectTrussCSS(appZ, { source: "/app/Z.css.ts" });
+    const sheet = trussStyle().sheet!;
+    const appZRule = sheet.cssRules[0];
+    __injectTrussCSS(libraryB, { order: 0 });
+    __injectTrussCSS(appA, { source: "/app/A.css.ts" });
+    __injectTrussCSS(libraryA, { order: 0 });
+    __injectTrussCSS(atomic);
 
-    const style = document.querySelector("style[data-truss]") as HTMLStyleElement;
-    expect(style).not.toBe(firstStyle);
-    expect(style.textContent).toBe("");
-    expect(Array.from(document.querySelectorAll("style[data-truss-chunk]"), (el) => el.textContent)).toEqual([
-      ".df { display: flex; }",
-      ".aic { align-items: center; }",
+    expect(sheetRules(sheet)).toEqual(productionRules([atomic, libraryB, libraryA, appA, appZ]));
+    expect(sheet.cssRules.length).toBe(7);
+    expect(sheet.cssRules[6]).toBe(appZRule);
+    const insert = vi.spyOn(sheet, "insertRule");
+    __injectTrussCSS(appA, { source: "/app/A.css.ts" });
+    expect(insert.mock.calls).toEqual([]);
+  });
+
+  test("retains the prelude from an empty bootstrap before all later rules", () => {
+    const prelude = ":root { --truss-ready: 1; }";
+    __injectTrussCSS("", { prelude });
+    const sheet = trussStyle().sheet!;
+    const preludeRule = sheet.cssRules[0];
+    const atomic = atomicCss(1000, "df", ".df { display: flex; }");
+    __injectTrussCSS(atomic);
+    __injectTrussCSS("", { prelude });
+    expect(sheetRules(sheet)).toEqual(parseCssRules(`${prelude}\n${mergeTrussCss([parseTrussCss(atomic)])}`));
+    expect(sheet.cssRules[0]).toBe(preludeRule);
+  });
+
+  test("skips unsupported @property without losing surrounding or later rules", () => {
+    const first = atomicCss(3000, "df", ".df { display: flex; }");
+    const property =
+      "/* @truss @property */\n@property --gap { syntax: '<length>'; inherits: false; initial-value: 0px; }";
+    const arbitrary = annotateArbitraryCssBlock(".target { color: red; }");
+    const later = atomicCss(1000, "margin", ".margin { margin: 4px; }");
+    __injectTrussCSS(first);
+    const sheet = trussStyle().sheet!;
+    const rule = sheet.cssRules[0];
+    // jsdom rejects @property through insertRule but skips it when parsing style text.
+    expect(() => sheet.insertRule(parseTrussCss(property).properties[0].cssText, 0)).toThrowError(DOMException);
+    const insert = vi.spyOn(sheet, "insertRule");
+    expect(() => __injectTrussCSS(`${first}\n${property}\n${arbitrary}`)).not.toThrow();
+    expect(insert.mock.calls).toEqual([
+      [parseTrussCss(property).properties[0].cssText, 1],
+      [parseCssRules(".target { color: red; }")[0], 1],
     ]);
+    __injectTrussCSS(later);
+    expect(sheetRules(sheet)).toEqual(productionRules([first, property, arbitrary, later]));
+    expect(sheet.cssRules[1]).toBe(rule);
+  });
+
+  test("propagates invalid atomic errors and retries failed chunks without duplicating installed rules", () => {
+    const first = atomicCss(3000, "df", ".df { display: flex; }");
+    const invalid = atomicCss(4000, "invalid", "not a CSS rule");
+    const last = atomicCss(5000, "last", ".last { color: red; }");
+    __injectTrussCSS(first);
+    const sheet = trussStyle().sheet!;
+    const rule = sheet.cssRules[0];
+    const insert = vi.spyOn(sheet, "insertRule");
+    const chunk = `${first}\n${invalid}\n${last}`;
+    expect(() => __injectTrussCSS(chunk)).toThrow();
+    expect(() => __injectTrussCSS(chunk)).toThrow();
+    expect(insert.mock.calls).toEqual([
+      ["not a CSS rule", 1],
+      ["not a CSS rule", 1],
+    ]);
+    expect(sheetRules(sheet)).toEqual(productionRules([first]));
+    const corrected = atomicCss(4000, "invalid", ".invalid { color: blue; }");
+    __injectTrussCSS(`${first}\n${corrected}\n${last}`);
+    expect(sheetRules(sheet)).toEqual(productionRules([first, corrected, last]));
+    expect(sheet.cssRules[0]).toBe(rule);
+  });
+
+  test.each([false, true])("resets the registry after removal with reattach=%s", (reattach) => {
+    const first = atomicCss(3000, "df", ".df { display: flex; }");
+    const second = atomicCss(4000, "aic", ".aic { align-items: center; }");
+    __injectTrussCSS(`${first}\n${second}`);
+    const style = trussStyle();
+    const sheet = style.sheet;
+    style.remove();
+    if (reattach) document.head.appendChild(style);
+    __injectTrussCSS(first);
+    expect(trussStyle() === style).toBe(reattach);
+    expect(trussStyle().sheet).not.toBe(sheet);
+    expect(sheetRules(trussStyle().sheet!)).toEqual(productionRules([first]));
+    __injectTrussCSS(`${first}\n${second}`);
+    expect(sheetRules(trussStyle().sheet!)).toEqual(productionRules([first, second]));
+  });
+
+  test("recovers in a replacement document and reuses the original document registry on return", () => {
+    const css = atomicCss(3000, "df", ".df { display: flex; }");
+    const expected = productionRules([css]);
+    __injectTrussCSS(css);
+    const original = trussStyle();
+    const originalRule = original.sheet!.cssRules[0];
+    const frame = document.createElement("iframe");
+    document.body.appendChild(frame);
+    const replacement = frame.contentDocument!;
+    vi.stubGlobal("document", replacement);
+    try {
+      __injectTrussCSS(css);
+      expect(trussStyle()).not.toBe(original);
+      expect(trussStyle().ownerDocument).toBe(replacement);
+      expect(sheetRules(trussStyle().sheet!)).toEqual(expected);
+      expect(replacement.querySelectorAll("style[data-truss]").length).toBe(1);
+    } finally {
+      vi.unstubAllGlobals();
+      frame.remove();
+    }
+    __injectTrussCSS(css);
+    expect(trussStyle()).toBe(original);
+    expect(original.sheet!.cssRules[0]).toBe(originalRule);
+    expect(sheetRules(original.sheet!)).toEqual(expected);
   });
 });
 
-/** Clean up any prior style tags, including the dedupe anchor and injected chunks. */
+/** Annotate one atomic rule with its production priority and class identity. */
+function atomicCss(priority: number, className: string, cssText: string): string {
+  return `/* @truss p:${priority} c:${className} */\n${cssText}`;
+}
+
+/** Merge canonical production sources and parse their expected CSSOM in a separate document. */
+function productionRules(sources: string[]): string[] {
+  return parseCssRules(mergeTrussCss(sources.map((source) => parseTrussCss(source))));
+}
+
+/** Parse stylesheet text without adding expected rules to the document under test. */
+function parseCssRules(cssText: string): string[] {
+  // createHTMLDocument has no browsing context, so jsdom does not create its stylesheets.
+  const frame = document.createElement("iframe");
+  document.body.appendChild(frame);
+  try {
+    const parserDocument = frame.contentDocument!;
+    const style = parserDocument.createElement("style");
+    parserDocument.head.appendChild(style);
+    style.textContent = cssText;
+    return sheetRules(style.sheet!);
+  } finally {
+    frame.remove();
+  }
+}
+
+/** Return the complete ordered CSSOM text, including nested at-rules. */
+function sheetRules(sheet: CSSStyleSheet): string[] {
+  return Array.from(sheet.cssRules, (rule) => rule.cssText);
+}
+
+/** Find the single runtime injection anchor. */
+function trussStyle(): HTMLStyleElement {
+  return document.querySelector<HTMLStyleElement>("style[data-truss]")!;
+}
+
+/** Remove the static stylesheet and its registry between tests. */
 function removeTrussStyles(): void {
-  document.querySelectorAll("style[data-truss], style[data-truss-chunk]").forEach((el) => el.remove());
+  document.querySelectorAll("style[data-truss]").forEach((el) => el.remove());
 }

--- a/packages/truss/src/runtime.ts
+++ b/packages/truss/src/runtime.ts
@@ -1,4 +1,5 @@
 import { useInsertionEffect } from "react";
+import { getOrCreateTrussStyleElement } from "./runtime-css";
 import {
   TRUSS_CSS_MARKER_KEY,
   TRUSS_CUSTOM_CLASS_PREFIX,
@@ -8,6 +9,7 @@ import {
 
 export { invertMediaQuery as __invertTrussMediaQuery } from "./media-query";
 export { maybeCssVar } from "./css-custom-property";
+export { __injectTrussCSS } from "./runtime-css";
 
 /** A compact source label for a Truss CSS expression, used in debug mode. */
 export class TrussDebugInfo {
@@ -42,8 +44,6 @@ export type RuntimeStyleCss = Record<string, RuntimeStyleDeclarations | string>;
 
 const shouldValidateTrussStyleValues = resolveShouldValidateTrussStyleValues();
 const shouldEmitTrussSrcAttribute = resolveShouldEmitTrussSrcAttribute();
-const TRUSS_CSS_CHUNKS = "__trussCssChunks__";
-let trussStyleElement: TrussStyleElement | null = null;
 
 /** Merge one or more Truss style hashes into `{ className, style?, data-truss-src? }`. */
 export function trussProps(
@@ -170,39 +170,6 @@ export function mergeProps(
   return result;
 }
 
-/**
- * Inject CSS text into the document for jsdom/test environments.
- *
- * A chunk is one transformed module's CSS or the test bootstrap's merged application
- * and library CSS snapshot. Chunks are static, append-only, and live until the document
- * is discarded; component unmounts do not remove them. Exact repeated chunks are skipped,
- * but different chunks can contain overlapping rules. Injecting changed CSS does not
- * replace old rules or remove declarations omitted from the new chunk.
- *
- * Each new chunk is appended in injection order, including after any mounted
- * useRuntimeStyle elements. Normal cascade rules apply across these sheets.
- * useRuntimeStyle owns its transient styles separately and removes them on effect cleanup.
- * In browser dev mode, the Vite virtual stylesheet is replaced on updates instead;
- * this helper is not an HMR replacement mechanism.
- */
-export function __injectTrussCSS(cssText: string): void {
-  if (typeof document === "undefined" || cssText.length === 0) return;
-
-  const style = getOrCreateTrussStyleElement();
-
-  // Track exact injected chunks on the style node so repeated execution of the
-  // test bootstrap or transformed modules does not append duplicate CSS text.
-  const injectedChunks = (style[TRUSS_CSS_CHUNKS] ??= new Set<string>());
-  if (injectedChunks.has(cssText)) return;
-
-  injectedChunks.add(cssText);
-  // Separate sheets let jsdom parse each chunk once instead of reparsing all prior chunks.
-  const chunkStyle = document.createElement("style");
-  chunkStyle.setAttribute("data-truss-chunk", "");
-  chunkStyle.textContent = cssText;
-  document.head.appendChild(chunkStyle);
-}
-
 export interface RuntimeStyleProps {
   css: RuntimeStyleCss;
 }
@@ -273,6 +240,15 @@ export function useRuntimeStyle(css: RuntimeStyleCss): void {
   const cssText = buildRuntimeStyleCssText(css);
   useInsertionEffect(() => {
     if (typeof document === "undefined" || cssText.length === 0) return;
+    // Reserve the static sheet before transient styles, even when no module CSS has loaded yet.
+    //
+    // This call is not redundant with getOrCreateTrussStyleElement inserting the static sheet
+    // before the first runtime style. jsdom cascades document.styleSheets in attach order, not
+    // DOM order. Without this reservation, a static sheet created after this runtime style
+    // mounts lands before it in <head> but after it in document.styleSheets, so the static
+    // rule wins the cascade. I.e. a runtime `.x { color: green }` mounted first loses to a
+    // later injected static `.x { color: red }`.
+    getOrCreateTrussStyleElement();
     const style = document.createElement("style");
     style.setAttribute("data-truss-runtime-style", "");
     style.textContent = cssText;
@@ -370,22 +346,3 @@ function resolveShouldEmitTrussSrcAttribute(): boolean {
   }
   return true;
 }
-
-function getOrCreateTrussStyleElement(): TrussStyleElement {
-  const id = "data-truss";
-  if (trussStyleElement?.ownerDocument === document && trussStyleElement.isConnected) {
-    return trussStyleElement;
-  }
-
-  const style = (document.querySelector(`style[${id}]`) as TrussStyleElement | null) ?? document.createElement("style");
-  if (!style.isConnected) {
-    style.setAttribute(id, "");
-    document.head.appendChild(style);
-  }
-  trussStyleElement = style;
-  return trussStyleElement;
-}
-
-type TrussStyleElement = HTMLStyleElement & {
-  [TRUSS_CSS_CHUNKS]?: Set<string>;
-};

--- a/packages/truss/src/truss-css.ts
+++ b/packages/truss/src/truss-css.ts
@@ -1,0 +1,120 @@
+/** A parsed CSS rule extracted from an annotated truss.css file. */
+export interface ParsedCssRule {
+  priority: number;
+  className: string;
+  cssText: string;
+}
+
+/** A parsed @property declaration extracted from an annotated truss.css file. */
+export interface ParsedPropertyDeclaration {
+  cssText: string;
+  /** The variable name, i.e. `--marginTop`. */
+  varName: string;
+}
+
+/** A parsed arbitrary CSS block extracted from an annotated truss.css file. */
+export interface ParsedArbitraryCssBlock {
+  cssText: string;
+}
+
+/** The result of parsing an annotated truss.css file. */
+export interface ParsedTrussCss {
+  rules: ParsedCssRule[];
+  properties: ParsedPropertyDeclaration[];
+  arbitraryCssBlocks: ParsedArbitraryCssBlock[];
+}
+
+/** Regex matching `/* @truss p:<priority> c:<className> *\/` annotations. */
+const RULE_ANNOTATION_RE = /^\/\* @truss p:([\d.]+) c:(\S+) \*\/$/;
+
+/** Regex matching `/* @truss @property *\/` annotations. */
+const PROPERTY_ANNOTATION_RE = /^\/\* @truss @property \*\/$/;
+
+/** Regex matching the start of an annotated arbitrary CSS block. */
+const ARBITRARY_START_RE = /^\/\* @truss arbitrary:start \*\/$/;
+
+/** Regex matching the end of an annotated arbitrary CSS block. */
+const ARBITRARY_END_RE = /^\/\* @truss arbitrary:end \*\/$/;
+
+/** Regex to extract the variable name from `@property --foo { ... }`. */
+const PROPERTY_VAR_RE = /^@property\s+(--\S+)/;
+
+/**
+ * Parse an annotated truss.css file into rules, @property declarations,
+ * and arbitrary CSS blocks.
+ *
+ * The file must contain `/* @truss p:<priority> c:<className> *\/` comments
+ * before each CSS rule, and `/* @truss @property *\/` before each @property declaration.
+ * Unannotated lines are ignored.
+ */
+export function parseTrussCss(cssText: string): ParsedTrussCss {
+  const lines = cssText.split("\n");
+  const rules: ParsedCssRule[] = [];
+  const properties: ParsedPropertyDeclaration[] = [];
+  const arbitraryCssBlocks: ParsedArbitraryCssBlock[] = [];
+
+  let i = 0;
+
+  /** Advance past the current annotation line and any blank lines to the annotated content line. */
+  function takeAnnotatedLine(): string | null {
+    i++;
+    while (i < lines.length && lines[i].trim() === "") i++;
+    return i < lines.length ? lines[i].trim() : null;
+  }
+
+  while (i < lines.length) {
+    const line = lines[i].trim();
+
+    // Check for rule annotation
+    const ruleMatch = RULE_ANNOTATION_RE.exec(line);
+    if (ruleMatch) {
+      const cssText = takeAnnotatedLine();
+      if (cssText !== null) {
+        rules.push({ priority: parseFloat(ruleMatch[1]), className: ruleMatch[2], cssText });
+      }
+      i++;
+      continue;
+    }
+
+    // Check for @property annotation
+    if (PROPERTY_ANNOTATION_RE.test(line)) {
+      const propLine = takeAnnotatedLine();
+      const varMatch = propLine === null ? null : PROPERTY_VAR_RE.exec(propLine);
+      if (propLine !== null && varMatch) {
+        properties.push({ cssText: propLine, varName: varMatch[1] });
+      }
+      i++;
+      continue;
+    }
+
+    if (ARBITRARY_START_RE.test(line)) {
+      i++;
+      const blockLines: string[] = [];
+      while (i < lines.length && !ARBITRARY_END_RE.test(lines[i].trim())) {
+        blockLines.push(lines[i]);
+        i++;
+      }
+      const blockText = blockLines.join("\n").trim();
+      if (blockText.length > 0) {
+        arbitraryCssBlocks.push({ cssText: blockText });
+      }
+      if (i < lines.length && ARBITRARY_END_RE.test(lines[i].trim())) {
+        i++;
+      }
+      continue;
+    }
+
+    i++;
+  }
+
+  return { rules, properties, arbitraryCssBlocks };
+}
+
+/** Wrap an arbitrary CSS block in annotations so it survives later Truss merges. */
+export function annotateArbitraryCssBlock(cssText: string): string {
+  const trimmed = cssText.trim();
+  if (trimmed.length === 0) {
+    return "";
+  }
+  return ["/* @truss arbitrary:start */", trimmed, "/* @truss arbitrary:end */"].join("\n");
+}


### PR DESCRIPTION
## Why

Follow-up to #279. The previous fix removed repeated parsing of accumulated CSS, but appending module-sized chunks still makes the test cascade depend on module execution order. That mismatch also existed before #279: concatenating individually sorted chunks is not the same as globally sorting their rules.

For example, production emits a broad responsive rule before a narrower rule so the narrower rule wins when both match. If the broad rule arrives in a later test module, appending its chunk reverses that precedence. A later module can also repeat a rule already present in bootstrap CSS, moving that rule after its intended override.

This PR keeps incremental loading and avoids accumulated-text reparsing while giving generated atomic CSS the same ordering and class dedupe as production. It does not require discovering the full component graph before tests execute.

## How It Works

- Maintain one document-owned static stylesheet and rule registry. New annotated atomic rules are inserted with CSSOM at their globally sorted position; existing rules are not reparsed.
- Share the actual production comparator: numeric priority, query-width interval, then class name. Priority-only buckets would not preserve responsive tie ordering.
- Deduplicate by atomic class identity, including overlapping bootstrap/module payloads. Library definitions take precedence over conflicting application definitions, even if registered later.
- Keep the static stylesheet in a fixed position before transient `useRuntimeStyle` sheets. Late static injection no longer jumps after mounted runtime styles.
- Bootstrap library CSS and the root spacing variable, then let application modules register their CSS as they evaluate. Side-effect-only `.css.ts` imports use virtual JS injection modules, so build-time expressions such as `Css.setVar(...).$` are compiled rather than executed. Late/dynamic stylesheet delivery is covered.

## Ordering And Compatibility

**Intentional production behavior change:** application arbitrary-CSS blocks now use canonical source-path order instead of collection/import order. Tests use that same order. Library blocks retain configured library order, and arbitrary CSS remains after atomics and property declarations. Consumers relying on import order between competing application `.css.ts` blocks should review that precedence.

- Static registrations live for the document lifetime and survive runtime module reloads. They are not component-owned or an HMR replacement system; within a source rank, the first definition wins and omitted rules are not removed.
- The injection helper has no external callers, so it has one contract: register the plugin's annotated CSS payloads in the ordered static sheet. Bootstrap supplies spacing explicitly through `options.prelude`; unannotated CSS is ignored. Both the mixed-content recovery path and the separate raw-string injection path have been removed, along with their compatibility tests and resource-loading test configuration.
- Arbitrary selectors remain supported through annotated `.css.ts` and library blocks. Their parser is retained; removing the unannotated entry point does not remove arbitrary-CSS support.
- Browser development HMR remains on its separate replacement-based stylesheet.

## jsdom Details

`insertRule` and `deleteRule` do not invalidate jsdom 29 computed-style caches. After a registration batch, a same-value anchor attribute write refreshes that cache without replacing the stylesheet. Regression tests read computed styles before and after late insertion.

jsdom also cascades stylesheets in attachment order rather than DOM order. `useRuntimeStyle` reserves the static sheet before attaching its transient sheet; inserting a newly created static element earlier in `<head>` would not be enough. The in-source comment now explains this constraint.

jsdom also throws for `@property` through `insertRule`, although its text parser silently skips those declarations. The runtime tolerates that specific unsupported case, but propagates atomic insertion errors and permits retries without corrupting indexes or duplicating successful rules.

## Review Guide

- `runtime-css.ts`: registry ownership, sorted insertion/replacement, annotated arbitrary-CSS parsing, and jsdom handling.
- `css-order.ts` and `truss-css.ts`: browser-safe extraction of existing ordering and annotation parsing; the plugin reuses these rather than introducing a parallel policy.
- `plugin/index.ts` and `plugin/transform-session.ts`: incremental test delivery and canonical arbitrary-CSS ordering.
- `runtime.test.ts`: live CSSOM compared with production merge output across original, reversed, shuffled, and overlapping-bootstrap inputs. Also covers retained rule identity, library conflicts, arbitrary blocks, error retries, document replacement, and the single-static-sheet invariant.
- App fixtures/tests: real plugin bootstrap, runtime-style precedence, build-only side effects, and late named/virtual stylesheet delivery without duplication.

## Verification

- `yarn test`, rerun locally after removing the unused compatibility paths: **500 passed, 1 existing skipped**, including all **388 Truss tests**. Three compatibility-only tests were removed across the review cleanups.
- `yarn tsc --build`: passed.
- `yarn workspace app build`: passed.
- Formatting checks: passed.
- Separate temporary no-library Vitest configuration: **73 passed**, with two library-dependent tests intentionally excluded; includes late stylesheet delivery.
- Local synthetic probe against the built runtime: **2,800 annotated rules in 161 reverse-ordered chunks took 98-159 ms** across three runs. An overlapping full-sheet registration took about **2 ms**, added no rules, and retained existing CSSRule identity. This is not a new beam benchmark, and CSSOM bookkeeping is not claimed to be strictly linear.
