### PR TITLE
fix: Fail production builds on unsupported patterns.

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,9 @@ npm install --save-dev @homebound/truss
    });
    ```
 
+   - In production builds with `vite build`, unsupported patterns (including unknown abbreviations) fail the build with a source location. Override with `unsupportedPattern: "warn"`.
+   - In dev builds with `vite dev`, unsupported patterns show a terminal warning and error overlay without stopping compilation. Override with `unsupportedPattern: "error"`.
+
    If the library builds with **tsup** (or esbuild), use the esbuild plugin:
 
    ```ts
@@ -265,7 +268,7 @@ npm install --save-dev @homebound/truss
    });
    ```
 
-   Both plugins transform `Css.*.$` expressions to plain objects and emit a `truss.css` file with annotations that enable correct merging. `.css.ts` arbitrary-selector rules are also emitted into `truss.css` and preserved as opaque blocks during app-level merges.
+   Both plugins transform `Css.*.$` expressions to plain objects and emit a `truss.css` file with annotations that enable correct merging. `.css.ts` arbitrary-selector rules are also emitted into `truss.css` and preserved as opaque blocks during app-level merges. The esbuild plugin also rejects unsupported patterns.
 
    For Vitest, use the Vite plugin:
 

--- a/packages/truss/package.json
+++ b/packages/truss/package.json
@@ -40,6 +40,7 @@
     "css-tree": "^3.2.1",
     "csstype": "^3.2.3",
     "jiti": "^2.7.0",
+    "rollup": "^4.34.8",
     "ts-poet": "^6.12.0"
   },
   "peerDependencies": {

--- a/packages/truss/src/plugin/chain-nodes.ts
+++ b/packages/truss/src/plugin/chain-nodes.ts
@@ -32,8 +32,8 @@ export interface ElseChainNode {
 /**
  * A chain pattern the compiler cannot resolve.
  *
- * Resolution catches it per node and records an error segment in the chain, which transform
- * reports as a `console.error` in the output and transform-css as a CSS comment.
+ * Resolution catches it per node and records an error segment for transforms to report to the
+ * build tool. Non-fatal transforms also retain a `console.error` or CSS comment in the output.
  */
 export class UnsupportedPatternError extends Error {
   constructor(message: string) {

--- a/packages/truss/src/plugin/diagnostic.ts
+++ b/packages/truss/src/plugin/diagnostic.ts
@@ -1,0 +1,15 @@
+import { type Node } from "@babel/types";
+
+/** A compiler diagnostic with the source location used by build tools. */
+export class Diagnostic extends Error {
+  id: string;
+  loc?: { file: string; line: number; column: number };
+
+  constructor(message: string, filename: string, node: Node) {
+    const start = node.loc?.start;
+    const location = start ? `${filename}:${start.line}:${start.column + 1}` : filename;
+    super(`${location}: ${message}`);
+    this.id = filename;
+    this.loc = start ? { file: filename, line: start.line, column: start.column } : undefined;
+  }
+}

--- a/packages/truss/src/plugin/esbuild-plugin.test.ts
+++ b/packages/truss/src/plugin/esbuild-plugin.test.ts
@@ -14,6 +14,32 @@ afterEach(() => {
 });
 
 describe("trussEsbuildPlugin", () => {
+  test.each([
+    {
+      file: "Button.tsx",
+      source: "const el = <div css={Css.markerOf().$} />;",
+      message: "markerOf() requires exactly one argument (a marker variable)",
+    },
+    {
+      file: "Button.css.ts",
+      source: "export const css = { ...styles };",
+      message: "spread elements in css.ts export",
+    },
+  ])("rejects diagnostics from $file: $source", (scenario) => {
+    // Given a mapping without atomic abbreviations
+    const root = createTempRoot();
+    writeMapping(join(root, "src", "Css.json"), {});
+    // And an esbuild plugin whose source and arbitrary CSS transforms must both reject diagnostics
+    const plugin = trussEsbuildPlugin({ mapping: join(root, "src", "Css.json") });
+    const { onLoadCallback } = setupPlugin(plugin, join(root, "dist"));
+    // And a module containing an unsupported pattern
+    const id = join(root, "src", scenario.file);
+    const contents = `import { Css } from "./Css";\n${scenario.source}`;
+
+    // When esbuild loads the module, then it rejects the unsupported pattern
+    expect(() => onLoadCallback({ path: id, contents })).toThrow(scenario.message);
+  });
+
   test("transforms source files via onLoad", () => {
     const root = createTempRoot();
     writeMapping(join(root, "src", "Css.json"), {

--- a/packages/truss/src/plugin/esbuild-plugin.ts
+++ b/packages/truss/src/plugin/esbuild-plugin.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync, mkdirSync } from "fs";
 import { resolve, join } from "path";
 import { createTrussTransformSession } from "./transform-session";
+import { type DiagnosticOptions } from "./types";
 
 export interface TrussEsbuildPluginOptions {
   /** Path to the Css.json mapping file (relative to cwd or absolute). */
@@ -27,6 +28,11 @@ export interface TrussEsbuildPluginOptions {
  * ```
  */
 export function trussEsbuildPlugin(opts: TrussEsbuildPluginOptions) {
+  const diagnostics: DiagnosticOptions = {
+    onDiagnostic(error) {
+      throw error;
+    },
+  };
   const session = createTrussTransformSession({
     mappingPath() {
       return resolve(process.cwd(), opts.mapping);
@@ -45,13 +51,13 @@ export function trussEsbuildPlugin(opts: TrussEsbuildPluginOptions) {
         const code = readFileSync(args.path, "utf8");
 
         if (args.path.endsWith(".css.ts")) {
-          session.updateArbitraryCssRegistry(args.path, code);
+          session.updateArbitraryCssRegistry(args.path, code, diagnostics);
           return { contents: code, loader: loaderForPath(args.path) };
         }
 
         if (!code.includes("Css") && !code.includes("css=")) return undefined;
 
-        const result = session.transformCode(code, args.path);
+        const result = session.transformCode(code, args.path, diagnostics);
         if (!result) return undefined;
 
         return { contents: result.code, loader: loaderForPath(args.path) };

--- a/packages/truss/src/plugin/index.test.ts
+++ b/packages/truss/src/plugin/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { dirname, join, resolve } from "path";
 import { tmpdir } from "os";
@@ -14,6 +14,114 @@ afterEach(() => {
 });
 
 describe("trussPlugin", () => {
+  test("production source typos fail with a location and suggestion", () => {
+    // Given a mapping with accent but no acent abbreviation
+    const root = createTempRoot();
+    writeMapping(join(root, "src", "Css.json"), { accent: { kind: "static", defs: { color: "red" } } });
+    // And a build using the default unsupported-pattern policy
+    const plugin = trussPlugin({ mapping: "./src/Css.json" });
+    invokeHook(plugin.configResolved, {}, { root, command: "build", mode: "production" });
+    invokeHook(plugin.buildStart, {});
+    // And a component with a misspelled abbreviation on its second line
+    const id = join(root, "src", "Button.tsx");
+    const code = 'import { Css } from "./Css";\nconst el = <div css={Css.acent.$} />;';
+
+    // When the component is transformed, then the build fails at the original source line
+    expect(() => runTransform(plugin, code, id)).toThrow(
+      `${id}:2:22: [truss] Unsupported pattern: Unknown abbreviation "acent". Did you mean "accent"?`,
+    );
+  });
+
+  test("production rejects unsupported .css.ts in virtual load and transform", () => {
+    // Given a mapping without atomic abbreviations
+    const root = createTempRoot();
+    writeMapping(join(root, "src", "Css.json"), {});
+    // And an arbitrary CSS file with an unsupported spread
+    const id = join(root, "src", "Button.css.ts");
+    const code = "export const css = { ...styles };";
+    writeFileSync(id, code);
+    // And a build using the default unsupported-pattern policy
+    const plugin = trussPlugin({ mapping: "./src/Css.json" });
+    invokeHook(plugin.configResolved, {}, { root, command: "build", mode: "production" });
+    invokeHook(plugin.buildStart, {});
+    const virtualId = invokeHook(plugin.resolveId, {}, "./Button.css.ts?truss-css", join(root, "src", "App.tsx"));
+    expect(virtualId).toBe("\0truss-css:" + id.slice(0, -3));
+
+    // When Vite loads then transforms the CSS, then both hooks reject the spread
+    expect(() => invokeHook(plugin.load, {}, virtualId)).toThrow("spread elements in css.ts export");
+    expect(() => runTransform(plugin, code, id)).toThrow("spread elements in css.ts export");
+  });
+
+  test("dev warns and sends an overlay for a non-typo error, then accepts corrected source", () => {
+    // Given a mapping with a valid accent abbreviation
+    const root = createTempRoot();
+    writeMapping(join(root, "src", "Css.json"), { accent: { kind: "static", defs: { color: "red" } } });
+    // And a plugin using the default serve policy
+    const plugin = trussPlugin({ mapping: "./src/Css.json" });
+    invokeHook(plugin.configResolved, {}, { root, command: "serve", mode: "development" });
+    invokeHook(plugin.buildStart, {});
+    // And a dev socket whose server close handler is always cleaned up
+    const send = vi.fn();
+    const on = vi.fn<(event: string, callback: () => void) => void>();
+    invokeHook(plugin.configureServer, {}, { middlewares: { use() {} }, ws: { send }, httpServer: { on } });
+    // And a component whose markerOf call is missing its required marker argument
+    const id = join(root, "src", "Button.tsx");
+    const code = 'import { Css } from "./Css";\nconst el = <div css={Css.markerOf().$} />;';
+    const warn = vi.fn();
+
+    try {
+      // When the component is transformed, then compilation continues with a located Error warning
+      const result = invokeHook(plugin.transform, { warn }, code, id);
+      expect(result).toMatchObject({ code: expect.any(String) });
+      expect(warn).toHaveBeenCalledTimes(1);
+      const warning = warn.mock.calls[0][0];
+      expect(warning).toBeInstanceOf(Error);
+      expect(warning).toMatchObject({ id, loc: { file: id, line: 2, column: 21 } });
+      expect(warning.message).toBe(
+        `${id}:2:22: [truss] Unsupported pattern: markerOf() requires exactly one argument (a marker variable)`,
+      );
+      // And the dev server receives a Vite error overlay
+      expect(send.mock.calls).toEqual([
+        [
+          {
+            type: "error",
+            err: { message: warning.message, stack: "", id, loc: warning.loc, plugin: "truss" },
+          },
+        ],
+      ]);
+      // And the component is corrected to use the configured accent abbreviation
+      warn.mockClear();
+      send.mockClear();
+      // When Vite transforms the corrected component, then it sends no warning or error overlay
+      const clean = invokeHook(plugin.transform, { warn }, code.replace("Css.markerOf().$", "Css.accent.$"), id);
+      expect(clean).toMatchObject({ code: expect.any(String) });
+      expect(warn).not.toHaveBeenCalled();
+      expect(send).not.toHaveBeenCalled();
+    } finally {
+      for (const [event, close] of on.mock.calls) {
+        if (event === "close") close();
+      }
+    }
+  });
+
+  test("production warn override is nonfatal", () => {
+    // Given a mapping with accent but no acent abbreviation
+    const root = createTempRoot();
+    writeMapping(join(root, "src", "Css.json"), { accent: { kind: "static", defs: { color: "red" } } });
+    // And a production plugin explicitly configured to warn about unsupported patterns
+    const plugin = trussPlugin({ mapping: "./src/Css.json", unsupportedPattern: "warn" });
+    invokeHook(plugin.configResolved, {}, { root, command: "build", mode: "production" });
+    invokeHook(plugin.buildStart, {});
+    // And a component containing a misspelled abbreviation
+    const id = join(root, "src", "Button.tsx");
+    const code = 'import { Css } from "./Css";\nconst el = <div css={Css.acent.$} />;';
+    const warn = vi.fn();
+
+    // When the component is transformed, then the override warns and compilation continues
+    expect(invokeHook(plugin.transform, { warn }, code, id)).toMatchObject({ code: expect.any(String) });
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
   test("uses the configured mapping for library files", () => {
     // Given we have a src/Css.json
     const root = createTempRoot();

--- a/packages/truss/src/plugin/index.ts
+++ b/packages/truss/src/plugin/index.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync, existsSync, readdirSync } from "fs";
 import { resolve, dirname, isAbsolute, join } from "path";
 import { createHash } from "crypto";
+import { type PluginContext } from "rollup";
 import { rewriteCssTsImports } from "./rewrite-css-ts-imports";
 import { createTrussTransformSession } from "./transform-session";
 import { splitArbitraryCss } from "./test-css";
@@ -8,15 +9,20 @@ import { rootSpacingPreludeCss } from "../spacing-css-var";
 import { generate, parseModule, traverse } from "./babel-utils";
 import { findNamedImportBinding, reservePreferredName, upsertNamedImports } from "./ast-utils";
 import * as t from "@babel/types";
+import { type DiagnosticOptions, type TransformDiagnostic } from "./types";
 
 export interface TrussPluginOptions {
   /** Path to the Css.json mapping file used for transforming files (relative to project root or absolute). */
   mapping: string;
   /** Paths to pre-compiled truss.css files from libraries to merge into the app's CSS. */
   libraries?: string[];
+  /** Unsupported patterns fail builds by default; dev transforms warn and keep serving the page. */
+  unsupportedPattern?: "error" | "warn";
 }
 
-// Intentionally loose Vite types so we don't depend on the `vite` package at compile time.
+type DiagnosticContext = Pick<PluginContext, "warn">;
+
+// Use Rollup's context for diagnostics; keep other hooks loose without a Vite compile-time dependency.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface TrussVitePlugin {
   name: string;
@@ -24,8 +30,8 @@ export interface TrussVitePlugin {
   configResolved?: (config: any) => void;
   buildStart?: () => void;
   resolveId?: (source: string, importer: string | undefined) => string | null;
-  load?: (id: string) => string | null;
-  transform?: (code: string, id: string) => { code: string; map: any } | null;
+  load?: (this: DiagnosticContext, id: string) => string | null;
+  transform?: (this: DiagnosticContext, code: string, id: string) => { code: string; map: any } | null;
   configureServer?: (server: any) => void;
   transformIndexHtml?: (html: string) => string;
   handleHotUpdate?: (ctx: any) => void;
@@ -73,6 +79,7 @@ export function trussPlugin(opts: TrussPluginOptions): TrussVitePlugin {
   let debug = false;
   let isTest = false;
   let isBuild = false;
+  let devSocket: { send: (payload: unknown) => void } | undefined;
   const libraryPaths = opts.libraries ?? [];
   /** The hashed CSS filename emitted during generateBundle, used by writeBundle to patch HTML. */
   let emittedCssFileName: string | null = null;
@@ -82,6 +89,13 @@ export function trussPlugin(opts: TrussPluginOptions): TrussVitePlugin {
 
   function mappingPath(): string {
     return resolve(projectRoot || process.cwd(), opts.mapping);
+  }
+
+  /** Connect transform diagnostics to Vite reporting. */
+  function diagnostics(context: DiagnosticContext): DiagnosticOptions {
+    return {
+      onDiagnostic: (error) => reportDiagnostic(context, error),
+    };
   }
 
   const session = createTrussTransformSession({
@@ -118,6 +132,7 @@ export function trussPlugin(opts: TrussPluginOptions): TrussVitePlugin {
       // Skip dev-server setup in test mode — Vitest doesn't start a real HTTP
       // server, so the interval would keep the process alive.
       if (isTest) return;
+      devSocket = server.ws;
 
       // Serve the current collected CSS at the virtual endpoint
       server.middlewares.use((req: any, res: any, next: any) => {
@@ -245,7 +260,7 @@ __injectTrussCSS(${JSON.stringify(payload)});
 
       if (id.startsWith(VIRTUAL_TEST_CSS_PREFIX)) {
         const sourcePath = canonicalSourcePath(id.slice(VIRTUAL_TEST_CSS_PREFIX.length));
-        session.updateArbitraryCssRegistry(sourcePath, readFileSync(sourcePath, "utf8"));
+        session.updateArbitraryCssRegistry(sourcePath, readFileSync(sourcePath, "utf8"), diagnostics(this));
         const payload = {
           arbitraryRules: splitArbitraryCss(session.getArbitraryCss(sourcePath)),
           source: sourcePath,
@@ -267,7 +282,7 @@ __injectTrussCSS(${JSON.stringify(payload)});
 
       // Populate the arbitrary CSS registry on first load; subsequent updates
       // happen in the transform hook when Vite re-transforms the changed file.
-      session.updateArbitraryCssRegistry(sourcePath, sourceCode);
+      session.updateArbitraryCssRegistry(sourcePath, sourceCode, diagnostics(this));
 
       // Return an empty stylesheet to Vite's CSS pipeline — the real CSS is now
       // served via collectCss() (dev: /virtual:truss.css, build: truss-<hash>.css)
@@ -308,7 +323,7 @@ __injectTrussCSS(${JSON.stringify(payload)});
         // Also update the arbitrary CSS registry so HMR picks up changes —
         // the load hook only runs on first resolve, so edits need to refresh
         // the registry here where Vite re-transforms changed files.
-        session.updateArbitraryCssRegistry(fileId, code);
+        session.updateArbitraryCssRegistry(fileId, code, diagnostics(this));
         if (isTest) {
           const css = session.getArbitraryCss(fileId);
           return { code: appendTestCssInjection(transformedCode, fileId, css), map: null };
@@ -323,7 +338,7 @@ __injectTrussCSS(${JSON.stringify(payload)});
 
       // For regular JS/TS modules that still use the DSL, run the full Truss
       // transform after the import rewrite so both behaviors compose.
-      const result = session.transformCode(transformedCode, fileId, { debug, injectCss: isTest });
+      const result = session.transformCode(transformedCode, fileId, { debug, injectCss: isTest, ...diagnostics(this) });
       return result ? { code: result.code, map: result.map } : importsOnlyResult;
     },
 
@@ -361,6 +376,17 @@ __injectTrussCSS(${JSON.stringify(payload)});
       }
     },
   };
+  /** Reject fatal diagnostics; report the rest in the terminal and dev overlay. */
+  function reportDiagnostic(context: DiagnosticContext, error: TransformDiagnostic): void {
+    if ((opts.unsupportedPattern ?? (isBuild ? "error" : "warn")) === "error") {
+      throw error;
+    }
+    context.warn(error);
+    devSocket?.send({
+      type: "error",
+      err: { message: error.message, stack: "", id: error.id, loc: error.loc, plugin: "truss" },
+    });
+  }
 }
 
 function resolveImportPath(source: string, importer: string | undefined, projectRoot: string | undefined): string {

--- a/packages/truss/src/plugin/resolve-chain.ts
+++ b/packages/truss/src/plugin/resolve-chain.ts
@@ -274,6 +274,8 @@ function resolveNode(ctx: ResolveChainCtx, node: ChainNode, context: ResolvedCon
     }
     return [];
   } catch (err) {
+    // Preserve unsupported patterns as error segments so transforms can report them to the build tool.
+    // Production rejects these diagnostics; dev can keep valid segments while reporting the errors.
     if (!(err instanceof UnsupportedPatternError)) throw err;
     return [errorSegment(err.message)];
   }

--- a/packages/truss/src/plugin/resolve-entry.ts
+++ b/packages/truss/src/plugin/resolve-entry.ts
@@ -7,12 +7,13 @@ import type {
 } from "./types";
 import { UnsupportedPatternError } from "./chain-nodes";
 import { cloneConditionContext } from "./condition-context";
+import { UnknownAbbreviationError } from "./unknown-abbreviation";
 
 /** The mapping entry for `abbr`, or an unsupported-pattern error for an unknown abbreviation. */
 export function requireEntry(mapping: TrussMapping, abbr: string): TrussMappingEntry {
   const entry = mapping.abbreviations[abbr];
   if (!entry) {
-    throw new UnsupportedPatternError(`Unknown abbreviation "${abbr}"`);
+    throw new UnknownAbbreviationError(abbr, Object.keys(mapping.abbreviations));
   }
   return entry;
 }

--- a/packages/truss/src/plugin/transform-css.ts
+++ b/packages/truss/src/plugin/transform-css.ts
@@ -1,10 +1,11 @@
 import * as t from "@babel/types";
-import type { TrussMapping } from "./types";
+import { type DiagnosticOptions, type TrussMapping } from "./types";
 import { resolveFullChain } from "./resolve-chain";
 import { extractDollarChain, findCssImportBinding, unwrapExpression } from "./ast-utils";
 import { collectStaticStringBindings, resolveStaticString } from "./css-ts-utils";
 import { camelToKebab } from "./style-entries";
 import { parseModule } from "./babel-utils";
+import { Diagnostic } from "./diagnostic";
 
 /**
  * Transform a `.css.ts` file into a plain CSS string.
@@ -28,7 +29,12 @@ import { parseModule } from "./babel-utils";
  *
  * Returns the generated CSS string.
  */
-export function transformCssTs(code: string, filename: string, mapping: TrussMapping): string {
+export function transformCssTs(
+  code: string,
+  filename: string,
+  mapping: TrussMapping,
+  options: DiagnosticOptions = {},
+): string {
   const ast = parseModule(code, filename);
 
   // Css import is optional — only needed when Css.*.$  chains are used
@@ -37,6 +43,9 @@ export function transformCssTs(code: string, filename: string, mapping: TrussMap
   // Find the `export const css = { ... }` expression
   const cssExport = findNamedCssExportObject(ast);
   if (!cssExport) {
+    options.onDiagnostic?.(
+      new Diagnostic("expected `export const css = { ... }` with an object literal", filename, ast.program),
+    );
     return `/* [truss] ${filename}: expected \`export const css = { ... }\` with an object literal */\n`;
   }
 
@@ -45,19 +54,19 @@ export function transformCssTs(code: string, filename: string, mapping: TrussMap
 
   for (const prop of cssExport.properties) {
     if (t.isSpreadElement(prop)) {
-      rules.push(`/* [truss] unsupported: spread elements in css.ts export */`);
+      rules.push(unsupported("spread elements in css.ts export", prop));
       continue;
     }
 
     if (!t.isObjectProperty(prop)) {
-      rules.push(`/* [truss] unsupported: non-property in css.ts export */`);
+      rules.push(unsupported("non-property in css.ts export", prop));
       continue;
     }
 
     // Key must be a string literal (the CSS selector)
     const selector = objectPropertyStringKey(prop, stringBindings);
     if (selector === null) {
-      rules.push(`/* [truss] unsupported: non-string-literal key in css.ts export */`);
+      rules.push(unsupported("non-string-literal key in css.ts export", prop));
       continue;
     }
 
@@ -72,18 +81,18 @@ export function transformCssTs(code: string, filename: string, mapping: TrussMap
 
     // Otherwise value must be a Css.*.$  expression
     if (!t.isExpression(valueNode)) {
-      rules.push(`/* [truss] unsupported: "${selector}" value is not an expression */`);
+      rules.push(unsupported(`"${selector}" value is not an expression`, valueNode));
       continue;
     }
 
     if (!cssBindingName) {
-      rules.push(`/* [truss] unsupported: "${selector}" — Css.*.$  chain requires a Css import */`);
+      rules.push(unsupported(`"${selector}" — Css.*.$  chain requires a Css import`, valueNode));
       continue;
     }
 
-    const cssResult = resolveCssExpression(valueNode, cssBindingName, mapping, filename);
+    const cssResult = resolveCssExpression(valueNode, cssBindingName, mapping);
     if ("error" in cssResult) {
-      rules.push(`/* [truss] unsupported: "${selector}" — ${cssResult.error} */`);
+      rules.push(unsupported(`"${selector}" — ${cssResult.error}`, valueNode));
       continue;
     }
 
@@ -91,6 +100,12 @@ export function transformCssTs(code: string, filename: string, mapping: TrussMap
   }
 
   return rules.join("\n\n") + "\n";
+
+  /** Report omitted CSS to the build tool and retain a comment for non-fatal transforms. */
+  function unsupported(message: string, node: t.Node): string {
+    options.onDiagnostic?.(new Diagnostic(message, filename, node));
+    return `/* [truss] unsupported: ${message} */`;
+  }
 }
 
 /** Find the object expression in `export const css = { ... }`. */
@@ -161,7 +176,6 @@ function resolveCssExpression(
   node: t.Expression,
   cssBindingName: string,
   mapping: TrussMapping,
-  filename: string,
 ): CssResolution | CssError {
   // The expression must be a `Css.*.$` chain rooted at the Css import
   const chain = extractDollarChain(node, cssBindingName);

--- a/packages/truss/src/plugin/transform-session.ts
+++ b/packages/truss/src/plugin/transform-session.ts
@@ -8,7 +8,7 @@ import { serializeTrussCss } from "./truss-css";
 import { createTestCssPayload } from "./test-css";
 import type { TestCssPayload } from "../test-css";
 import { loadMapping } from "./mapping-utils";
-import type { TrussMapping } from "./types";
+import { type DiagnosticOptions, type TrussMapping } from "./types";
 import { rootSpacingPreludeCss } from "../spacing-css-var";
 import { compareClassNames } from "../css-order";
 
@@ -50,9 +50,13 @@ export function createTrussTransformSession(options: TrussTransformSessionOption
     libraryCache = null;
   }
 
-  function updateArbitraryCssRegistry(sourcePath: string, sourceCode: string): void {
+  function updateArbitraryCssRegistry(
+    sourcePath: string,
+    sourceCode: string,
+    diagnostics: DiagnosticOptions = {},
+  ): void {
     sourcePath = resolve(sourcePath).replace(/\\/g, "/");
-    const css = transformCssTs(sourceCode, sourcePath, ensureMapping()).trim();
+    const css = transformCssTs(sourceCode, sourcePath, ensureMapping(), diagnostics).trim();
     if (css.length > 0) {
       const prev = arbitraryCssRegistry.get(sourcePath);
       arbitraryCssRegistry.set(sourcePath, css);
@@ -135,5 +139,5 @@ export interface TrussTransformSession {
   hasCss: () => boolean;
   reset: () => void;
   transformCode: (code: string, fileId: string, options?: TransformTrussOptions) => TransformResult | null;
-  updateArbitraryCssRegistry: (sourcePath: string, sourceCode: string) => void;
+  updateArbitraryCssRegistry: (sourcePath: string, sourceCode: string, options?: DiagnosticOptions) => void;
 }

--- a/packages/truss/src/plugin/transform.ts
+++ b/packages/truss/src/plugin/transform.ts
@@ -1,7 +1,7 @@
 import type { NodePath } from "@babel/traverse";
 import * as t from "@babel/types";
 import { basename } from "path";
-import type { TrussMapping, ResolvedSegment } from "./types";
+import { type DiagnosticOptions, type TrussMapping, type ResolvedSegment } from "./types";
 import { chainSegments, resolveFullChain, type CssChainReferenceResolver, type ResolvedChain } from "./resolve-chain";
 import { generate, parseModule, traverse } from "./babel-utils";
 import {
@@ -24,6 +24,7 @@ import { collectAtomicRules, generateCssData, type AtomicRule } from "./emit-css
 import { serializeTrussCss } from "./truss-css";
 import { createTestCssPayload } from "./test-css";
 import { buildMaybeIncDeclaration, buildRuntimeLookupDeclaration } from "./emit-style-hash";
+import { Diagnostic } from "./diagnostic";
 import {
   rewriteExpressionSites,
   type ExpressionSite,
@@ -40,7 +41,7 @@ export interface TransformResult {
   rules: Map<string, AtomicRule>;
 }
 
-export interface TransformTrussOptions {
+export interface TransformTrussOptions extends DiagnosticOptions {
   debug?: boolean;
   /** When true, inject `__injectTrussCSS(payload)` call for jsdom/test environments. */
   injectCss?: boolean;
@@ -102,11 +103,19 @@ export function transformTruss(
       }
 
       const resolveCssChainReference = buildCssChainReferenceResolver(path, cssBindingName);
-      const resolvedChain = resolveFullChain({ mapping, cssBindingName, resolveCssChainReference }, chain);
+      const resolvedChain = resolveFullChain(
+        {
+          mapping,
+          cssBindingName,
+          resolveCssChainReference,
+        },
+        chain,
+      );
       sites.push({ path, resolvedChain });
 
       const line = path.node.loc?.start.line ?? null;
       for (const err of resolvedChain.errors) {
+        options.onDiagnostic?.(new Diagnostic(err, filename, path.node));
         errorMessages.push({ message: err, line });
       }
     },

--- a/packages/truss/src/plugin/types.ts
+++ b/packages/truss/src/plugin/types.ts
@@ -1,6 +1,17 @@
 import type * as t from "@babel/types";
 import type { WhenRelationship } from "./when-relationships";
 
+/** A transform error with optional source metadata for build-tool reporting. */
+export interface TransformDiagnostic extends Error {
+  id?: string;
+  loc?: { file: string; line: number; column: number };
+}
+
+/** Report transform diagnostics; the build tool decides whether they are fatal. */
+export interface DiagnosticOptions {
+  onDiagnostic?: (diagnostic: TransformDiagnostic) => void;
+}
+
 /** The shape of the Css.json mapping file consumed by the Vite plugin. */
 export interface TrussMapping {
   increment: number;
@@ -126,12 +137,7 @@ export type CssSegment = StaticSegment | VariableSegment;
 
 /** A resolved chain segment — one abbreviation resolved to its effect on the element. */
 export type ResolvedSegment =
-  | CssSegment
-  | ClassNameSegment
-  | InlineStyleSegment
-  | ComposedSegment
-  | TypographyLookupSegment
-  | ErrorSegment;
+  CssSegment | ClassNameSegment | InlineStyleSegment | ComposedSegment | TypographyLookupSegment | ErrorSegment;
 
 /**
  * A marker segment — not a CSS style, but a directive to attach

--- a/packages/truss/src/plugin/unknown-abbreviation.ts
+++ b/packages/truss/src/plugin/unknown-abbreviation.ts
@@ -1,0 +1,41 @@
+import { UnsupportedPatternError } from "./chain-nodes";
+
+/** An entry name that is absent from the configured abbreviation mapping. */
+export class UnknownAbbreviationError extends UnsupportedPatternError {
+  constructor(abbreviation: string, candidates: string[]) {
+    const suggestion = closestAbbreviation(abbreviation, candidates);
+    super(`Unknown abbreviation "${abbreviation}"${suggestion ? `. Did you mean "${suggestion}"?` : ""}`);
+  }
+}
+
+/**
+ * Find the nearest mapping key within two insertions, deletions, or substitutions.
+ * Each row stores exact Levenshtein distances for prefixes of one candidate.
+ * I.e. abbreviation "acent" and candidate "accent" finish with distance 1.
+ * Equal distances keep the first mapping key; unrelated names yield no suggestion.
+ */
+function closestAbbreviation(abbreviation: string, candidates: string[]): string | undefined {
+  let closest: string | undefined;
+  let bestDistance = 3;
+  for (const candidate of candidates) {
+    if (Math.abs(candidate.length - abbreviation.length) >= bestDistance) continue;
+    let previous = Array.from({ length: candidate.length + 1 }, (_, index) => index);
+    for (let i = 1; i <= abbreviation.length; i++) {
+      const current = [i];
+      for (let j = 1; j <= candidate.length; j++) {
+        current[j] = Math.min(
+          current[j - 1] + 1,
+          previous[j] + 1,
+          previous[j - 1] + (abbreviation[i - 1] === candidate[j - 1] ? 0 : 1),
+        );
+      }
+      previous = current;
+    }
+    const distance = previous[candidate.length];
+    if (distance < bestDistance) {
+      closest = candidate;
+      bestDistance = distance;
+    }
+  }
+  return closest;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -533,6 +533,7 @@ __metadata:
     jiti: "npm:^2.7.0"
     jsdom: "npm:^30.0.1"
     react: "npm:^19.2.8"
+    rollup: "npm:^4.34.8"
     ts-poet: "npm:^6.12.0"
     tsup: "npm:^8.5.1"
     typescript: "npm:^6.0.3"


### PR DESCRIPTION
## Summary
- Report unsupported chain patterns and `.css.ts` restrictions through a shared, source-located diagnostic callback instead of silently omitting styles in production.
- Fail Vite production builds by default while keeping dev transforms non-fatal with terminal warnings and error overlays. Add `unsupportedPattern: "error" | "warn"` to override the Vite policy.
- Reject unsupported patterns in esbuild/tsup builds and suggest nearby mapping keys for unknown abbreviations.
- Type warning contexts with `Pick<PluginContext, "warn">` and document the defaults.

## Validation
- `yarn workspace @homebound/truss test`: 541 tests passed.
- `yarn build`: TypeScript, JavaScript bundles, and declaration generation passed.
- Regression coverage includes unknown names, invalid chain calls, `.css.ts` structural and expression restrictions, transform/load paths, dev reporting, explicit policy overrides, and clean transforms.