### PR TITLE
fix: Mark the Css import type-only when only types remain.

### DIFF
--- a/packages/truss/src/plugin/ast-utils.ts
+++ b/packages/truss/src/plugin/ast-utils.ts
@@ -77,6 +77,11 @@ export function isCssMethodCall(node: t.CallExpression, binding: string, method:
 
 /**
  * Remove the Css import specifier. If it was the only specifier, remove the whole import.
+ *
+ * When only type specifiers remain, the declaration is marked type-only so the bundler
+ * erases it. I.e. `import { Css, type Properties } from "~/Css"` becomes
+ * `import type { Properties } from "~/Css"`, because verbatimModuleSyntax keeps a
+ * `import { type Properties }` declaration as a side-effect import of the Css module.
  */
 export function removeCssImport(ast: t.File, cssBinding: string): void {
   for (let i = 0; i < ast.program.body.length; i++) {
@@ -90,6 +95,7 @@ export function removeCssImport(ast: t.File, cssBinding: string): void {
       ast.program.body.splice(i, 1);
     } else {
       node.specifiers.splice(cssSpecIndex, 1);
+      hoistTypeOnlyImportKind(node);
     }
     return;
   }
@@ -306,6 +312,22 @@ export function memberPropertyName(node: t.MemberExpression): string | null {
   if (!node.computed && t.isIdentifier(node.property)) return node.property.name;
   if (node.computed && t.isStringLiteral(node.property)) return node.property.value;
   return null;
+}
+
+/**
+ * Mark a declaration type-only when every remaining specifier is type-only.
+ *
+ * I.e. `import { type Properties } from "~/Css"` becomes `import type { Properties } from "~/Css"`.
+ * The per-specifier `type` markers are cleared, since `import type { type Properties }` is invalid.
+ */
+function hoistTypeOnlyImportKind(node: t.ImportDeclaration): void {
+  if (node.importKind === "type") return;
+  const typeOnly = node.specifiers.every((spec) => t.isImportSpecifier(spec) && spec.importKind === "type");
+  if (!typeOnly) return;
+  node.importKind = "type";
+  for (const spec of node.specifiers) {
+    if (t.isImportSpecifier(spec)) spec.importKind = null;
+  }
 }
 
 function toImportSpecifier(entry: NamedImport): t.ImportSpecifier {

--- a/packages/truss/src/plugin/transform.test.ts
+++ b/packages/truss/src/plugin/transform.test.ts
@@ -1060,7 +1060,7 @@ describe("transform", () => {
 
     expectTrussTransform(code).toHaveTrussOutput(
       `
-      import { type Typography } from "./Css";
+      import type { Typography } from "./Css";
       const __typography = {
         f24: { fontSize: "f24" },
         f18: { fontSize: "f18" },
@@ -1108,7 +1108,7 @@ describe("transform", () => {
     `,
     ).toHaveTrussOutput(
       `
-      import { type Typography } from "./Css";
+      import type { Typography } from "./Css";
       const __typography = {
         f24: { fontSize: "f24" },
         f18: { fontSize: "f18" },
@@ -1197,6 +1197,52 @@ describe("transform", () => {
     `).toHaveTrussOutput(
       `
       const s = { display: "df" };
+    `,
+      `
+      .df {
+        display: flex;
+      }
+    `,
+    );
+  });
+
+  test("type-only remainder becomes a type-only import", () => {
+    // Given a file that imports Css alongside a type from the same module
+    // And the type is still referenced in an annotation, so its binding must survive
+    expectTrussTransform(`
+      import { Css, type Properties } from "./Css";
+      export function Foo(p: Properties) {
+        return Css.df.$;
+      }
+    `).toHaveTrussOutput(
+      `
+      import type { Properties } from "./Css";
+      export function Foo(p: Properties) {
+        return { display: "df" };
+      }
+    `,
+      `
+      .df {
+        display: flex;
+      }
+    `,
+    );
+  });
+
+  test("value remainder keeps the import runnable", () => {
+    // Given a file that imports Css alongside both a value and a type from the same module
+    // And the value keeps the declaration a real import, so it must not become type-only
+    expectTrussTransform(`
+      import { Css, Palette, type Properties } from "./Css";
+      export function Foo(p: Properties) {
+        return [Css.df.$, Palette.Black];
+      }
+    `).toHaveTrussOutput(
+      `
+      import { Palette, type Properties } from "./Css";
+      export function Foo(p: Properties) {
+        return [{ display: "df" }, Palette.Black];
+      }
     `,
       `
       .df {


### PR DESCRIPTION
Removing the Css specifier left `import { type Properties } from "~/Css"` behind. Under verbatimModuleSyntax that declaration is preserved as a side-effect import, so the Css module ran and the whole generated builder landed in the client bundle. The declaration is now marked type-only, which bundlers erase, while a remaining value specifier still emits a real import.