### PR TITLE
refactor: Rename the "folded" literal terminology to "evaluated".

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -51,7 +51,7 @@ Css.mt(x).$ → { marginTop: ["mt_var", { "--marginTop": maybeCssVar(__maybeInc(
 
 The tuple format is `[classNames: string, vars: Record<string, string>]`. At runtime, `trussProps` splits this into `className: "mt_var"` and `style: { "--marginTop": "16px" }`.
 
-When the argument is a literal, the value is folded at build time into a static class:
+When the argument is a literal, the value is evaluated at build time into a static class:
 
 ```ts
 Css.mt(2).$ → { marginTop: "mt_2" }        // .mt_2 { margin-top: calc(var(--t-spacing) * 2) }
@@ -190,7 +190,7 @@ Class names are deterministic and human-readable:
 | Raw media/container query | `media_min_width_600px_blue` | `@media (min-width: 600px) { .media_min_width_600px_blue.media_min_width_600px_blue { ... } }` |
 | Pseudo-element            | `placeholder_blue`           | `.placeholder_blue::placeholder { color: #526675 }`                                            |
 | Variable                  | `mt_var`                     | `.mt_var { margin-top: var(--marginTop) }`                                                     |
-| Literal-folded            | `mt_2`                       | `.mt_2 { margin-top: calc(var(--t-spacing) * 2) }`                                             |
+| Literal-evaluated         | `mt_2`                       | `.mt_2 { margin-top: calc(var(--t-spacing) * 2) }`                                             |
 | `add()` literal           | `tsn_all_240ms`              | `.tsn_all_240ms { transition: all 240ms }`                                                     |
 | `add()` variable          | `color_var`                  | `.color_var { color: var(--color) }`                                                           |
 | `when()` relationship     | `wh_anc_h_blue`              | `._mrk:hover .wh_anc_h_blue { color: #526675 }`                                                |

--- a/packages/app/src/Css.test.tsx
+++ b/packages/app/src/Css.test.tsx
@@ -164,7 +164,7 @@ describe("Truss CssBuilder", () => {
   });
 
   describe("parameterized methods (variable styles via CSS variables)", () => {
-    // Ordinary literals (numbers, "red", "10px") fold to static classes.
+    // Ordinary literals (numbers, "red", "10px") evaluate to static classes.
     // Custom-property args (Tokens.*, "--token") use the shared _var class
     // plus inline --propName values; runtime variables use maybeCssVar on the arg.
 

--- a/packages/truss/src/plugin/emit-style-hash.ts
+++ b/packages/truss/src/plugin/emit-style-hash.ts
@@ -88,7 +88,7 @@ export function styleHashProperties(
 /**
  * The runtime value stored in a variable tuple's vars object.
  *
- * I.e. a folded `Tokens.gap` → `"var(--gap)"`; `mt(x)` → `maybeCssVar(__maybeInc(x))`; `mtPx(x)` → `` `${x}px` ``.
+ * I.e. an evaluated `Tokens.gap` → `"var(--gap)"`; `mt(x)` → `maybeCssVar(__maybeInc(x))`; `mtPx(x)` → `` `${x}px` ``.
  */
 function variableValueExpression(
   dyn: StyleEntry,

--- a/packages/truss/src/plugin/resolve-calls.ts
+++ b/packages/truss/src/plugin/resolve-calls.ts
@@ -80,7 +80,7 @@ function resolveDelegateCall(
     throw new UnsupportedPatternError(`Delegate "${abbr}" targets "${entry.target}" which is not a variable entry`);
   }
   const arg = singleArg(node, abbr);
-  // I.e. `mtPx(12)` folds to `12px` and `mtPx(-4)` to `-4px`; anything else is a runtime value
+  // I.e. `mtPx(12)` evaluates to `12px` and `mtPx(-4)` to `-4px`; anything else is a runtime value
   const pixels = tryNumericLiteral(arg);
   // Use the target abbreviation name for delegate segments (i.e. mtPx → mt)
   return resolveLiteralOrVariableSegment({
@@ -97,10 +97,10 @@ function resolveDelegateCall(
 }
 
 /**
- * Resolve a parameterized call argument to either a static fold, a compile-time `_var` tuple,
+ * Resolve a parameterized call argument to either a static evaluation, a compile-time `_var` tuple,
  * or a runtime `_var` tuple.
  *
- * I.e. `mt(2)` folds to `defs: { marginTop: "calc(var(--t-spacing) * 2)" }`; `mt(Tokens.gap)` stays a
+ * I.e. `mt(2)` evaluates to `defs: { marginTop: "calc(var(--t-spacing) * 2)" }`; `mt(Tokens.gap)` stays a
  * `_var` segment with `argResolved: "var(--gap)"` so every token shares one `mt_var` class; and `mt(x)`
  * is a `_var` segment whose value is only known at runtime.
  */
@@ -253,7 +253,7 @@ function resolveAddObjectLiteral(
  *
  * When the pair matches an existing single-property abbreviation in the mapping, that abbreviation
  * is reused so the class is shared with direct uses. Otherwise the property name itself is the
- * abbreviation: a literal value folds to a static class named with the property's short form from
+ * abbreviation: a literal value evaluates to a static class named with the property's short form from
  * the CSS property abbreviation table, and a runtime value becomes a `_var` tuple that keeps the
  * property name.
  *

--- a/packages/truss/src/plugin/rewrite-sites.ts
+++ b/packages/truss/src/plugin/rewrite-sites.ts
@@ -405,7 +405,7 @@ function isMetadataKey(name: string): boolean {
  * Build the spread attribute for a JSX `css=` attribute.
  *
  * I.e. `{...trussProps(hash)}`, or `{...mergeProps(className, style, hash)}` when the element
- * also has `className`/`style` attributes (which are removed and folded in).
+ * also has `className`/`style` attributes (which are removed and merged in).
  */
 function buildCssSpreadAttribute(
   path: NodePath<t.JSXAttribute>,

--- a/packages/truss/src/plugin/style-entries.ts
+++ b/packages/truss/src/plugin/style-entries.ts
@@ -123,7 +123,7 @@ function variableStyleEntries(
  * I.e. `ba` → `bss`, `bw1` (not `ba_borderStyle`, etc.)
  * I.e. `lineClamp("3")` display:-webkit-box → `d_negwebkit_box`, not `d_3`
  *
- * For literal-folded variables (argResolved set), includes the value:
+ * For literal-evaluated variables (argResolved set), includes the value:
  * I.e. `mt(2)` → `mt_2` (web increment calc), `mt(-1)` → `mt_neg1`, `bc("red")` → `bc_red`.
  * A base name that is itself a CSS property name is abbreviated too, so the single-property path
  * names a declaration the same way the multi-property path does.

--- a/packages/truss/src/plugin/transform.test.ts
+++ b/packages/truss/src/plugin/transform.test.ts
@@ -725,7 +725,7 @@ describe("transform", () => {
     );
   });
 
-  test("delegate with negative literal folds like a positive one: Css.mtPx(-4).$", () => {
+  test("delegate with negative literal evaluates like a positive one: Css.mtPx(-4).$", () => {
     expectTrussTransform(`
       import { Css } from "./Css";
       const s = Css.mtPx(-4).$;
@@ -741,7 +741,7 @@ describe("transform", () => {
     );
   });
 
-  test("delegate shorthand with negative literal folds every longhand: Css.mPx(-1).$", () => {
+  test("delegate shorthand with negative literal evaluates every longhand: Css.mPx(-1).$", () => {
     expectTrussTransform(`
       import { Css } from "./Css";
       const s = Css.mPx(-1).$;
@@ -3924,7 +3924,7 @@ describe("transform", () => {
   test("add shares one class with a multi-property abbreviation for the same declaration", () => {
     // Given `Css.bb`, whose two properties take abbreviated names from the multi-property path
     // And an `add` of `borderBottomStyle: solid`, the same declaration `bb` already emits, but
-    // reached through the single-property path, which folds the literal and used to spell the
+    // reached through the single-property path, which evaluates the literal and used to spell the
     // property out
     const code = `
       import { Css } from "./Css";

--- a/packages/truss/src/plugin/types.ts
+++ b/packages/truss/src/plugin/types.ts
@@ -64,7 +64,7 @@ interface CssSegmentBase {
 /**
  * Concrete CSS property/value pairs.
  *
- * I.e. `Css.df.$` → `defs: { display: "flex" }`. A folded `Css.mt(2).$` also carries
+ * I.e. `Css.df.$` → `defs: { display: "flex" }`. An evaluated `Css.mt(2).$` also carries
  * `argResolved: "calc(var(--t-spacing) * 2)"` so its class name can include the value.
  */
 export interface StaticSegment extends CssSegmentBase {


### PR DESCRIPTION
Follow-up to #294, comments and docs only.

## Why

Comments and docs described a compile-time literal as "folded": "the value is folded at build time", "literal-folded variables", "either a static fold, a compile-time `_var` tuple". The function that actually does the work is `tryEvaluatePropertyLiteral`, so the prose now matches the code.

## What

13 sites across `types.ts`, `emit-style-hash.ts`, `resolve-calls.ts`, `style-entries.ts`, `transform.test.ts`, `Css.test.tsx` and `docs/overview.md`:

| before | after |
| --- | --- |
| "the value is folded at build time into a static class" | "…is evaluated at build time…" |
| `Literal-folded` (class-name table row) | `Literal-evaluated` |
| "`mtPx(12)` folds to `12px`" | "`mtPx(12)` evaluates to `12px`" |
| "either a static fold, a compile-time `_var` tuple" | "either a static evaluation, …" |
| "For literal-folded variables (argResolved set)" | "For literal-evaluated variables …" |

Two test names change with it (`delegate with negative literal evaluates like a positive one`, `delegate shorthand with negative literal evaluates every longhand`).

One site used "fold" in an unrelated sense — `rewrite-sites.ts` said `className`/`style` attributes are "removed and folded in", meaning merged. That reads "merged in" now, matching the `mergeProps` call it describes. Flagging it since it is a judgement call rather than a mechanical rename.

Untouched: `CHANGELOG.md` (generated history, and a released commit subject reads "Fold negative literals in Px delegates") and `packages/truss/build/` (untracked build output).

## Scope

Comments, JSDoc, test names and docs only — no behaviour change. 548 tests pass, `tsc --build` and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)