### PR TITLE
fix: Safely reuse imports for test CSS injection

### DIFF
--- a/packages/truss/src/css-order.ts
+++ b/packages/truss/src/css-order.ts
@@ -1,6 +1,6 @@
 /**
- * The sort key shared by `emit-css` and `merge-css`, so a stylesheet merged from library CSS
- * keeps the same rule order as the per-file output.
+ * The sort key shared by `emit-css`, `merge-css`, and `runtime-css`, so a stylesheet merged from
+ * library CSS or assembled rule by rule in jsdom keeps the same rule order as the per-file output.
  */
 export interface RuleSortKey {
   priority: number;

--- a/packages/truss/src/plugin/ast-utils.ts
+++ b/packages/truss/src/plugin/ast-utils.ts
@@ -119,16 +119,20 @@ export function insertAfterLeadingImports(ast: t.File, statements: t.Statement[]
 }
 
 /**
- * Find the local name of a named import, i.e. `mergeProps13` for `import { mergeProps as mergeProps13 }`.
+ * Find the local name of a named value import, i.e. `mergeProps13` for `import { mergeProps as mergeProps13 }`.
  *
  * When `source` is given, only imports from that module are considered.
  */
 export function findNamedImportBinding(ast: t.File, importedName: string, source?: string): string | null {
   for (const node of ast.program.body) {
-    if (!t.isImportDeclaration(node)) continue;
+    if (!t.isImportDeclaration(node) || node.importKind === "type") continue;
     if (source !== undefined && node.source.value !== source) continue;
     for (const spec of node.specifiers) {
-      if (t.isImportSpecifier(spec) && t.isIdentifier(spec.imported, { name: importedName })) {
+      if (
+        t.isImportSpecifier(spec) &&
+        spec.importKind !== "type" &&
+        t.isIdentifier(spec.imported, { name: importedName })
+      ) {
         return spec.local.name;
       }
     }
@@ -172,11 +176,20 @@ export function replaceCssImportWithNamedImports(
   return false;
 }
 
-/** Add `imports` to the existing import of `source`, or add a new import after the last one. */
+/**
+ * Add named value imports to a compatible declaration, or add a new import after the last one.
+ * Type-only declarations are erased, and namespace imports cannot contain named specifiers.
+ */
 export function upsertNamedImports(ast: t.File, source: string, imports: NamedImport[]): void {
   if (imports.length === 0) return;
 
-  const existing = findImportDeclaration(ast, source);
+  const existing = ast.program.body.find(
+    (node): node is t.ImportDeclaration =>
+      t.isImportDeclaration(node) &&
+      node.source.value === source &&
+      node.importKind !== "type" &&
+      !node.specifiers.some((spec) => t.isImportNamespaceSpecifier(spec)),
+  );
   if (!existing) {
     const importDecl = t.importDeclaration(imports.map(toImportSpecifier), t.stringLiteral(source));
     ast.program.body.splice(findLastImportIndex(ast) + 1, 0, importDecl);
@@ -185,7 +198,11 @@ export function upsertNamedImports(ast: t.File, source: string, imports: NamedIm
 
   for (const entry of imports) {
     const exists = existing.specifiers.some((spec) => {
-      return t.isImportSpecifier(spec) && t.isIdentifier(spec.imported, { name: entry.importedName });
+      return (
+        t.isImportSpecifier(spec) &&
+        spec.importKind !== "type" &&
+        t.isIdentifier(spec.imported, { name: entry.importedName })
+      );
     });
     if (!exists) existing.specifiers.push(toImportSpecifier(entry));
   }

--- a/packages/truss/src/plugin/index.test.ts
+++ b/packages/truss/src/plugin/index.test.ts
@@ -193,13 +193,13 @@ describe("trussPlugin", () => {
     const result = runTransform(plugin, code, `/@fs/${sourcePath}?v=1`);
     expect(n(result?.code ?? "")).toBe(
       n(`
-      import { __injectTrussCSS as _injectTrussCSS2 } from "@homebound/truss/runtime";
       import { Css } from "./Css";
       export const _injectTrussCSS = "occupied";
       export const __injectTrussCSS = "also occupied";
       export const css = { ".late": Css.df.$ };
       import "virtual:truss:test-css";
-      _injectTrussCSS2("/* @truss arbitrary:start */\\n.late {\\n  display: flex;\\n}\\n/* @truss arbitrary:end */", { source: ${JSON.stringify(sourcePath)} });
+      import { __injectTrussCSS as __injectTrussCSS_1 } from "@homebound/truss/runtime";
+      __injectTrussCSS_1("/* @truss arbitrary:start */\\n.late {\\n  display: flex;\\n}\\n/* @truss arbitrary:end */", { source: ${JSON.stringify(sourcePath)} });
     `),
     );
     expect(getTestCssModule(plugin)).toBe(bootstrap);
@@ -211,6 +211,77 @@ describe("trussPlugin", () => {
       import { __injectTrussCSS } from "@homebound/truss/runtime";
       __injectTrussCSS("/* @truss arbitrary:start */\\n.late {\\n  display: flex;\\n}\\n/* @truss arbitrary:end */", {"source":${JSON.stringify(sourcePath)}});
     `),
+    );
+  });
+
+  test.each([
+    {
+      name: "a type-only declaration",
+      imports: 'import type { RuntimeStyleCss } from "@homebound/truss/runtime";',
+      expectedImports: 'import type { RuntimeStyleCss } from "@homebound/truss/runtime";',
+      addedImport: 'import { __injectTrussCSS } from "@homebound/truss/runtime";',
+      helper: "__injectTrussCSS",
+    },
+    {
+      name: "a type-only helper declaration",
+      imports: 'import type { __injectTrussCSS } from "@homebound/truss/runtime";',
+      expectedImports: 'import type { __injectTrussCSS } from "@homebound/truss/runtime";',
+      addedImport: 'import { __injectTrussCSS as __injectTrussCSS_1 } from "@homebound/truss/runtime";',
+      helper: "__injectTrussCSS_1",
+    },
+    {
+      name: "an inline type-only helper specifier",
+      imports: 'import { type __injectTrussCSS } from "@homebound/truss/runtime";',
+      expectedImports:
+        'import { type __injectTrussCSS, __injectTrussCSS as __injectTrussCSS_1 } from "@homebound/truss/runtime";',
+      addedImport: "",
+      helper: "__injectTrussCSS_1",
+    },
+    {
+      name: "a namespace import",
+      imports: 'import * as runtime from "@homebound/truss/runtime";',
+      expectedImports: 'import * as runtime from "@homebound/truss/runtime";',
+      addedImport: 'import { __injectTrussCSS } from "@homebound/truss/runtime";',
+      helper: "__injectTrussCSS",
+    },
+    {
+      name: "an existing aliased value import",
+      imports: 'import { __injectTrussCSS as inject } from "@homebound/truss/runtime";',
+      expectedImports: 'import { __injectTrussCSS as inject } from "@homebound/truss/runtime";',
+      addedImport: "",
+      helper: "inject",
+    },
+    {
+      name: "a value declaration after a type-only declaration",
+      imports: `import type { RuntimeStyleCss } from "@homebound/truss/runtime";
+        import { RuntimeStyle } from "@homebound/truss/runtime";`,
+      expectedImports: `import type { RuntimeStyleCss } from "@homebound/truss/runtime";
+        import { RuntimeStyle, __injectTrussCSS } from "@homebound/truss/runtime";`,
+      addedImport: "",
+      helper: "__injectTrussCSS",
+    },
+  ])("test mode injects arbitrary CSS with $name", (scenario) => {
+    // Given an application mapping without atomic rules
+    const root = createTempRoot();
+    writeMapping(join(root, "src", "Css.json"), {});
+    // And a test-mode plugin that injects CSS when the module evaluates
+    const plugin = trussPlugin({ mapping: "./src/Css.json" });
+    invokeHook(plugin.configResolved, {}, { root, command: "serve", mode: "test" });
+    invokeHook(plugin.buildStart, {});
+    // And an arbitrary CSS module with an existing runtime import
+    const sourcePath = join(root, "src", "Imports.css.ts");
+    const code = `${scenario.imports}\nexport const css = { ".target": "color: red;" };`;
+
+    const result = runTransform(plugin, code, sourcePath);
+
+    expect(n(result?.code ?? "")).toBe(
+      n(`
+        ${scenario.expectedImports}
+        export const css = { ".target": "color: red;" };
+        import "virtual:truss:test-css";
+        ${scenario.addedImport}
+        ${scenario.helper}("/* @truss arbitrary:start */\\n.target {\\n  color: red;\\n}\\n/* @truss arbitrary:end */", { source: ${JSON.stringify(sourcePath)} });
+      `),
     );
   });
 

--- a/packages/truss/src/plugin/index.ts
+++ b/packages/truss/src/plugin/index.ts
@@ -3,9 +3,10 @@ import { resolve, dirname, isAbsolute, join } from "path";
 import { createHash } from "crypto";
 import { rewriteCssTsImports } from "./rewrite-css-ts-imports";
 import { createTrussTransformSession } from "./transform-session";
-import { annotateArbitraryCssBlock } from "./merge-css";
+import { annotateArbitraryCssBlock } from "../truss-css";
 import { rootSpacingPreludeCss } from "../spacing-css-var";
 import { generate, parseModule, traverse } from "./babel-utils";
+import { findNamedImportBinding, reservePreferredName, upsertNamedImports } from "./ast-utils";
 import * as t from "@babel/types";
 
 export interface TrussPluginOptions {
@@ -36,6 +37,8 @@ export interface TrussVitePlugin {
 const VIRTUAL_CSS_PREFIX = "\0truss-css:";
 const VIRTUAL_TEST_CSS_PREFIX = "\0truss-test-css:";
 const CSS_TS_QUERY = "?truss-css";
+const RUNTIME_MODULE = "@homebound/truss/runtime";
+const INJECT_CSS_HELPER = "__injectTrussCSS";
 
 /** Placeholder injected into HTML during build; replaced with the hashed CSS filename in generateBundle. */
 const TRUSS_CSS_PLACEHOLDER = "__TRUSS_CSS_HASH__";
@@ -241,7 +244,7 @@ __injectTrussCSS(${JSON.stringify(css)}, ${JSON.stringify(options)});
       }
 
       if (id.startsWith(VIRTUAL_TEST_CSS_PREFIX)) {
-        const sourcePath = resolve(id.slice(VIRTUAL_TEST_CSS_PREFIX.length)).replace(/\\/g, "/");
+        const sourcePath = canonicalSourcePath(id.slice(VIRTUAL_TEST_CSS_PREFIX.length));
         session.updateArbitraryCssRegistry(sourcePath, readFileSync(sourcePath, "utf8"));
         const css = annotateArbitraryCssBlock(session.getArbitraryCss(sourcePath));
         return `
@@ -305,31 +308,7 @@ __injectTrussCSS(${JSON.stringify(css)}, ${JSON.stringify({ source: sourcePath }
         session.updateArbitraryCssRegistry(fileId, code);
         if (isTest) {
           const css = annotateArbitraryCssBlock(session.getArbitraryCss(fileId));
-          const ast = parseModule(transformedCode, fileId);
-          traverse(ast, {
-            Program(path) {
-              const inject = path.scope.generateUidIdentifier("injectTrussCSS");
-              path.unshiftContainer(
-                "body",
-                t.importDeclaration(
-                  [t.importSpecifier(inject, t.identifier("__injectTrussCSS"))],
-                  t.stringLiteral("@homebound/truss/runtime"),
-                ),
-              );
-              path.pushContainer(
-                "body",
-                t.expressionStatement(
-                  t.callExpression(inject, [
-                    t.stringLiteral(css),
-                    t.objectExpression([
-                      t.objectProperty(t.identifier("source"), t.stringLiteral(resolve(fileId).replace(/\\/g, "/"))),
-                    ]),
-                  ]),
-                ),
-              );
-            },
-          });
-          return { code: generate(ast, { sourceFileName: fileId }).code, map: null };
+          return { code: appendTestCssInjection(transformedCode, fileId, css), map: null };
         }
         return importsOnlyResult;
       }
@@ -412,6 +391,43 @@ function stripQueryAndHash(id: string): string {
 
 function isNodeModulesFile(filePath: string): boolean {
   return filePath.replace(/\\/g, "/").includes("/node_modules/");
+}
+
+/** Absolute, forward-slashed path, matching the arbitrary CSS registry keys on every platform. */
+function canonicalSourcePath(filePath: string): string {
+  return resolve(filePath).replace(/\\/g, "/");
+}
+
+/**
+ * Append an `__injectTrussCSS` call so a `.css.ts` module delivers its compiled CSS when it
+ * evaluates in tests, including through dynamic imports the import rewrite cannot see.
+ *
+ * Reuses an existing runtime import of the helper, otherwise reserves a collision-free local
+ * name the same way the main transform does, so `export const __injectTrussCSS` in the module
+ * still works.
+ */
+function appendTestCssInjection(code: string, fileId: string, css: string): string {
+  const ast = parseModule(code, fileId);
+  // Module-scope names, so the injected import can avoid collisions
+  let usedTopLevelNames = new Set<string>();
+  traverse(ast, {
+    Program(path) {
+      usedTopLevelNames = new Set(Object.keys(path.scope.bindings));
+      path.stop();
+    },
+  });
+  const existing = findNamedImportBinding(ast, INJECT_CSS_HELPER, RUNTIME_MODULE);
+  const localName = existing ?? reservePreferredName(usedTopLevelNames, INJECT_CSS_HELPER);
+  if (!existing) upsertNamedImports(ast, RUNTIME_MODULE, [{ importedName: INJECT_CSS_HELPER, localName }]);
+  ast.program.body.push(
+    t.expressionStatement(
+      t.callExpression(t.identifier(localName), [
+        t.stringLiteral(css),
+        t.objectExpression([t.objectProperty(t.identifier("source"), t.stringLiteral(canonicalSourcePath(fileId)))]),
+      ]),
+    ),
+  );
+  return generate(ast, { sourceFileName: fileId }).code;
 }
 
 export type { TrussMapping, TrussMappingEntry } from "./types";

--- a/packages/truss/src/plugin/merge-css.test.ts
+++ b/packages/truss/src/plugin/merge-css.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
-import { parseTrussCss, mergeTrussCss, type ParsedTrussCss } from "./merge-css";
+import { mergeTrussCss } from "./merge-css";
+import { parseTrussCss, type ParsedTrussCss } from "../truss-css";
 
 describe("parseTrussCss", () => {
   test("parses rules with priority annotations", () => {

--- a/packages/truss/src/plugin/merge-css.ts
+++ b/packages/truss/src/plugin/merge-css.ts
@@ -3,9 +3,6 @@ import { atRulePrelude, compareRuleSortKeys, ruleSortKey } from "../css-order";
 import { annotateArbitraryCssBlock, parseTrussCss } from "../truss-css";
 import type { ParsedArbitraryCssBlock, ParsedCssRule, ParsedPropertyDeclaration, ParsedTrussCss } from "../truss-css";
 
-export { annotateArbitraryCssBlock, parseTrussCss } from "../truss-css";
-export type { ParsedArbitraryCssBlock, ParsedCssRule, ParsedPropertyDeclaration, ParsedTrussCss } from "../truss-css";
-
 /**
  * Read and parse an annotated truss.css file from disk.
  *

--- a/packages/truss/src/plugin/priority.ts
+++ b/packages/truss/src/plugin/priority.ts
@@ -20,9 +20,6 @@ import {
 import { WHEN_RELATIONSHIPS } from "./when-relationships";
 import type { AtomicRule } from "./emit-css";
 
-export { compareClassNames, compareRuleSortKeys, ruleSortKey } from "../css-order";
-export type { RuleSortKey, WidthInterval } from "../css-order";
-
 /**
  * Compute the numeric priority for a single AtomicRule.
  *

--- a/packages/truss/src/plugin/transform-session.ts
+++ b/packages/truss/src/plugin/transform-session.ts
@@ -2,13 +2,8 @@ import { resolve } from "path";
 import { generateCssText, type AtomicRule } from "./emit-css";
 import { transformCssTs } from "./transform-css";
 import { transformTruss, type TransformResult, type TransformTrussOptions } from "./transform";
-import {
-  annotateArbitraryCssBlock,
-  mergeTrussCss,
-  parseTrussCss,
-  readTrussCss,
-  type ParsedTrussCss,
-} from "./merge-css";
+import { mergeTrussCss, readTrussCss } from "./merge-css";
+import { annotateArbitraryCssBlock, parseTrussCss, type ParsedTrussCss } from "../truss-css";
 import { loadMapping } from "./mapping-utils";
 import type { TrussMapping } from "./types";
 import { rootSpacingPreludeCss } from "../spacing-css-var";

--- a/packages/truss/src/runtime-css.ts
+++ b/packages/truss/src/runtime-css.ts
@@ -1,7 +1,8 @@
 import { atRulePrelude, compareClassNames, compareRuleSortKeys, ruleSortKey, type RuleSortKey } from "./css-order";
 import { parseTrussCss } from "./truss-css";
 
-interface InjectionOptions {
+/** Options for `__injectTrussCSS`; the plugin passes these from its generated test modules. */
+export interface InjectionOptions {
   /** Canonical source path for ordering and deduplicating application arbitrary CSS. */
   source?: string;
   /** Libraries use 0 and application modules use 1, matching the production merge. */

--- a/packages/truss/src/runtime.ts
+++ b/packages/truss/src/runtime.ts
@@ -9,7 +9,7 @@ import {
 
 export { invertMediaQuery as __invertTrussMediaQuery } from "./media-query";
 export { maybeCssVar } from "./css-custom-property";
-export { __injectTrussCSS } from "./runtime-css";
+export { __injectTrussCSS, type InjectionOptions } from "./runtime-css";
 
 /** A compact source label for a Truss CSS expression, used in debug mode. */
 export class TrussDebugInfo {


### PR DESCRIPTION
## Context

Stacked on #284. This PR contains only the follow-up module cleanup and import-handling fixes, not the original ordered-CSS implementation. Merge after #284 and retarget to main as appropriate.

## Changes

- Extract `.css.ts` test injection into a dedicated helper that reuses existing runtime value imports and reserves collision-free names.
- Fix two edge cases in the shared import utilities: type-only imports must not be reused for runtime calls, and named specifiers cannot be appended to namespace imports.
- Keep type-only declarations intact and select a compatible value-import declaration, or create a separate declaration when necessary. Inline type-only specifiers are also excluded from helper lookup and value-import dedupe.
- Import shared CSS parsing and ordering definitions directly instead of retaining forwarding exports in the old plugin modules.
- Centralize canonical source-path handling within the plugin, update the shared comparator documentation, and export the injection options type alongside the helper.

## Why The Import Fixes Matter

Appending the helper to `import type { RuntimeStyleCss }` causes TypeScript to erase its import while retaining the injected call. Appending it to `import * as runtime` produces invalid JavaScript syntax. Both cases now preserve the original import and create a valid runtime binding.

## Verification

- Added six full-output regression cases: a type-only declaration, a type-only helper declaration, an inline type-only helper specifier, a namespace import, an existing aliased value import, and a value declaration following a type-only declaration.
- Five cases reproduced failures before the fix; all six now pass.
- `yarn test`: 506 passed, 1 existing skipped, including all 394 Truss tests.
- `yarn tsc --build`: passed.
- Formatting checks for the import-helper fix and regression tests: passed.