### PR TITLE
refactor: Drop the Babel 7 CJS default-import shim.

### DIFF
--- a/packages/truss/src/plugin/babel-utils.ts
+++ b/packages/truss/src/plugin/babel-utils.ts
@@ -1,13 +1,9 @@
-import _generate from "@babel/generator";
+import generate from "@babel/generator";
 import { parse } from "@babel/parser";
-import _traverse from "@babel/traverse";
+import traverse from "@babel/traverse";
 import * as t from "@babel/types";
 
-// Babel packages are CJS today; normalize default interop across loaders.
-export const generate = ((_generate as unknown as { default?: typeof _generate }).default ??
-  _generate) as typeof _generate;
-export const traverse = ((_traverse as unknown as { default?: typeof _traverse }).default ??
-  _traverse) as typeof _traverse;
+export { generate, traverse };
 
 /** Parse a TypeScript/JSX module with the plugin's standard parser options. */
 export function parseModule(code: string, filename: string): t.File {


### PR DESCRIPTION
Babel 8 packages are ESM, so the default exports of @babel/generator and @babel/traverse no longer need the `.default ?? module` interop that Babel 7's CJS builds required across loaders. babel-utils.ts now re-exports the default imports directly. No behaviour change.