### PR TITLE
fix: Notify CSS HMR only after transforms change styles.

### DIFF
--- a/packages/truss/src/plugin/index.test.ts
+++ b/packages/truss/src/plugin/index.test.ts
@@ -8,6 +8,7 @@ import { trussPlugin } from "./index";
 const tempDirs: string[] = [];
 
 afterEach(() => {
+  vi.useRealTimers();
   for (const dir of tempDirs) {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -627,6 +628,135 @@ describe("trussPlugin", () => {
         "}",
       ].join("\n"),
     );
+  });
+
+  test("dev batches CSS changes after transforms and ignores unchanged CSS", () => {
+    // Given a mapping with a flex rule
+    const root = createTempRoot();
+    writeMapping(join(root, "src", "Css.json"), { df: { kind: "static", defs: { display: "flex" } } });
+    // And a dev server with controlled update timing and a captured CSS endpoint
+    vi.useFakeTimers();
+    const plugin = trussPlugin({ mapping: "./src/Css.json" });
+    invokeHook(plugin.configResolved, {}, { root, command: "serve", mode: "development" });
+    invokeHook(plugin.buildStart, {});
+    const send = vi.fn();
+    const use = vi.fn();
+    const server = { middlewares: { use }, ws: { send }, httpServer: { on() {} } };
+    invokeHook(plugin.configureServer, {}, server);
+
+    // When Vite reports a file change before transforming it
+    invokeHook(plugin.handleHotUpdate, {}, { server });
+    vi.runAllTimers();
+
+    // Then no stale stylesheet update is sent and no poller is running
+    expect(send.mock.calls).toEqual([]);
+    expect(vi.getTimerCount()).toBe(0);
+
+    // When an application module and a .css.ts module add CSS in the same turn
+    const appId = join(root, "src", "App.tsx");
+    const cssId = join(root, "src", "App.css.ts");
+    const appCode = 'import { Css } from "./Css"; const s = Css.df.$;';
+    const cssCode = 'export const css = { body: "color: red;" };';
+    runTransform(plugin, appCode, appId);
+    runTransform(plugin, cssCode, cssId);
+
+    // Then notification is deferred and both changes share one timer
+    expect(send.mock.calls).toEqual([]);
+    expect(vi.getTimerCount()).toBe(1);
+    vi.runAllTimers();
+    expect(send.mock.calls).toEqual([[{ type: "custom", event: "truss:css-update" }]]);
+    // And the endpoint already serves both completed transforms
+    const end = vi.fn();
+    use.mock.calls[0][0]({ url: "/virtual:truss.css" }, { setHeader() {}, end }, () => {});
+    expect(end.mock.calls).toEqual([
+      [
+        [
+          ":root { --t-spacing: 8px; }",
+          "/* @truss p:3000 c:df */",
+          ".df { display: flex; }",
+          "/* @truss arbitrary:start */",
+          "body {",
+          "  color: red;",
+          "}",
+          "/* @truss arbitrary:end */",
+        ].join("\n"),
+      ],
+    ]);
+
+    // When Vite retransforms unchanged CSS or a module without styles
+    send.mockClear();
+    runTransform(plugin, appCode, appId);
+    runTransform(plugin, cssCode, cssId);
+    runTransform(plugin, "export const value = 1;", join(root, "src", "other.ts"));
+    vi.runAllTimers();
+
+    // Then no stylesheet is requested
+    expect(send.mock.calls).toEqual([]);
+    expect(vi.getTimerCount()).toBe(0);
+
+    // When a later .css.ts edit replaces its rules
+    runTransform(plugin, 'export const css = { body: "color: blue;" };', cssId);
+    vi.runAllTimers();
+
+    // Then the edit gets one new notification without an initial file-change event
+    expect(send.mock.calls).toEqual([[{ type: "custom", event: "truss:css-update" }]]);
+  });
+
+  test.each(["close", "buildStart"])("dev cancels pending CSS updates on %s", (event) => {
+    // Given a mapping with a flex rule
+    const root = createTempRoot();
+    writeMapping(join(root, "src", "Css.json"), { df: { kind: "static", defs: { display: "flex" } } });
+    // And a dev server with a pending CSS update
+    vi.useFakeTimers();
+    const plugin = trussPlugin({ mapping: "./src/Css.json" });
+    invokeHook(plugin.configResolved, {}, { root, command: "serve", mode: "development" });
+    invokeHook(plugin.buildStart, {});
+    const send = vi.fn();
+    const on = vi.fn();
+    invokeHook(plugin.configureServer, {}, { middlewares: { use() {} }, ws: { send }, httpServer: { on } });
+    runTransform(plugin, 'import { Css } from "./Css"; const s = Css.df.$;', join(root, "src", "App.tsx"));
+    expect(vi.getTimerCount()).toBe(1);
+
+    // When the server closes or the build state resets before notification
+    if (event === "close") {
+      expect(on.mock.calls[0][0]).toBe("close");
+      on.mock.calls[0][1]();
+    } else {
+      invokeHook(plugin.buildStart, {});
+    }
+
+    // Then the pending timer is removed and no update is sent
+    expect(vi.getTimerCount()).toBe(0);
+    vi.runAllTimers();
+    expect(send.mock.calls).toEqual([]);
+  });
+
+  test("dev runtime fetches initially and only subscribes to CSS changes", async () => {
+    // Given the dev runtime and a browser with an existing Truss style element
+    const plugin = trussPlugin({ mapping: "./src/Css.json" });
+    const id = invokeHook(plugin.resolveId, {}, "virtual:truss:runtime", undefined);
+    const code = invokeHook(plugin.load, {}, id) as string;
+    const style = { textContent: "" };
+    const document = { getElementById: () => style };
+    const fetch = vi.fn().mockResolvedValue({ text: async () => ".df { display: flex; }" });
+    const on = vi.fn();
+
+    // When the browser evaluates the runtime
+    new Function("document", "fetch", "hot", code.replaceAll("import.meta.hot", "hot"))(document, fetch, { on });
+
+    // Then it fetches once on startup and does not subscribe to Vite JS updates
+    expect(fetch.mock.calls).toEqual([["/virtual:truss.css"]]);
+    expect(on.mock.calls.map((call) => call[0])).toEqual(["truss:css-update"]);
+    await vi.waitFor(() => expect(style.textContent).toBe(".df { display: flex; }"));
+
+    // When the server reports changed CSS
+    fetch.mockClear();
+    fetch.mockResolvedValue({ text: async () => ".df { display: grid; }" });
+    on.mock.calls[0][1]();
+
+    // Then the browser fetches and applies the stylesheet once
+    expect(fetch.mock.calls).toEqual([["/virtual:truss.css"]]);
+    await vi.waitFor(() => expect(style.textContent).toBe(".df { display: grid; }"));
   });
 
   test("dev html injects the runtime without a stylesheet link", () => {

--- a/packages/truss/src/plugin/index.ts
+++ b/packages/truss/src/plugin/index.ts
@@ -85,8 +85,7 @@ export function trussPlugin(opts: TrussPluginOptions): TrussVitePlugin {
   /** The hashed CSS filename emitted during generateBundle, used by writeBundle to patch HTML. */
   let emittedCssFileName: string | null = null;
 
-  let cssVersion = 0;
-  let lastSentVersion = 0;
+  let cssUpdateTimer: ReturnType<typeof setTimeout> | undefined;
 
   function mappingPath(): string {
     return resolve(projectRoot || process.cwd(), opts.mapping);
@@ -104,7 +103,12 @@ export function trussPlugin(opts: TrussPluginOptions): TrussVitePlugin {
     projectRoot: () => projectRoot || process.cwd(),
     libraries: libraryPaths,
     onCssChanged() {
-      cssVersion++;
+      if (!devSocket || cssUpdateTimer !== undefined) return;
+      // Notify after transforms finish, batching registry changes in this event-loop turn.
+      cssUpdateTimer = setTimeout(() => {
+        cssUpdateTimer = undefined;
+        devSocket?.send({ type: "custom", event: "truss:css-update" });
+      }, 0);
     },
   });
 
@@ -124,15 +128,15 @@ export function trussPlugin(opts: TrussPluginOptions): TrussVitePlugin {
       session.ensureMapping();
       // Reset registries and library cache at start of each build
       session.reset();
-      cssVersion = 0;
-      lastSentVersion = 0;
+      clearTimeout(cssUpdateTimer);
+      cssUpdateTimer = undefined;
     },
 
     // -- Dev mode HMR --
 
     configureServer(server: any) {
       // Skip dev-server setup in test mode — Vitest doesn't start a real HTTP
-      // server, so the interval would keep the process alive.
+      // server and does not use browser CSS updates.
       if (isTest) return;
       devSocket = server.ws;
 
@@ -145,17 +149,11 @@ export function trussPlugin(opts: TrussPluginOptions): TrussVitePlugin {
         res.end(css);
       });
 
-      // Poll for CSS version changes and push HMR updates
-      const interval = setInterval(() => {
-        if (cssVersion !== lastSentVersion && server.ws) {
-          lastSentVersion = cssVersion;
-          server.ws.send({ type: "custom", event: "truss:css-update" });
-        }
-      }, 150);
-
-      // Clean up interval when server closes
+      // Cancel pending CSS updates when the server closes.
       server.httpServer?.on("close", () => {
-        clearInterval(interval);
+        clearTimeout(cssUpdateTimer);
+        cssUpdateTimer = undefined;
+        devSocket = undefined;
       });
     },
 
@@ -176,13 +174,6 @@ export function trussPlugin(opts: TrussPluginOptions): TrussVitePlugin {
       // Inject the virtual runtime script for dev mode; it owns style updates.
       const tag = `<script type="module" src="/${VIRTUAL_RUNTIME_ID}"></script>`;
       return html.replace("</head>", `    ${tag}\n  </head>`);
-    },
-
-    handleHotUpdate(ctx: any) {
-      // Send CSS update event on any file change for safety
-      if (ctx.server?.ws) {
-        ctx.server.ws.send({ type: "custom", event: "truss:css-update" });
-      }
     },
 
     // -- Virtual module resolution --
@@ -237,9 +228,6 @@ export function trussPlugin(opts: TrussPluginOptions): TrussVitePlugin {
 
   if (import.meta.hot) {
     import.meta.hot.on("truss:css-update", fetchCss);
-    import.meta.hot.on("vite:afterUpdate", () => {
-      setTimeout(fetchCss, 50);
-    });
   }
 })();
 `;


### PR DESCRIPTION
## Summary
- Remove the early file-change notification and the extra browser fetch after Vite JS updates.
- Replace the 150 ms version poller with a deferred notification when the CSS registry changes, batching changes within the same event-loop turn.
- Keep the existing CSS endpoint, runtime, and initial page-load fetch; cancel pending notifications on server close or build reset.
- Add regression coverage for notification timing, batching, unchanged CSS, .css.ts edits, cleanup, and runtime fetches.

## Scope
This is the narrow timing fix only. Stale-rule cleanup and migration to native Vite CSS HMR are not included. Existing arena documentation changes are also excluded.

## Verification
- All 357 plugin tests pass: `yarn workspace @homebound/truss test src/plugin/`
- TypeScript passes: `yarn tsc --project packages/truss/tsconfig.json --noEmit --incremental false`
- Prettier passes for both changed files.
- The arena browser payload probe was not run because it is not present in this checkout.