### PR TITLE
fix: Abbreviate the property prefix on value-folded class names.

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -191,7 +191,7 @@ Class names are deterministic and human-readable:
 | Pseudo-element            | `placeholder_blue`           | `.placeholder_blue::placeholder { color: #526675 }`                                            |
 | Variable                  | `mt_var`                     | `.mt_var { margin-top: var(--marginTop) }`                                                     |
 | Literal-folded            | `mt_2`                       | `.mt_2 { margin-top: calc(var(--t-spacing) * 2) }`                                             |
-| `add()` literal           | `add_transition_all_240ms`   | `.add_transition_all_240ms { transition: all 240ms }`                                          |
+| `add()` literal           | `tsn_all_240ms`              | `.tsn_all_240ms { transition: all 240ms }`                                                     |
 | `add()` variable          | `color_var`                  | `.color_var { color: var(--color) }`                                                           |
 | `when()` relationship     | `wh_anc_h_blue`              | `._mrk:hover .wh_anc_h_blue { color: #526675 }`                                                |
 

--- a/packages/truss/src/plugin/css-property-abbreviations.ts
+++ b/packages/truss/src/plugin/css-property-abbreviations.ts
@@ -12,6 +12,9 @@
  * over these — this mapping is only the fallback.
  */
 export const cssPropertyAbbreviations: Record<string, string> = {
+  // Accent color
+  accentColor: "acc",
+
   // Alignment
   alignContent: "ac",
   alignItems: "ai",

--- a/packages/truss/src/plugin/resolve-calls.ts
+++ b/packages/truss/src/plugin/resolve-calls.ts
@@ -253,9 +253,11 @@ function resolveAddObjectLiteral(
  *
  * When the pair matches an existing single-property abbreviation in the mapping, that abbreviation
  * is reused so the class is shared with direct uses. Otherwise the property name itself is the
- * abbreviation, folded to a static class for literal values or a `_var` tuple for runtime values.
+ * abbreviation: a literal value folds to a static class named with the property's short form from
+ * the CSS property abbreviation table, and a runtime value becomes a `_var` tuple that keeps the
+ * property name.
  *
- * I.e. `("display", "grid")` → the `dg` segment; `("boxShadow", "0 0 0 1px blue")` → `boxShadow_0_0_0_1px_blue`;
+ * I.e. `("display", "grid")` → the `dg` segment; `("boxShadow", "0 0 0 1px blue")` → `bxs_0_0_0_1px_blue`;
  * `("boxShadow", shadow)` → `boxShadow_var` with `--boxShadow: shadow`.
  */
 function resolveAddDeclaration(

--- a/packages/truss/src/plugin/style-entries.ts
+++ b/packages/truss/src/plugin/style-entries.ts
@@ -125,6 +125,9 @@ function variableStyleEntries(
  *
  * For literal-folded variables (argResolved set), includes the value:
  * I.e. `mt(2)` → `mt_2` (web increment calc), `mt(-1)` → `mt_neg1`, `bc("red")` → `bc_red`.
+ * A base name that is itself a CSS property name is abbreviated too, so the single-property path
+ * names a declaration the same way the multi-property path does.
+ * I.e. `letterSpacing("-0.022em")` → `ls_neg0_022em`, `add("borderBottomStyle", "solid")` → `bbs_solid`.
  */
 function computeStaticBaseName(
   seg: CssSegment,
@@ -138,7 +141,12 @@ function computeStaticBaseName(
     return canonical ?? `${getPropertyAbbreviation(cssProp)}_${classNameFragmentForResolvedValue(cssValue)}`;
   }
   if (seg.argResolved !== undefined) {
-    return `${seg.abbr}_${classNameFragmentForResolvedValue(seg.argResolved)}`;
+    // `seg.abbr` is the CSS property name when `add()` names a property directly, or when a param
+    // method keeps its default base name, i.e. `Css.letterSpacing(...)`; abbreviate those the same
+    // way the multi-property branch does. Names the table does not list keep their spelling: both
+    // the abbreviations that are already short, i.e. `mt`, and properties with no entry, i.e.
+    // `scrollbarGutter`.
+    return `${getPropertyAbbreviation(seg.abbr)}_${classNameFragmentForResolvedValue(seg.argResolved)}`;
   }
   return seg.abbr;
 }

--- a/packages/truss/src/plugin/transform.test.ts
+++ b/packages/truss/src/plugin/transform.test.ts
@@ -234,39 +234,39 @@ describe("transform", () => {
       `
       const s = {
         transformBox: "transformBox_fill_box",
-        transformOrigin: "transformOrigin_center",
-        transform: "transform_scale_0_5",
-        animationName: "animationName_aiStarLoader",
-        animationDuration: "animationDuration_1500ms",
-        animationIterationCount: "animationIterationCount_infinite",
-        animationTimingFunction: "animationTimingFunction_ease_in_out",
-        animationDelay: "animationDelay_500ms"
+        transformOrigin: "tfo_center",
+        transform: "tf_scale_0_5",
+        animationName: "animn_aiStarLoader",
+        animationDuration: "animdu_1500ms",
+        animationIterationCount: "animic_infinite",
+        animationTimingFunction: "animtf_ease_in_out",
+        animationDelay: "animd_500ms"
       };
     `,
       `
-      .animationDelay_500ms {
+      .animd_500ms {
         animation-delay: 500ms;
       }
-      .animationDuration_1500ms {
+      .animdu_1500ms {
         animation-duration: 1500ms;
       }
-      .animationIterationCount_infinite {
+      .animic_infinite {
         animation-iteration-count: infinite;
       }
-      .animationName_aiStarLoader {
+      .animn_aiStarLoader {
         animation-name: aiStarLoader;
       }
-      .animationTimingFunction_ease_in_out {
+      .animtf_ease_in_out {
         animation-timing-function: ease-in-out;
+      }
+      .tf_scale_0_5 {
+        transform: scale(0.5);
+      }
+      .tfo_center {
+        transform-origin: center;
       }
       .transformBox_fill_box {
         transform-box: fill-box;
-      }
-      .transformOrigin_center {
-        transform-origin: center;
-      }
-      .transform_scale_0_5 {
-        transform: scale(0.5);
       }
     `,
     );
@@ -278,10 +278,10 @@ describe("transform", () => {
       const s = Css.animation("pulse 2s ease-in-out infinite").$;
     `).toHaveTrussOutput(
       `
-      const s = { animation: "animation_pulse_2s_ease_in_out_infinite" };
+      const s = { animation: "anim_pulse_2s_ease_in_out_infinite" };
     `,
       `
-      .animation_pulse_2s_ease_in_out_infinite {
+      .anim_pulse_2s_ease_in_out_infinite {
         animation: pulse 2s ease-in-out infinite;
       }
     `,
@@ -294,16 +294,16 @@ describe("transform", () => {
       const s = Css.rotate("45deg").scale("1.5").translate("10px 20px").$;
     `).toHaveTrussOutput(
       `
-      const s = { rotate: "rotate_45deg", scale: "scale_1_5", translate: "translate_10px_20px" };
+      const s = { rotate: "rot_45deg", scale: "sc_1_5", translate: "tsl_10px_20px" };
     `,
       `
-      .rotate_45deg {
+      .rot_45deg {
         rotate: 45deg;
       }
-      .scale_1_5 {
+      .sc_1_5 {
         scale: 1.5;
       }
-      .translate_10px_20px {
+      .tsl_10px_20px {
         translate: 10px 20px;
       }
     `,
@@ -317,19 +317,19 @@ describe("transform", () => {
     `).toHaveTrussOutput(
       `
       const s = {
-        transitionProperty: "transitionProperty_transform",
-        transitionDuration: "transitionDuration_200ms",
-        transform: "h_transform_scale_1_1"
+        transitionProperty: "tsnp_transform",
+        transitionDuration: "tsndu_200ms",
+        transform: "h_tf_scale_1_1"
       };
     `,
       `
-      .transitionDuration_200ms {
+      .tsndu_200ms {
         transition-duration: 200ms;
       }
-      .transitionProperty_transform {
+      .tsnp_transform {
         transition-property: transform;
       }
-      .h_transform_scale_1_1:hover {
+      .h_tf_scale_1_1:hover {
         transform: scale(1.1);
       }
     `,
@@ -344,10 +344,10 @@ describe("transform", () => {
       const el = <div css={Css.mt2.transition("all 240ms").$} />;
     `).toHaveTrussOutput(
       `
-      const el = <div className="mt2 transition_all_240ms" />;
+      const el = <div className="mt2 tsn_all_240ms" />;
     `,
       `
-      .transition_all_240ms {
+      .tsn_all_240ms {
         transition: all 240ms;
       }
       .mt2 {
@@ -2312,7 +2312,7 @@ describe("transform", () => {
       import { trussProps } from "@homebound/truss/runtime";
       const el = <div {...trussProps({
         position: "absolute",
-        bottom: "bottom_4px",
+        bottom: "bot_4px",
         width: "w_4px",
         height: "h_4px",
         backgroundColor: "bgBlue",
@@ -2333,7 +2333,7 @@ describe("transform", () => {
       .bgWhite {
         background-color: #fcfcfa;
       }
-      .bottom_4px {
+      .bot_4px {
         bottom: 4px;
       }
       .h_4px {
@@ -2378,17 +2378,17 @@ describe("transform", () => {
       const s = Css.ba.add("borderWidth", "3px").$;
     `).toHaveTrussOutput(
       `
-      const s = { borderStyle: "bss", borderWidth: "borderWidth_3px" };
+      const s = { borderStyle: "bss", borderWidth: "bw_3px" };
     `,
       `
-      .borderWidth_3px {
-        border-width: 3px;
-      }
       .bss {
         border-style: solid;
       }
       .bw1 {
         border-width: 1px;
+      }
+      .bw_3px {
+        border-width: 3px;
       }
     `,
     );
@@ -3863,10 +3863,10 @@ describe("transform", () => {
       const s = Css.add("boxShadow", "0 0 0 1px blue").$;
     `).toHaveTrussOutput(
       `
-      const s = { boxShadow: "boxShadow_0_0_0_1px_blue" };
+      const s = { boxShadow: "bxs_0_0_0_1px_blue" };
     `,
       `
-      .boxShadow_0_0_0_1px_blue {
+      .bxs_0_0_0_1px_blue {
         box-shadow: 0 0 0 1px blue;
       }
     `,
@@ -3879,11 +3879,71 @@ describe("transform", () => {
       const s = Css.add("animationDelay", "300ms").$;
     `).toHaveTrussOutput(
       `
-      const s = { animationDelay: "animationDelay_300ms" };
+      const s = { animationDelay: "animd_300ms" };
     `,
       `
-      .animationDelay_300ms {
+      .animd_300ms {
         animation-delay: 300ms;
+      }
+    `,
+    );
+  });
+
+  test("add abbreviates the property name: Css.add('letterSpacing', '-0.022em').$", () => {
+    expectTrussTransform(`
+      import { Css } from "./Css";
+      const s = Css.add("letterSpacing", "-0.022em").$;
+    `).toHaveTrussOutput(
+      `
+      const s = { letterSpacing: "ls_neg0_022em" };
+    `,
+      `
+      .ls_neg0_022em {
+        letter-spacing: -0.022em;
+      }
+    `,
+    );
+  });
+
+  test("add keeps the property name when it has no abbreviation: Css.add('scrollbarGutter', 'stable').$", () => {
+    expectTrussTransform(`
+      import { Css } from "./Css";
+      const s = Css.add("scrollbarGutter", "stable").$;
+    `).toHaveTrussOutput(
+      `
+      const s = { scrollbarGutter: "scrollbarGutter_stable" };
+    `,
+      `
+      .scrollbarGutter_stable {
+        scrollbar-gutter: stable;
+      }
+    `,
+    );
+  });
+
+  test("add shares one class with a multi-property abbreviation for the same declaration", () => {
+    // Given `Css.bb`, whose two properties take abbreviated names from the multi-property path
+    // And an `add` of `borderBottomStyle: solid`, the same declaration `bb` already emits, but
+    // reached through the single-property path, which folds the literal and used to spell the
+    // property out
+    const code = `
+      import { Css } from "./Css";
+      const s = Css.bb.$;
+      const t = Css.add("borderBottomStyle", "solid").$;
+    `;
+
+    // Then both paths name it `bbs_solid` and the stylesheet carries the declaration once
+    expectTrussTransform(code).toHaveTrussOutput(
+      `
+      const s = { borderBottomStyle: "bbs_solid", borderBottomWidth: "bbw_1px" };
+      const t = { borderBottomStyle: "bbs_solid" };
+    `,
+      `
+      .bbs_solid {
+        border-bottom-style: solid;
+      }
+      .bbw_1px {
+        border-bottom-width: 1px;
       }
     `,
     );
@@ -3936,7 +3996,7 @@ describe("transform", () => {
     );
   });
 
-  test("add uses property name in jsx output and generated css", () => {
+  test("add uses the property abbreviation in jsx output and generated css", () => {
     const code = `
       import { Css } from "./Css";
       const el = <div css={Css.mt2.add("transition", "all 240ms").$} />;
@@ -3944,10 +4004,10 @@ describe("transform", () => {
 
     expectTrussTransform(code).toHaveTrussOutput(
       `
-      const el = <div className="mt2 transition_all_240ms" />;
+      const el = <div className="mt2 tsn_all_240ms" />;
     `,
       `
-      .transition_all_240ms {
+      .tsn_all_240ms {
         transition: all 240ms;
       }
       .mt2 {


### PR DESCRIPTION
## Problem

A single-property chain that folds a literal value spelled the CSS property out in full:

```css
.letterSpacing_neg0_022em                         { letter-spacing: -0.022em; }
.transitionProperty_background_color_border_color { transition-property: background-color, border-color; }
```

The multi-property path already abbreviated, so the same declaration could land under two class names, two rules:

```css
.bbs_solid               { border-bottom-style: solid; }  /* Css.bb */
.borderBottomStyle_solid { border-bottom-style: solid; }  /* add("borderBottomStyle", "solid") */
```

Those names then repeat in every `class` attribute that uses them. In the [css-in-js-arena](https://github.com/stephenh/css-in-js-arena) app that is 77,297 B of class attributes against StyleX's 70,843 B — the one shipped-bytes row Truss loses.

## Fix

`computeStaticBaseName()` now runs the folded base name through the same `cssPropertyAbbreviations` table the multi-property branch already uses, falling back to the name when the table has no entry.

| before | after |
| --- | --- |
| `letterSpacing_neg0_022em` | `ls_neg0_022em` |
| `transitionProperty_transform` | `tsnp_transform` |
| `boxShadow_0_0_0_1px_blue` | `bxs_0_0_0_1px_blue` |
| `borderBottomStyle_solid` | `bbs_solid` (merges with the existing rule) |

Names the table does not list are untouched — both the abbreviations that are already short (`mt_2`, `bc_red`) and properties with no entry (`scrollbarGutter_stable`, `transformBox_fill_box`). Also adds `accentColor: "acc"`.

The runtime `_var` path is unchanged and still spells properties out (`boxShadow_var`, `--boxShadow`); shortening it would rename the CSS custom property too, so it is a separate change.

## Collision safety

- The abbreviation table is injective, enforced by a throw at module load, so a duplicate entry fails any build or test run that imports it.
- A sweep over both shipped mappings (`packages/app`, `packages/template-tachyons`) finds no collisions across 343 distinct folded base names, counting every `add()`-reachable property plus every single-prop, `extraDefs`-free variable/delegate abbreviation. Multi-property abbreviations like `m`/`p` never reach this branch, so `add("margin", …)` → `m_8px` cannot clash with `Css.m(1)` → `mt_8px`.

## Release note

This renames generated classes. A library pre-compiled with an older Truss keeps the long names and will not dedupe against an app built with this version. Both rules still carry the same declaration, so rendering is correct, but the merged sheet carries both — the same version-alignment constraint the priority annotations already impose.

## Docs

`docs/overview.md` listed the `add()` literal class as `add_transition_all_240ms`. There has never been an `add_` prefix, so that row was already wrong; it is now `tsn_all_240ms`, matching the test.

## Tests

19 class names updated across 10 existing `transform.test.ts` expectations, plus three new black-box tests: the table hit (`add('letterSpacing', …)` → `ls_neg0_022em`), the no-entry fallback (`add('scrollbarGutter', 'stable')`), and the merge case (`Css.bb` and `add("borderBottomStyle", "solid")` sharing one `bbs_solid` rule).

548 tests pass across the four packages; `tsc --build` and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
