### PR TITLE
fix: Omit rule annotations from application CSS builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,17 @@ Notes:
 - `mapping` is required and should point to the single `Css.json` you want to compile against.
 - `libraries` lists paths to pre-compiled `truss.css` files that will be merged with the app's own generated CSS. Rules are deduplicated by class name and sorted by priority to produce a correct unified stylesheet.
 
+### CSS Annotations
+
+Truss metadata comments in emitted CSS, such as `/* @truss p:3000 c:accent */`, let consuming applications sort and deduplicate rules from library stylesheets.
+
+- **Vite:** Dev stylesheets and library builds retain annotations. Use Vite's `build.lib` setting when building a library. Application builds omit annotations, regardless of `mode` or `build.cssMinify`.
+- **esbuild / tsup:** The plugin produces library CSS and always retains annotations.
+
+Application builds omit generated annotations after merging library CSS. User-authored comments are preserved.
+
+**Unannotated CSS cannot be used as library input through `libraries`.** Publish annotated `truss.css` for downstream merging, and omit annotations only from the final application stylesheet.
+
 ### Plugin Comparison
 
 Truss ships two build plugins. Both transform `Css.*.$` expressions into plain objects and emit a `truss.css` file, but they target different build tools and have different feature sets.

--- a/packages/truss/src/plugin/index.test.ts
+++ b/packages/truss/src/plugin/index.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { dirname, join, resolve } from "path";
 import { tmpdir } from "os";
+import { createHash } from "crypto";
 import { trussPlugin } from "./index";
 
 const tempDirs: string[] = [];
@@ -14,6 +15,117 @@ afterEach(() => {
 });
 
 describe("trussPlugin", () => {
+  test.each([
+    { command: "build", mode: "production", lib: false, expected: false },
+    { command: "build", mode: "development", lib: false, expected: false },
+    { command: "build", mode: "production", lib: { entry: "src/index.ts" }, expected: true },
+    { command: "serve", mode: "development", lib: false, expected: true },
+  ])("annotation policy: $command $mode lib=$lib", (scenario) => {
+    // Given a mapping with a flex rule
+    const root = createTempRoot();
+    writeMapping(join(root, "src", "Css.json"), { df: { kind: "static", defs: { display: "flex" } } });
+    // And a plugin configured for this output type without CSS minification
+    const plugin = trussPlugin({ mapping: "./src/Css.json" });
+    invokeHook(
+      plugin.configResolved,
+      {},
+      {
+        root,
+        command: scenario.command,
+        mode: scenario.mode,
+        build: { lib: scenario.lib, cssMinify: false },
+      },
+    );
+    invokeHook(plugin.buildStart, {});
+    // And an application module using the flex rule
+    runTransform(plugin, 'import { Css } from "./Css"; const s = Css.df.$;', join(root, "src", "App.tsx"));
+
+    // When the stylesheet is served or emitted
+    let css = "";
+    let fileName = "";
+    if (scenario.command === "serve") {
+      css = getVirtualCss(plugin);
+    } else {
+      invokeHook(
+        plugin.generateBundle,
+        {
+          emitFile(asset: { source: string; fileName: string }) {
+            css = asset.source;
+            fileName = asset.fileName;
+          },
+        },
+        {},
+        {},
+      );
+    }
+
+    // Then only library and dev outputs carry merge annotations
+    expect(css).toBe(
+      ":root { --t-spacing: 8px; }\n" +
+        (scenario.expected ? "/* @truss p:3000 c:df */\n" : "") +
+        ".df { display: flex; }",
+    );
+    if (scenario.command === "build") {
+      // And the asset name hashes the exact final stylesheet
+      expect(fileName).toBe(`assets/truss-${createHash("sha256").update(css).digest("hex").slice(0, 8)}.css`);
+    }
+  });
+
+  test("an annotated library build merges into an annotation-free application build", () => {
+    // Given a mapping shared by a library and its consuming application
+    const root = createTempRoot();
+    writeMapping(join(root, "src", "Css.json"), {
+      df: { kind: "static", defs: { display: "flex" } },
+      black: { kind: "static", defs: { color: "black" } },
+    });
+    // And a library build containing an atomic rule and arbitrary CSS
+    const library = trussPlugin({ mapping: "./src/Css.json" });
+    invokeHook(library.configResolved, {}, { root, command: "build", mode: "production", build: { lib: {} } });
+    invokeHook(library.buildStart, {});
+    runTransform(library, 'import { Css } from "./Css"; const s = Css.df.$;', join(root, "src", "Lib.tsx"));
+    runTransform(library, 'export const css = { body: "/* keep */ margin: 0;" };', join(root, "src", "Lib.css.ts"));
+    invokeHook(
+      library.generateBundle,
+      {
+        emitFile(asset: { source: string }) {
+          writeFileSync(join(root, "library.css"), asset.source);
+        },
+      },
+      {},
+      {},
+    );
+    // And an application using the library stylesheet and an overlapping atomic rule
+    const app = trussPlugin({ mapping: "./src/Css.json", libraries: ["./library.css"] });
+    invokeHook(app.configResolved, {}, { root, command: "build", mode: "production" });
+    invokeHook(app.buildStart, {});
+    runTransform(app, 'import { Css } from "./Css"; const s = Css.df.black.$;', join(root, "src", "App.tsx"));
+
+    // When the application emits its final stylesheet
+    let css = "";
+    invokeHook(
+      app.generateBundle,
+      {
+        emitFile(asset: { source: string }) {
+          css = asset.source;
+        },
+      },
+      {},
+      {},
+    );
+
+    // Then library rules survive, atomic rules are sorted and deduplicated, and user comments remain
+    expect(css).toBe(
+      [
+        ":root { --t-spacing: 8px; }",
+        ".black { color: black; }",
+        ".df { display: flex; }",
+        "body {",
+        "  /* keep */ margin: 0;",
+        "}",
+      ].join("\n"),
+    );
+  });
+
   test("production source typos fail with a location and suggestion", () => {
     // Given a mapping with accent but no acent abbreviation
     const root = createTempRoot();
@@ -506,7 +618,6 @@ describe("trussPlugin", () => {
     expect(css).toBe(
       [
         ":root { --t-spacing: 8px; }",
-        "/* @truss arbitrary:start */",
         ".upper {",
         "  display: flex;",
         "}",
@@ -514,7 +625,6 @@ describe("trussPlugin", () => {
         ".lower {",
         "  display: flex;",
         "}",
-        "/* @truss arbitrary:end */",
       ].join("\n"),
     );
   });

--- a/packages/truss/src/plugin/index.ts
+++ b/packages/truss/src/plugin/index.ts
@@ -79,6 +79,7 @@ export function trussPlugin(opts: TrussPluginOptions): TrussVitePlugin {
   let debug = false;
   let isTest = false;
   let isBuild = false;
+  let annotate = true;
   let devSocket: { send: (payload: unknown) => void } | undefined;
   const libraryPaths = opts.libraries ?? [];
   /** The hashed CSS filename emitted during generateBundle, used by writeBundle to patch HTML. */
@@ -116,6 +117,7 @@ export function trussPlugin(opts: TrussPluginOptions): TrussVitePlugin {
       debug = config.command === "serve" || config.mode === "development" || config.mode === "test";
       isTest = config.mode === "test";
       isBuild = config.command === "build";
+      annotate = !isBuild || Boolean(config.build?.lib);
     },
 
     buildStart() {
@@ -137,7 +139,7 @@ export function trussPlugin(opts: TrussPluginOptions): TrussVitePlugin {
       // Serve the current collected CSS at the virtual endpoint
       server.middlewares.use((req: any, res: any, next: any) => {
         if (req.url !== VIRTUAL_CSS_ENDPOINT) return next();
-        const css = session.collectCss();
+        const css = session.collectCss(annotate);
         res.setHeader("Content-Type", "text/css");
         res.setHeader("Cache-Control", "no-store");
         res.end(css);
@@ -346,7 +348,7 @@ __injectTrussCSS(${JSON.stringify(payload)});
 
     generateBundle(_options: any, _bundle: any) {
       if (!isBuild) return;
-      const css = session.collectCss();
+      const css = session.collectCss(annotate);
       if (!css) return;
 
       // Compute a content hash so the filename is cache-bustable.

--- a/packages/truss/src/plugin/transform-session.ts
+++ b/packages/truss/src/plugin/transform-session.ts
@@ -91,7 +91,8 @@ export function createTrussTransformSession(options: TrussTransformSessionOption
     return result;
   }
 
-  function collectCss(): string {
+  /** Merge library and application CSS before optionally omitting build-time annotations. */
+  function collectCss(annotate = true): string {
     const mapping = ensureMapping();
     const appCss = generateCssData(cssRegistry);
     const allArbitrary = Array.from(arbitraryCssRegistry.entries())
@@ -100,7 +101,7 @@ export function createTrussTransformSession(options: TrussTransformSessionOption
       .join("\n\n");
     if (allArbitrary.length > 0) appCss.arbitraryCssBlocks.push({ cssText: allArbitrary });
     const libs = loadLibraries();
-    const body = serializeTrussCss(libs.length === 0 ? appCss : mergeTrussCssData([...libs, appCss]));
+    const body = serializeTrussCss(libs.length === 0 ? appCss : mergeTrussCssData([...libs, appCss]), annotate);
     if (body.length === 0) return "";
     return `${rootSpacingPreludeCss(mapping.increment)}\n${body}`;
   }
@@ -132,7 +133,7 @@ export function createTrussTransformSession(options: TrussTransformSessionOption
 }
 
 export interface TrussTransformSession {
-  collectCss: () => string;
+  collectCss: (annotate?: boolean) => string;
   collectTestCss: () => TestCssPayload;
   getArbitraryCss: (sourcePath: string) => string;
   ensureMapping: () => TrussMapping;

--- a/packages/truss/src/plugin/truss-css.test.ts
+++ b/packages/truss/src/plugin/truss-css.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "vitest";
+import { type ParsedTrussCss } from "../truss-css";
+import { parseTrussCss, serializeTrussCss } from "./truss-css";
+
+test("serialization omits only generated annotations when requested", () => {
+  // Given structured CSS with a fractional priority and duplicate fallback declarations
+  const css: ParsedTrussCss = {
+    rules: [
+      {
+        priority: 3000.5,
+        className: "flex",
+        cssText: "@media (min-width: 600px) { .flex { display: block; display: flex; } }",
+      },
+    ],
+    properties: [
+      {
+        varName: "--color",
+        cssText: '@property --color { syntax: "<color>"; inherits: false; initial-value: red; }',
+      },
+    ],
+    arbitraryCssBlocks: [{ cssText: '/* user comment */\n.label::after { content: "/* @truss literal */"; }' }],
+  };
+
+  // When serialized for a library, then all metadata survives a parser round trip
+  expect(serializeTrussCss(css)).toBe(
+    [
+      "/* @truss p:3000.5 c:flex */",
+      css.rules[0].cssText,
+      "/* @truss @property */",
+      css.properties[0].cssText,
+      "/* @truss arbitrary:start */",
+      css.arbitraryCssBlocks[0].cssText,
+      "/* @truss arbitrary:end */",
+    ].join("\n"),
+  );
+  expect(parseTrussCss(serializeTrussCss(css))).toEqual(css);
+
+  // When serialized for an application, then CSS bodies and user comments remain unchanged
+  expect(serializeTrussCss(css, false)).toBe(
+    [css.rules[0].cssText, css.properties[0].cssText, css.arbitraryCssBlocks[0].cssText].join("\n"),
+  );
+});
+
+test.each([true, false])("empty CSS stays empty with annotate=%s", (annotate) => {
+  expect(serializeTrussCss({ rules: [], properties: [], arbitraryCssBlocks: [] }, annotate)).toBe("");
+});

--- a/packages/truss/src/plugin/truss-css.ts
+++ b/packages/truss/src/plugin/truss-css.ts
@@ -87,16 +87,18 @@ export function parseTrussCss(cssText: string): ParsedTrussCss {
 }
 
 /** Serialize structured CSS without changing rule order or removing duplicate declarations. */
-export function serializeTrussCss(css: ParsedTrussCss): string {
+export function serializeTrussCss(css: ParsedTrussCss, annotate = true): string {
   const lines: string[] = [];
   for (const rule of css.rules) {
-    lines.push(`/* @truss p:${rule.priority} c:${rule.className} */`, rule.cssText);
+    if (annotate) lines.push(`/* @truss p:${rule.priority} c:${rule.className} */`);
+    lines.push(rule.cssText);
   }
   for (const prop of css.properties) {
-    lines.push(`/* @truss @property */`, prop.cssText);
+    if (annotate) lines.push(`/* @truss @property */`);
+    lines.push(prop.cssText);
   }
   for (const block of css.arbitraryCssBlocks) {
-    lines.push(annotateArbitraryCssBlock(block.cssText));
+    lines.push(annotate ? annotateArbitraryCssBlock(block.cssText) : block.cssText.trim());
   }
   return lines.join("\n");
 }


### PR DESCRIPTION
## Summary
- Omit generated Truss annotations from Vite application CSS after library merging, independent of mode or CSS minification.
- Preserve annotations in dev, Vite library builds using `build.lib`, and esbuild/tsup library output.
- Preserve user comments and hash the final emitted CSS; document automatic behavior without adding public configuration.

## Verification
- `yarn workspace @homebound/truss test`: 429 tests passed.
- `yarn build`: passed, including TypeScript and declaration generation.
- Tests cover output policy, library-to-application merging, annotation serialization, and final asset hashes.
- Arena byte benchmarks have not been run; documented byte targets remain unverified.