### PR TITLE
feat: Add config support for @property registration and @keyframes

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ And a static, build-time generated CSS file:
   - [See example config](https://github.com/homebound-team/truss/blob/main/packages/template-tachyons/truss-config.ts) and the "Customization" section below
 
 - Optional **design tokens** (`config.tokens`) and **`Css.setVar`** for scoped CSS variables on **web** (build-time atomic classes). React Native does not support `setVar`. See [Design tokens and Css.setVar](#design-tokens-and-csssetvar).
+- Optional **`@property` registration** (the object form of `config.tokens`) and **`@keyframes`** (`config.keyframes`), so animation names are checked at build time and unused keyframes are pruned. See [Registering a token with `@property`](#registering-a-token-with-property) and [Keyframes](#keyframes).
 
 - Escape hatch to arbitrary/runtime selectors
   - `useRuntimeStyle({ body: RuntimeCss.blue.$ })`
@@ -245,9 +246,7 @@ npm install --save-dev @homebound/truss
    export default defineConfig({
      plugins: [trussPlugin({ mapping: "./src/Css.json" })],
      build: {
-       lib: {
-         /* your library entry */
-       },
+       lib: {/* your library entry */},
      },
    });
    ```
@@ -908,6 +907,68 @@ React Native: **`setVar`** is not supported (no web atomic pipeline).
   }
 />
 ```
+
+#### Registering a token with `@property`
+
+Naming a token and registering it are two different things in `truss-config.ts`:
+
+- Defining a token as just a `string` value only gives the variable a TypeScript name; it emits no CSS at all.
+- Defining a token as an `object` also emits an **`@property`** block.
+
+  This tells the _browser_ about the variable: how to parse and type-check its value, to fall back to **`initialValue`**, and to **interpolate** it when used in animations.
+
+```typescript
+tokens: {
+  ThemePrimary: "--theme-primary",                                       // named only
+  Angle: { var: "--angle", syntax: "<angle>", inherits: false, initialValue: "0deg" },
+},
+```
+
+Whether you define a token as a `string` or `object` does not change how you use the token:
+
+- **`Css.setVar({ [Tokens.Angle]: "45deg" })`** to write it,
+- **`Tokens.Angle`** as a whole value to read it (Truss wraps it as `var(--angle)`), or
+  interpolated into a larger value, i.e. ``Css.add("backgroundImage", `conic-gradient(from ${Tokens.Angle}, red, blue)`)``
+
+When using the `object` form:
+
+- **`inherits`** defaults to `false`,
+- **`initialValue`** is required for every **`syntax`** except `"*"`
+
+**`@property`** blocks are emitted unconditionally rather than pruned based on usage. Static usage like `Css.bc(Tokens.Angle)` is knowable at build time, but dynamic usage like `const token = ...; Css.bc(token)` is not, and would force keeping everything anyway, so pruning is likely not really worth it.
+
+(Unlike keyframes, below, which we do prune based on usage, b/c they are sufficiently larger than tokens, and also easier to detect in terms of dynamic usage b/c their names must always be used in an `animation` property.)
+
+#### Keyframes
+
+Truss supports declaring **`keyframes`** for animation in `truss-config.ts`, in addition to just raw CSS blocks in a `.css.ts`.
+
+Using `truss-config.ts` declarations is preferable as then Truss knows about the name: it can check the animations that use it, and write the declaration only while some rule still does.
+
+```typescript
+keyframes: {
+  spin: { to: { transform: "rotate(360deg)" } },
+  pulse: { "0%, 100%": { opacity: 1 }, "50%": { opacity: 0.45 } },
+  sweep: { to: { "--angle": "360deg" } },                // animating a registered property
+  shimmer: "from { background-position: 200% 0; }",      // raw body escape hatch
+  aiStarLoader: null,                                    // defined by another stylesheet
+},
+```
+
+Each entry is a keyframe selector (`from`, `to`, `50%`, `0%, 100%`), which csstype validates like any other declaration — plus custom properties, since animating a registered property is written as a keyframe that sets it. A **string** is a raw body, for a timeline the typed form cannot express. **`null`** declares a name some other stylesheet owns (a global CSS file, a third-party package): Truss accepts the name and writes nothing.
+
+The generated `Css.ts` file will have an **`export enum Keyframes { … }`** with a PascalCase member per name:
+
+```tsx
+<div css={Css.animationName(Keyframes.Spin).animationDuration("0.8s").$} />
+<div css={Css.animation(`${Keyframes.Spin} 0.8s linear infinite`).$} />
+```
+
+Once keyframes are configured, Truss checks every `animation` / `animation-name` usage at build-time and fails the build on a name you have not declared, the same way a mistyped abbreviation does — `Unknown keyframes "spinn" - add it to config.keyframes. Did you mean "spin"?`.
+
+A keyframe declaration is written only when used, so unused animations are pruned — the same effect as declaring them in a `.css.ts` file that is never actually imported.
+
+The disclaimer is that values built at runtime, i.e. `Css.animation(motion)`, leave no name in the CSS, so a) they are not checked, and b) they trigger every configured keyframe to emit, just in case the browser ends up asking for one.
 
 ### Per-Project Utility Methods
 

--- a/packages/app/src/Css.json
+++ b/packages/app/src/Css.json
@@ -2,7 +2,9 @@
   "increment": 8,
   "breakpoints": {"ifPrint":"@media print","ifSm":"@media screen and (max-width: 599px)","ifMd":"@media screen and (min-width: 600px) and (max-width: 959px)","ifSmOrMd":"@media screen and (max-width: 959px)","ifMdAndUp":"@media screen and (min-width: 600px)","ifMdAndDown":"@media screen and (max-width: 959px)","ifLg":"@media screen and (min-width: 960px)","ifMdOrLg":"@media screen and (min-width: 600px)"},
   "typography": ["f24","f18","f16","f14","f12","f10"],
-  "tokens": {"ThemeAccent":"--theme-accent"},
+  "tokens": {"ThemeAccent":"--theme-accent","Angle":"--angle"},
+  "properties": {"--angle":"@property --angle { syntax: \"<angle>\"; inherits: false; initial-value: 0deg; }"},
+  "keyframes": {"spin":"@keyframes spin { to { transform: rotate(360deg); } }","sweep":"@keyframes sweep { to { --angle: 360deg; } }","pulse":"@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }","aiStarLoader":""},
   "abbreviations": {
     "animation": {"kind":"variable","props":["animation"],"incremented":false},
     "animationDelay": {"kind":"variable","props":["animationDelay"],"incremented":false},

--- a/packages/app/src/Css.test.tsx
+++ b/packages/app/src/Css.test.tsx
@@ -1,7 +1,17 @@
 import React from "react";
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, test } from "vitest";
-import { Css, Palette, RuntimeCss, Tokens, useRuntimeStyle, type Only, type Properties, type Xss } from "./Css";
+import {
+  Css,
+  Keyframes,
+  Palette,
+  RuntimeCss,
+  Tokens,
+  useRuntimeStyle,
+  type Only,
+  type Properties,
+  type Xss,
+} from "./Css";
 import { hasCssDeclaration } from "./testCssUtils";
 
 afterEach(cleanup);
@@ -530,6 +540,29 @@ describe("Truss CssBuilder", () => {
     });
   });
 
+  describe("keyframes and registered properties", () => {
+    test("the animated keyframe reaches the document stylesheet", () => {
+      // Given a component whose animation names the configured `spin` keyframe
+      const r = render(<div css={Css.animation(`${Keyframes.Spin} 0.8s linear infinite`).$} />);
+      const el = r.container.firstChild as HTMLElement;
+
+      // Then the rule applies the shorthand with the configured name
+      expect(el).toHaveStyle({ animation: "spin 0.8s linear infinite" });
+      // And the browser can resolve that name, because its block is in the sheet
+      // jsdom normalizes the `to` selector to `100%`
+      expect(keyframesText("spin")).toEqual("100% { transform: rotate(360deg); }");
+    });
+
+    test("a keyframe nothing animates is never written", () => {
+      // Given a render that names no animation at all
+      render(<div css={Css.df.$} />);
+
+      // Then `shimmer` is not a configured keyframe, and `pulse` is configured but unused
+      expect(keyframesText("pulse")).toBeUndefined();
+      expect(keyframesText("shimmer")).toBeUndefined();
+    });
+  });
+
   describe("useRuntimeStyle", () => {
     function UseRuntimeStyleHarness(props: { space: number }) {
       useRuntimeStyle({ ".hook-target": RuntimeCss.mt(props.space).black.$ });
@@ -707,3 +740,25 @@ describe("Truss CssBuilder", () => {
     expect(el).toHaveStyle({ display: "flex", color: "#353535" });
   });
 });
+
+/** The body of an `@keyframes` block in the injected stylesheet, or undefined when none was written. */
+function keyframesText(name: string): string | undefined {
+  for (const rule of allRules()) {
+    if (rule.type === CSSRule.KEYFRAMES_RULE && (rule as CSSKeyframesRule).name === name) {
+      return Array.from((rule as CSSKeyframesRule).cssRules)
+        .map((frame) => frame.cssText)
+        .join(" ");
+    }
+  }
+  return undefined;
+}
+
+function allRules(): CSSRule[] {
+  return Array.from(document.styleSheets).flatMap((sheet) => {
+    try {
+      return Array.from(sheet.cssRules);
+    } catch {
+      return [];
+    }
+  });
+}

--- a/packages/app/src/Css.ts
+++ b/packages/app/src/Css.ts
@@ -43,6 +43,7 @@ export type Typography = "f24" | "f18" | "f16" | "f14" | "f12" | "f10";
 
 export enum Tokens {
   ThemeAccent = "--theme-accent",
+  Angle = "--angle",
 }
 
 export type CssSetVarKeys = Tokens | `--${string}`;
@@ -54,6 +55,13 @@ export type CssSetVarValue = CssSetVarScalar | {
   media?: Partial<Record<Breakpoint, CssSetVarScalar>>;
   container?: Array<{ name?: string; gt?: number; lt?: number; value: CssSetVarScalar }>;
 };
+
+export enum Keyframes {
+  Spin = "spin",
+  Sweep = "sweep",
+  Pulse = "pulse",
+  AiStarLoader = "aiStarLoader",
+}
 
 // Augment React types so all JSX elements accept the `css` prop:
 // - HTMLAttributes/SVGAttributes cover intrinsic elements (div, svg, etc.)

--- a/packages/app/truss-config.ts
+++ b/packages/app/truss-config.ts
@@ -36,6 +36,16 @@ export default defineConfig({
   breakpoints: { sm: 0, md: 600, lg: 960 },
   tokens: {
     ThemeAccent: "--theme-accent",
+    // Registered, so the browser types `--angle` and can interpolate it.
+    Angle: { var: "--angle", syntax: "<angle>", inherits: false, initialValue: "0deg" },
+  },
+  keyframes: {
+    spin: { to: { transform: "rotate(360deg)" } },
+    // Animating a registered property: the only reference to `--angle` is inside this keyframe.
+    sweep: { to: { "--angle": "360deg" } },
+    pulse: { "0%, 100%": { opacity: 1 }, "50%": { opacity: 0.45 } },
+    // Defined by a global stylesheet, not by Truss; declared so animations may still name it.
+    aiStarLoader: null,
   },
   target: "web",
 });

--- a/packages/truss/src/at-rules.ts
+++ b/packages/truss/src/at-rules.ts
@@ -1,0 +1,93 @@
+import { type KeyframesConfig, type TokenDefinition, type TokenRegistry } from "src/config";
+import { camelToKebab } from "src/utils";
+
+/**
+ * The CSS custom property a token names, for either form of `config.tokens`.
+ *
+ * I.e. `"--theme-primary"` → `"--theme-primary"`, and
+ * `{ var: "--angle", syntax: "<angle>" }` → `"--angle"`.
+ */
+export function tokenVarName(token: TokenRegistry[string]): string {
+  return typeof token === "string" ? token : token.var;
+}
+
+/** The registration half of a token, or undefined for the string form, which only names it. */
+export function tokenDefinition(token: TokenRegistry[string]): TokenDefinition | undefined {
+  return typeof token === "string" ? undefined : token;
+}
+
+/** Token member name → CSS custom property, i.e. `{ Angle: "--angle" }`, for both token forms. */
+export function tokenVarNames(tokens: TokenRegistry | undefined): Record<string, string> {
+  const names: Record<string, string> = {};
+  for (const [name, token] of Object.entries(tokens ?? {})) {
+    names[name] = tokenVarName(token);
+  }
+  return names;
+}
+
+/**
+ * CSS custom property → its `@property` block, for the tokens that declare a `syntax`.
+ *
+ * I.e. `{ "--angle": '@property --angle { syntax: "<angle>"; inherits: false; initial-value: 0deg; }' }`.
+ *
+ * Throws when a non-universal syntax has no `initialValue`: the browser drops the whole `@property`
+ * rule in that case, so the token would silently keep behaving as an unregistered one.
+ */
+export function tokenPropertyBlocks(tokens: TokenRegistry | undefined): Record<string, string> {
+  const blocks: Record<string, string> = {};
+  for (const [name, token] of Object.entries(tokens ?? {})) {
+    const definition = tokenDefinition(token);
+    if (!definition) continue;
+    if (definition.syntax !== "*" && definition.initialValue === undefined) {
+      throw new Error(
+        `Token "${name}" has syntax ${JSON.stringify(definition.syntax)} but no initialValue. ` +
+          `@property requires an initial value for every syntax except "*".`,
+      );
+    }
+    blocks[definition.var] = propertyCssText(definition);
+  }
+  return blocks;
+}
+
+/** I.e. `@property --angle { syntax: "<angle>"; inherits: false; initial-value: 0deg; }`. */
+export function propertyCssText(definition: TokenDefinition): string {
+  const descriptors = [`syntax: ${JSON.stringify(definition.syntax)}`, `inherits: ${definition.inherits ?? false}`];
+  if (definition.initialValue !== undefined) {
+    descriptors.push(`initial-value: ${definition.initialValue}`);
+  }
+  return `@property ${definition.var} { ${descriptors.join("; ")}; }`;
+}
+
+/**
+ * Keyframe name → its `@keyframes` block, i.e. `{ spin: "@keyframes spin { to { … } }" }`.
+ *
+ * A name declared as `null` is defined by some other stylesheet, so it maps to an empty block: the
+ * plugin still accepts the name in an animation value, and writes nothing for it.
+ */
+export function keyframesBlocks(keyframes: KeyframesConfig | undefined): Record<string, string> {
+  const blocks: Record<string, string> = {};
+  for (const [name, frames] of Object.entries(keyframes ?? {})) {
+    blocks[name] = frames === null ? "" : keyframesCssText(name, frames);
+  }
+  return blocks;
+}
+
+/**
+ * I.e. `("spin", { to: { transform: "rotate(360deg)" } })` → `@keyframes spin { to { transform: rotate(360deg); } }`.
+ *
+ * Values are written as authored, so numbers stay unitless — a keyframe body is literal CSS, not a
+ * Truss increment. The string form is a raw body and is passed through with its whitespace collapsed.
+ */
+export function keyframesCssText(name: string, frames: NonNullable<KeyframesConfig[string]>): string {
+  if (typeof frames === "string") {
+    return `@keyframes ${name} { ${frames.trim().replace(/\s+/g, " ")} }`;
+  }
+  const steps = Object.entries(frames).map(([selector, properties]) => {
+    const declarations = Object.entries(properties)
+      .filter((entry) => entry[1] !== undefined)
+      .map((entry) => `${camelToKebab(entry[0])}: ${entry[1]};`)
+      .join(" ");
+    return `${selector} { ${declarations} }`;
+  });
+  return `@keyframes ${name} { ${steps.join(" ")} }`;
+}

--- a/packages/truss/src/config.ts
+++ b/packages/truss/src/config.ts
@@ -11,8 +11,59 @@ export type FontConfig = Record<string, string | Properties>;
 /**
  * Maps a design token name (enum member / key) to a CSS custom property name.
  * Values must be valid custom property identifiers (`--…`).
+ *
+ * The object form additionally registers the property with `@property`, i.e. so the browser
+ * types the value and can animate it. See `TokenDefinition`.
  */
-export type TokenRegistry = Record<string, `--${string}`>;
+export type TokenRegistry = Record<string, `--${string}` | TokenDefinition>;
+
+/**
+ * A token that is also registered with `@property`.
+ *
+ * Naming a token and registering it are two different things. The string form of `tokens` only
+ * gives the variable a TypeScript name and emits no CSS. Registering it tells the browser about
+ * the variable: to parse and type-check its value, to fall back to `initialValue` instead of
+ * inheriting an unparsed token stream, and — the reason most design systems want it — to
+ * *interpolate* it, since an unregistered custom property is an opaque token stream that no
+ * transition or keyframe can animate.
+ *
+ * I.e. `{ var: "--angle", syntax: "<angle>", inherits: false, initialValue: "0deg" }` emits
+ * `@property --angle { syntax: "<angle>"; inherits: false; initial-value: 0deg; }`.
+ */
+export interface TokenDefinition {
+  /** The CSS custom property name, i.e. `--angle`. */
+  var: `--${string}`;
+  /** The `@property` syntax descriptor, i.e. `"<angle>"`, or `"*"` to register without typing. */
+  syntax: string;
+  /** The `@property` inherits descriptor. Defaults to `false`. */
+  inherits?: boolean;
+  /** The `@property` initial-value descriptor, i.e. `"0deg"`. Required unless `syntax` is `"*"`. */
+  initialValue?: string;
+}
+
+/**
+ * A map from `@keyframes` name to its animation timeline.
+ *
+ * The object form is keyframe selector (`from`, `to`, `50%`, `0%, 100%`) to declarations, which
+ * csstype validates like any other declaration. The string form is a raw body, for a timeline the
+ * typed form cannot express. Either way Truss owns the name, so it can check the animations that
+ * use it and write the block only when one still does.
+ *
+ * `null` declares a name that some other stylesheet defines — a global CSS file, a third-party
+ * package. Truss accepts the name and writes nothing. Without it, adopting `keyframes` at all would
+ * make every animation Truss did not declare fail the build.
+ *
+ * I.e. `{ spin: { to: { transform: "rotate(360deg)" } }, aiStarLoader: null }`.
+ */
+export type KeyframesConfig = Record<string, Record<string, KeyframeDeclarations> | string | null>;
+
+/**
+ * The declarations in one keyframe selector.
+ *
+ * Custom properties are allowed alongside real CSS properties, because animating a registered
+ * property is written as a keyframe that sets it, i.e. `{ to: { "--angle": "360deg" } }`.
+ */
+export type KeyframeDeclarations = Properties & { [customProperty: `--${string}`]: string | number };
 
 /**
  * Provides users with an easy way to configure the major/most-often configurable
@@ -65,6 +116,12 @@ export interface Config {
    * `Css.setVar({ [Tokens.X]: … })` at build time (web target).
    */
   tokens?: TokenRegistry;
+
+  /**
+   * Optional `@keyframes` animations: emitted as a `Keyframes` enum in generated `Css.ts` (web
+   * target), and written to the stylesheet only while some rule still names them.
+   */
+  keyframes?: KeyframesConfig;
 
   /**
    * Which default methods to include.

--- a/packages/truss/src/generate.test.ts
+++ b/packages/truss/src/generate.test.ts
@@ -33,6 +33,78 @@ describe("generate", () => {
     }
   });
 
+  it("registers tokens with @property and emits a Keyframes enum", async () => {
+    // Given a config with one plain token and one registered with a syntax
+    const dir = mkdtempSync(join(tmpdir(), "truss-generate-"));
+    const config: Config = {
+      outputPath: join(dir, "Css.ts"),
+      palette: {},
+      fonts: {},
+      increment: 8,
+      numberOfIncrements: 1,
+      tokens: {
+        ThemePrimary: "--theme-primary",
+        Angle: { var: "--angle", syntax: "<angle>", inherits: false, initialValue: "0deg" },
+      },
+      // And keyframes in all three forms: typed declarations, a raw body, and a name defined elsewhere
+      keyframes: {
+        spin: { to: { transform: "rotate(360deg)" } },
+        shimmer: "from { background-position: 200% 0; }",
+        aiStarLoader: null,
+      },
+    };
+    try {
+      // When we generate the Css.ts file and its mapping
+      await generate(config);
+      const lines = readFileSync(config.outputPath, "utf8").split("\n");
+      const mapping = JSON.parse(readFileSync(join(dir, "Css.json"), "utf8"));
+
+      // Then both token forms produce the same kind of enum member
+      expect(lines.find((line) => line.includes("ThemePrimary ="))).toEqual('  ThemePrimary = "--theme-primary",');
+      expect(lines.find((line) => line.includes("Angle ="))).toEqual('  Angle = "--angle",');
+      // And every keyframe name is a PascalCase member of its own enum
+      expect(lines.find((line) => line.includes("Spin ="))).toEqual('  Spin = "spin",');
+      expect(lines.find((line) => line.includes("AiStarLoader ="))).toEqual('  AiStarLoader = "aiStarLoader",');
+
+      // And the mapping names both tokens the same way, since registering one does not rename it
+      expect(mapping.tokens).toEqual({ ThemePrimary: "--theme-primary", Angle: "--angle" });
+      // And only the registered one carries an @property block
+      expect(mapping.properties).toEqual({
+        "--angle": '@property --angle { syntax: "<angle>"; inherits: false; initial-value: 0deg; }',
+      });
+      // And the raw body is passed through while the externally defined name maps to no block
+      expect(mapping.keyframes).toEqual({
+        spin: "@keyframes spin { to { transform: rotate(360deg); } }",
+        shimmer: "@keyframes shimmer { from { background-position: 200% 0; } }",
+        aiStarLoader: "",
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws for a registered token whose syntax has no initial value", async () => {
+    // Given a token registered with a real syntax but no initialValue, which the browser would reject
+    const dir = mkdtempSync(join(tmpdir(), "truss-generate-"));
+    const config: Config = {
+      outputPath: join(dir, "Css.ts"),
+      palette: {},
+      fonts: {},
+      increment: 8,
+      numberOfIncrements: 1,
+      tokens: { Angle: { var: "--angle", syntax: "<angle>" } },
+    };
+
+    try {
+      await expect(generate(config)).rejects.toThrow(
+        'Token "Angle" has syntax "<angle>" but no initialValue. ' +
+          '@property requires an initial value for every syntax except "*".',
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("throws for unsupported targets", async () => {
     const config = {
       outputPath: "./ignore.ts",

--- a/packages/truss/src/generate.ts
+++ b/packages/truss/src/generate.ts
@@ -10,6 +10,7 @@ import { pascalCase } from "change-case";
 import { reactNativeSections } from "src/sections/tachyons-rn";
 import { TRUSS_PSEUDO_METHODS } from "src/pseudo-selectors";
 import { SPACING_CUSTOM_PROPERTY } from "src/spacing-css-var";
+import { keyframesBlocks, tokenPropertyBlocks, tokenVarNames } from "src/at-rules";
 
 // A type-only import, so generated files also compile under `verbatimModuleSyntax`
 const CssProperties = imp("t:Properties@csstype");
@@ -21,8 +22,8 @@ export const defaultTypeAliases: Record<string, Array<keyof Properties>> = {
 
 /** Emitted in generated Css.ts before CssBuilder so `setVar` types are in scope. */
 function emitTokensEnumAndSetVarTypes(tokens: Config["tokens"] | undefined): string {
-  const entries =
-    tokens && typeof tokens === "object" ? Object.entries(tokens).filter(([, v]) => typeof v === "string") : [];
+  // Both token forms produce the same enum member; the object form only adds `@property` registration.
+  const entries = Object.entries(tokenVarNames(tokens));
   const hasTokens = entries.length > 0;
   const enumBlock = hasTokens
     ? `export enum Tokens {\n${entries.map(([name, value]) => `  ${name} = ${JSON.stringify(value)},`).join("\n")}\n}\n\n`
@@ -39,6 +40,19 @@ function emitTokensEnumAndSetVarTypes(tokens: Config["tokens"] | undefined): str
       container?: Array<{ name?: string; gt?: number; lt?: number; value: CssSetVarScalar }>;
     };\n\n`;
   return enumBlock + keysType + scalar + valueType;
+}
+
+/**
+ * Emitted in generated Css.ts so `Css.animation(`${Keyframes.Spin} 1s`)` names a checked keyframe.
+ *
+ * I.e. `{ spin: … }` → `export enum Keyframes { Spin = "spin" }`. The member is PascalCase like
+ * `Tokens`, and its value is the name written to the stylesheet.
+ */
+function emitKeyframesEnum(keyframes: Config["keyframes"] | undefined): string {
+  const names = Object.keys(keyframes ?? {});
+  if (names.length === 0) return "";
+  const members = names.map((name) => `  ${pascalCase(name)} = ${JSON.stringify(name)},`).join("\n");
+  return `export enum Keyframes {\n${members}\n}\n\n`;
 }
 
 export async function generate(config: Config): Promise<void> {
@@ -481,7 +495,7 @@ export type ${def("RuntimeStyles")} = RawCssProperties & { readonly __kind: "run
 ${typographyType}
 
 ${emitTokensEnumAndSetVarTypes(tokens)}
-
+${emitKeyframesEnum(config.keyframes)}
 // Augment React types so all JSX elements accept the \`css\` prop:
 // - HTMLAttributes/SVGAttributes cover intrinsic elements (div, svg, etc.)
 // - JSX.IntrinsicAttributes covers custom components (Card, Page, etc.)
@@ -773,6 +787,10 @@ export interface TrussMapping {
   breakpoints?: Record<string, string>;
   typography?: string[];
   tokens?: Record<string, string>;
+  /** CSS custom property → its `@property` block, for the tokens that declare a `syntax`. */
+  properties?: Record<string, string>;
+  /** Keyframe name → its `@keyframes` block, from `config.keyframes`. */
+  keyframes?: Record<string, string>;
   abbreviations: Record<string, TrussMappingEntry>;
 }
 
@@ -836,13 +854,17 @@ function generateTrussMapping(config: Config, entries: WebEntry[]): TrussMapping
     breakpointEntries[`if${pascalCase(name)}`] = mediaQuery;
   }
 
-  const tokenEntries = config.tokens && Object.keys(config.tokens).length > 0 ? config.tokens : undefined;
+  const tokenEntries = tokenVarNames(config.tokens);
+  const propertyEntries = tokenPropertyBlocks(config.tokens);
+  const keyframeEntries = keyframesBlocks(config.keyframes);
 
   return {
     increment: config.increment,
     ...(Object.keys(breakpointEntries).length > 0 ? { breakpoints: breakpointEntries } : {}),
     ...(Object.keys(config.fonts).length > 0 ? { typography: Object.keys(config.fonts) } : {}),
-    ...(tokenEntries ? { tokens: tokenEntries as Record<string, string> } : {}),
+    ...(Object.keys(tokenEntries).length > 0 ? { tokens: tokenEntries } : {}),
+    ...(Object.keys(propertyEntries).length > 0 ? { properties: propertyEntries } : {}),
+    ...(Object.keys(keyframeEntries).length > 0 ? { keyframes: keyframeEntries } : {}),
     abbreviations,
   };
 }
@@ -860,6 +882,12 @@ function condensedJson(mapping: TrussMapping): string {
   }
   if (mapping.tokens && Object.keys(mapping.tokens).length > 0) {
     lines.push(`  "tokens": ${JSON.stringify(mapping.tokens)},`);
+  }
+  if (mapping.properties && Object.keys(mapping.properties).length > 0) {
+    lines.push(`  "properties": ${JSON.stringify(mapping.properties)},`);
+  }
+  if (mapping.keyframes && Object.keys(mapping.keyframes).length > 0) {
+    lines.push(`  "keyframes": ${JSON.stringify(mapping.keyframes)},`);
   }
   lines.push(`  "abbreviations": {`);
   const entries = Object.entries(mapping.abbreviations);

--- a/packages/truss/src/plugin/at-rule-refs.ts
+++ b/packages/truss/src/plugin/at-rule-refs.ts
@@ -1,0 +1,98 @@
+import type { ParsedTrussCss } from "../truss-css";
+import type { TrussMapping } from "./types";
+
+/**
+ * Writes the `@property` and `@keyframes` blocks that `config.tokens` and `config.keyframes` declare.
+ *
+ * The rule for whether a configured at-rule prunes:
+ *
+ * > Truss prunes a configured at-rule when pruning pays for itself: the block has to be big enough
+ * > to matter, and the usage the build cannot resolve statically has to be rare enough that the
+ * > conservative fallback does not fire constantly.
+ *
+ * Keyframe bodies are unbounded, and only an `animation` value built at runtime hides a name, so
+ * keyframes prune. An `@property` block is one line, and any non-px runtime value could be a token,
+ * so pruning registrations would usually be a no-op — registration is unconditional. Neither at-rule
+ * is unknowable; each function below says why its half comes out the way it does.
+ */
+
+/** I.e. `animation: spin 0.8s linear infinite` and `animation-name: spin, pulse` → the whole value. */
+const ANIMATION_VALUE_RE = /\banimation(?:-name)?\s*:\s*([^;}]+)/g;
+
+/**
+ * Add the configured `@keyframes` blocks this CSS still names, so a keyframe prunes with the rules
+ * that animate it: deleting the last rule that names it deletes the block.
+ *
+ * Names are read out of the emitted CSS text rather than out of the resolved chains, because an
+ * animation reaches the stylesheet from several directions — a `Css.animation` value, a
+ * `Css.add("animationName", …)`, and raw `Css.raw` blocks in a `.css.ts`.
+ *
+ * A name can still hide: `Css.animation(motion)` compiles to `animation: var(--animation)` and leaves
+ * the name in the JS bundle. That is detectable and unusual — only an `animation` value does it — so
+ * it falls back to keeping every configured block.
+ */
+export function applyReferencedKeyframes(css: ParsedTrussCss, mapping: TrussMapping): void {
+  const configured = mapping.keyframes ?? {};
+  if (Object.keys(configured).length === 0) return;
+
+  const cssTexts = [...css.rules.map((rule) => rule.cssText), ...css.arbitraryCssBlocks.map((block) => block.cssText)];
+  const alreadyEmitted = new Set(css.keyframes.map((block) => block.name));
+  for (const name of referencedKeyframes(cssTexts, Object.keys(configured))) {
+    // An empty block is a name another stylesheet defines; Truss only accepts it, never writes it.
+    if (alreadyEmitted.has(name) || configured[name].length === 0) continue;
+    css.keyframes.push({ name, cssText: configured[name] });
+  }
+}
+
+/**
+ * Add the `@property` block of every registered token, once, to the whole stylesheet.
+ *
+ * Registration does not prune, and not because the usage cannot be seen. `Css.bc(Tokens.Angle)`
+ * resolves to `Tokens.Angle` during chain resolution, so `collectAtomicRules` could hand the emitter
+ * a set of referenced tokens the way it already hands it `needsMaybeCssVar`. Pruning is skipped
+ * because it would not pay for itself. `maybeCssVar` exists so a `--token` can flow through a
+ * runtime value, i.e. `Css.color(c)`, so any non-px runtime argument might be a token and would have
+ * to fall back to keeping every registration — a fallback that fires for a great many real apps.
+ * The saving would be one fixed line per unused token, and only the object form of `tokens` writes
+ * one at all, so the cost of being wrong (a dropped registration silently stops an animation)
+ * outweighs it.
+ *
+ * A registered token replaces the `syntax: "*"` block Truss writes for its own runtime variables, at
+ * that block's position, so the typed form wins no matter which source the merge saw first. The
+ * replacement is a new entry rather than an edit, because a merged stylesheet shares its declaration
+ * objects with the cached library CSS they came from.
+ */
+export function applyRegisteredProperties(css: ParsedTrussCss, mapping: TrussMapping): void {
+  const pending = new Map(Object.entries(mapping.properties ?? {}));
+  if (pending.size === 0) return;
+
+  for (let i = 0; i < css.properties.length; i++) {
+    const varName = css.properties[i].varName;
+    const cssText = pending.get(varName);
+    if (cssText === undefined) continue;
+    css.properties[i] = { varName, cssText };
+    pending.delete(varName);
+  }
+  for (const [varName, cssText] of pending) {
+    css.properties.push({ varName, cssText });
+  }
+}
+
+/**
+ * The configured keyframe names that some `animation` or `animation-name` declaration uses.
+ *
+ * An animation value built at runtime, i.e. `Css.animation(duration)`, reaches the stylesheet as
+ * `animation: var(--animation)` and hides its name, so every configured keyframe is kept rather than
+ * pruning one the browser will ask for. Literal values still prune exactly.
+ */
+function referencedKeyframes(cssTexts: string[], names: string[]): string[] {
+  if (names.length === 0) return [];
+  const referenced = new Set<string>();
+  for (const cssText of cssTexts) {
+    for (const match of cssText.matchAll(ANIMATION_VALUE_RE)) {
+      if (match[1].includes("var(")) return names;
+      for (const token of match[1].trim().split(/[\s,]+/)) referenced.add(token);
+    }
+  }
+  return names.filter((name) => referenced.has(name));
+}

--- a/packages/truss/src/plugin/emit-css.test.ts
+++ b/packages/truss/src/plugin/emit-css.test.ts
@@ -28,6 +28,7 @@ test("structured emission retains duplicate property declarations and exact prod
       { varName: "--width", cssText: '@property --width { syntax: "*"; inherits: false; }' },
       { varName: "--width", cssText: '@property --width { syntax: "*"; inherits: false; }' },
     ],
+    keyframes: [],
     arbitraryCssBlocks: [],
   });
   expect(generateCssText(rules)).toEqual(

--- a/packages/truss/src/plugin/emit-css.ts
+++ b/packages/truss/src/plugin/emit-css.ts
@@ -1,7 +1,8 @@
 import { chainSegments, type ResolvedChain } from "./resolve-chain";
 import { isCssSegment, type CssSegment, type ResolvedSegment, type TrussMapping, type WhenCondition } from "./types";
 import { sortRulesByPriority } from "./priority";
-import { camelToKebab, markerClassName, styleEntriesForSegment } from "./style-entries";
+import { markerClassName, styleEntriesForSegment } from "./style-entries";
+import { camelToKebab } from "../utils";
 import { WHEN_RELATIONSHIPS, type WhenRelationship } from "./when-relationships";
 import { variableValueNeedsMaybeCssVar } from "../css-custom-property";
 import type { ParsedTrussCss } from "../truss-css";

--- a/packages/truss/src/plugin/emit-css.ts
+++ b/packages/truss/src/plugin/emit-css.ts
@@ -157,6 +157,7 @@ export function generateCssData(rules: Map<string, AtomicRule>): ParsedTrussCss 
       cssText: formatRule(entry.rule),
     })),
     properties: [],
+    keyframes: [],
     arbitraryCssBlocks: [],
   };
 

--- a/packages/truss/src/plugin/index.test.ts
+++ b/packages/truss/src/plugin/index.test.ts
@@ -1137,6 +1137,110 @@ describe("trussPlugin", () => {
       ].join("\n"),
     );
   });
+
+  test("writes a configured @keyframes block only while a rule still animates it", () => {
+    // Given a mapping with two configured keyframes and a registered token
+    const root = createTempRoot();
+    writeMapping(
+      join(root, "src", "Css.json"),
+      { anim: { kind: "variable", props: ["animation"], incremented: false } },
+      {
+        properties: { "--angle": '@property --angle { syntax: "<angle>"; inherits: false; initial-value: 0deg; }' },
+        keyframes: {
+          spin: "@keyframes spin { to { transform: rotate(360deg); } }",
+          pulse: "@keyframes pulse { 50% { opacity: 0.45; } }",
+        },
+      },
+    );
+    const plugin = trussPlugin({ mapping: "./src/Css.json" });
+    runConfigHooks(plugin, root);
+
+    // And an application module that animates `spin` and never mentions `pulse`
+    runTransform(
+      plugin,
+      `import { Css } from "./Css"; const s = Css.anim("spin 1s linear infinite").$;`,
+      join(root, "src", "App.tsx"),
+    );
+
+    // When the stylesheet is served
+    const css = getVirtualCss(plugin);
+
+    // Then the animated keyframe is written, the unused one is not, and the token stays registered
+    expect(css).toBe(
+      [
+        ":root { --t-spacing: 8px; }",
+        "/* @truss p:1000 c:anim_spin_1s_linear_infinite */",
+        ".anim_spin_1s_linear_infinite { animation: spin 1s linear infinite; }",
+        "/* @truss @property */",
+        '@property --angle { syntax: "<angle>"; inherits: false; initial-value: 0deg; }',
+        "/* @truss @keyframes */",
+        "@keyframes spin { to { transform: rotate(360deg); } }",
+      ].join("\n"),
+    );
+  });
+
+  test("drops a configured @keyframes block once the module that animated it is gone", () => {
+    // Given the same mapping, with `spin` configured
+    const root = createTempRoot();
+    writeMapping(
+      join(root, "src", "Css.json"),
+      {
+        anim: { kind: "variable", props: ["animation"], incremented: false },
+        df: { kind: "static", defs: { display: "flex" } },
+      },
+      { keyframes: { spin: "@keyframes spin { to { transform: rotate(360deg); } }" } },
+    );
+    const plugin = trussPlugin({ mapping: "./src/Css.json" });
+    runConfigHooks(plugin, root);
+
+    // And a build whose only animating module has been deleted, so just the flex module is transformed
+    runTransform(plugin, `import { Css } from "./Css"; const s = Css.df.$;`, join(root, "src", "App.tsx"));
+
+    // When the stylesheet is served
+    const css = getVirtualCss(plugin);
+
+    // Then nothing names `spin`, so its block is not written at all
+    expect(css).toBe([":root { --t-spacing: 8px; }", "/* @truss p:3000 c:df */", ".df { display: flex; }"].join("\n"));
+  });
+
+  test("keeps a keyframe a .css.ts raw block animates", () => {
+    // Given a mapping with a configured keyframe
+    const root = createTempRoot();
+    writeMapping(
+      join(root, "src", "Css.json"),
+      { df: { kind: "static", defs: { display: "flex" } } },
+      { keyframes: { spin: "@keyframes spin { to { transform: rotate(360deg); } }" } },
+    );
+    // And a .css.ts whose raw body names it, rather than a Css chain
+    const cssTsPath = join(root, "src", "App.css.ts");
+    mkdirSync(dirname(cssTsPath), { recursive: true });
+    writeFileSync(
+      cssTsPath,
+      'import { Css } from "./Css";\nexport const css = { ".loader": Css.raw`animation: spin 1s linear infinite;` };\n',
+      "utf8",
+    );
+    const plugin = trussPlugin({ mapping: "./src/Css.json" });
+    runConfigHooks(plugin, root);
+    const resolvedId = invokeHook(plugin.resolveId, {} as unknown, "./App.css.ts?truss-css", cssTsPath);
+    invokeHook(plugin.load, {} as unknown, resolvedId);
+
+    // When the stylesheet is served
+    const css = getVirtualCss(plugin);
+
+    // Then the raw block counts as a reference, the same as a Css.anim chain would
+    expect(css).toBe(
+      [
+        ":root { --t-spacing: 8px; }",
+        "/* @truss @keyframes */",
+        "@keyframes spin { to { transform: rotate(360deg); } }",
+        "/* @truss arbitrary:start */",
+        ".loader {",
+        "  animation: spin 1s linear infinite;",
+        "}",
+        "/* @truss arbitrary:end */",
+      ].join("\n"),
+    );
+  });
 });
 
 function n(s: string): string {
@@ -1149,10 +1253,15 @@ function createTempRoot(): string {
   return root;
 }
 
-function writeMapping(path: string, abbreviations: Record<string, Record<string, unknown>>): void {
+function writeMapping(
+  path: string,
+  abbreviations: Record<string, Record<string, unknown>>,
+  extra: Record<string, unknown> = {},
+): void {
   mkdirSync(dirname(path), { recursive: true });
   const mapping = {
     increment: 8,
+    ...extra,
     abbreviations,
   };
   writeFileSync(path, `${JSON.stringify(mapping, null, 2)}\n`, "utf8");

--- a/packages/truss/src/plugin/index.ts
+++ b/packages/truss/src/plugin/index.ts
@@ -5,6 +5,8 @@ import { type PluginContext } from "rollup";
 import { rewriteCssTsImports } from "./rewrite-css-ts-imports";
 import { createTrussTransformSession } from "./transform-session";
 import { splitArbitraryCss } from "./test-css";
+import { applyReferencedKeyframes } from "./at-rule-refs";
+import type { ParsedTrussCss } from "../truss-css";
 import { rootSpacingPreludeCss } from "../spacing-css-var";
 import { generate, parseModule, traverse } from "./babel-utils";
 import { findNamedImportBinding, reservePreferredName, upsertNamedImports } from "./ast-utils";
@@ -251,8 +253,18 @@ __injectTrussCSS(${JSON.stringify(payload)});
       if (id.startsWith(VIRTUAL_TEST_CSS_PREFIX)) {
         const sourcePath = canonicalSourcePath(id.slice(VIRTUAL_TEST_CSS_PREFIX.length));
         session.updateArbitraryCssRegistry(sourcePath, readFileSync(sourcePath, "utf8"), diagnostics(this));
+        const arbitraryRules = splitArbitraryCss(session.getArbitraryCss(sourcePath));
+        // Raw blocks name keyframes too, so this module carries the ones it animates.
+        const atRules: ParsedTrussCss = {
+          rules: [],
+          properties: [],
+          keyframes: [],
+          arbitraryCssBlocks: arbitraryRules.map((cssText) => ({ cssText })),
+        };
+        applyReferencedKeyframes(atRules, session.ensureMapping());
         const payload = {
-          arbitraryRules: splitArbitraryCss(session.getArbitraryCss(sourcePath)),
+          arbitraryRules,
+          ...(atRules.keyframes.length > 0 ? { keyframes: atRules.keyframes } : {}),
           source: sourcePath,
         };
         return `

--- a/packages/truss/src/plugin/keyframe-names.ts
+++ b/packages/truss/src/plugin/keyframe-names.ts
@@ -1,0 +1,91 @@
+import { UnsupportedPatternError } from "./chain-nodes";
+import type { TrussMapping } from "./types";
+import { closestName } from "./unknown-abbreviation";
+
+/**
+ * Every keyword the `animation` shorthand accepts besides the animation name.
+ *
+ * The set is closed by the CSS grammar, so checking against it is exact rather than a heuristic:
+ * anything left over in an `animation` value is a `<custom-ident>`, which can only be a keyframe name.
+ */
+const ANIMATION_KEYWORDS = new Set([
+  // CSS-wide
+  "inherit",
+  "initial",
+  "unset",
+  "revert",
+  "revert-layer",
+  // <single-animation-iteration-count>, <single-animation-name>, <single-animation-fill-mode>
+  "infinite",
+  "none",
+  "forwards",
+  "backwards",
+  "both",
+  // <single-animation-direction>
+  "normal",
+  "reverse",
+  "alternate",
+  "alternate-reverse",
+  // <single-animation-play-state>
+  "running",
+  "paused",
+  // <easing-function>
+  "linear",
+  "ease",
+  "ease-in",
+  "ease-out",
+  "ease-in-out",
+  "step-start",
+  "step-end",
+  // <single-animation-timeline>
+  "auto",
+]);
+
+/** I.e. `1s`, `0.8s`, `100ms`, `3`, `.5` — a time or an iteration count, never a name. */
+const NUMERIC_TOKEN_RE = /^[+-]?(\d+\.?\d*|\.\d+)(m?s)?$/;
+
+/**
+ * Reject an `animation` or `animation-name` value that names a keyframe `config.keyframes` does not
+ * declare, the same way a mistyped abbreviation is rejected.
+ *
+ * I.e. `Css.animation("spinn 1s linear infinite")` with `spin` configured fails the build with
+ * `Unknown keyframes "spinn". Did you mean "spin"?`.
+ *
+ * The check runs only once a project declares keyframes in config, so a project that has not adopted
+ * the feature keeps its raw `@keyframes` blocks working. Once it has, every animation name must come
+ * from config — a body the typed form cannot express goes in as a `keyframes` string instead of a raw
+ * block, so there is still one registry of names.
+ *
+ * A value is skipped when it interpolates a runtime expression, since the name is not knowable.
+ */
+export function validateAnimationValue(props: string[], value: string, mapping: TrussMapping): void {
+  const configured = mapping.keyframes;
+  if (!configured || Object.keys(configured).length === 0) return;
+  if (!props.some((prop) => ANIMATION_PROPERTIES.has(prop))) return;
+  if (value.includes("var(")) return;
+
+  for (const rawToken of value.trim().split(/[\s,]+/)) {
+    // A name may also be written as a string, i.e. `animation-name: "spin"`.
+    const token = rawToken.replace(/^["']|["']$/g, "");
+    if (token.length === 0) continue;
+    // Functions (`steps(4)`), dashed idents (`--my-timeline`), times, and counts are never names.
+    if (token.includes("(") || token.includes(")") || token.startsWith("--")) continue;
+    if (NUMERIC_TOKEN_RE.test(token)) continue;
+    if (ANIMATION_KEYWORDS.has(token.toLowerCase())) continue;
+    if (Object.hasOwn(configured, token)) continue;
+    throw new UnknownKeyframesError(token, Object.keys(configured));
+  }
+}
+
+/** The properties whose value can name a keyframe, in both the camelCase and CSS spellings. */
+const ANIMATION_PROPERTIES = new Set(["animation", "animationName", "animation-name"]);
+
+/** An animation name that is absent from `config.keyframes`. */
+export class UnknownKeyframesError extends UnsupportedPatternError {
+  constructor(name: string, candidates: string[]) {
+    const suggestion = closestName(name, candidates);
+    super(
+      `Unknown keyframes "${name}" - add it to config.keyframes${suggestion ? `. Did you mean "${suggestion}"?` : ""}`,
+    );
+  }
+}

--- a/packages/truss/src/plugin/merge-css.test.ts
+++ b/packages/truss/src/plugin/merge-css.test.ts
@@ -373,6 +373,7 @@ function parsedTrussCss(input: Partial<ParsedTrussCss>): ParsedTrussCss {
   return {
     rules: input.rules ?? [],
     properties: input.properties ?? [],
+    keyframes: input.keyframes ?? [],
     arbitraryCssBlocks: input.arbitraryCssBlocks ?? [],
   };
 }

--- a/packages/truss/src/plugin/merge-css.ts
+++ b/packages/truss/src/plugin/merge-css.ts
@@ -1,7 +1,13 @@
 import { readFileSync } from "fs";
 import { atRulePrelude, compareRuleSortKeys, ruleSortKey } from "../css-order";
 import { parseTrussCss, serializeTrussCss } from "./truss-css";
-import type { ParsedArbitraryCssBlock, ParsedCssRule, ParsedPropertyDeclaration, ParsedTrussCss } from "../truss-css";
+import type {
+  ParsedArbitraryCssBlock,
+  ParsedCssRule,
+  ParsedKeyframesBlock,
+  ParsedPropertyDeclaration,
+  ParsedTrussCss,
+} from "../truss-css";
 
 /**
  * Read and parse an annotated truss.css file from disk.
@@ -19,14 +25,17 @@ export function readTrussCss(filePath: string): ParsedTrussCss {
  * Rules are deduplicated by class name (first occurrence wins, since
  * deterministic output means identical class names produce identical rules),
  * then sorted with the same comparator emit-css uses: priority, then media-query width, then class name.
- * @property declarations are deduplicated by variable name and appended next.
- * Arbitrary CSS blocks are left opaque and appended in source order at the end.
+ * @property declarations are deduplicated by variable name and appended next, then @keyframes
+ * blocks by animation name. Arbitrary CSS blocks are left opaque and appended in source order at
+ * the end.
  */
 export function mergeTrussCssData(sources: ParsedTrussCss[]): ParsedTrussCss {
   const seenClasses = new Set<string>();
   const allRules: ParsedCssRule[] = [];
   const seenProperties = new Set<string>();
   const allProperties: ParsedPropertyDeclaration[] = [];
+  const seenKeyframes = new Set<string>();
+  const allKeyframes: ParsedKeyframesBlock[] = [];
   const allArbitraryCssBlocks: ParsedArbitraryCssBlock[] = [];
 
   for (const source of sources) {
@@ -42,6 +51,12 @@ export function mergeTrussCssData(sources: ParsedTrussCss[]): ParsedTrussCss {
         allProperties.push(prop);
       }
     }
+    for (const block of source.keyframes) {
+      if (!seenKeyframes.has(block.name)) {
+        seenKeyframes.add(block.name);
+        allKeyframes.push(block);
+      }
+    }
     allArbitraryCssBlocks.push(...source.arbitraryCssBlocks);
   }
 
@@ -54,6 +69,7 @@ export function mergeTrussCssData(sources: ParsedTrussCss[]): ParsedTrussCss {
   return {
     rules: decorated.map((entry) => entry.rule),
     properties: allProperties,
+    keyframes: allKeyframes,
     arbitraryCssBlocks: allArbitraryCssBlocks,
   };
 }

--- a/packages/truss/src/plugin/resolve-calls.ts
+++ b/packages/truss/src/plugin/resolve-calls.ts
@@ -12,6 +12,7 @@ import { type CallChainNode, UnsupportedPatternError } from "./chain-nodes";
 import { cloneConditionContext } from "./condition-context";
 import { requireEntry, staticSegment } from "./resolve-entry";
 import { isCustomPropertyLiteral, singleArg, tryEvaluatePropertyLiteral, tryNumericLiteral } from "./resolve-literals";
+import { validateAnimationValue } from "./keyframe-names";
 import { resolveSetVarCall } from "./resolve-setvar";
 import { resolveTypographyCall } from "./resolve-typography";
 
@@ -116,6 +117,8 @@ function resolveLiteralOrVariableSegment(params: {
   context: ResolvedConditionContext;
 }): ResolvedSegment {
   const { abbr, props, incremented, appendPx = false, extraDefs, argAst, literalValue, mapping, context } = params;
+
+  if (literalValue !== null) validateAnimationValue(props, literalValue, mapping);
 
   if (literalValue !== null && !isCustomPropertyLiteral(argAst, mapping)) {
     const defs: Record<string, unknown> = Object.fromEntries(props.map((prop) => [prop, literalValue]));

--- a/packages/truss/src/plugin/resolve-literals.ts
+++ b/packages/truss/src/plugin/resolve-literals.ts
@@ -2,7 +2,9 @@ import * as t from "@babel/types";
 import type { TrussMapping } from "./types";
 import { memberPropertyName, staticPropertyName, unwrapExpression } from "./ast-utils";
 import { type CallChainNode, UnsupportedPatternError } from "./chain-nodes";
+import { pascalCase } from "change-case";
 import { isCustomPropertyName, maybeCssVar } from "../css-custom-property";
+import { UnknownKeyframesError } from "./keyframe-names";
 import { incrementCssValue } from "../spacing-css-var";
 
 // ── Literal evaluation ────────────────────────────────────────────────
@@ -36,12 +38,38 @@ export function tryResolveValueLiteral(node: t.Expression, mapping?: TrussMappin
   if (mapping) {
     const token = tryResolveTokensMember(node, mapping);
     if (token !== null) return token;
+    const keyframes = tryResolveKeyframesMember(node, mapping);
+    if (keyframes !== null) return keyframes;
+    const template = tryResolveTemplateLiteral(node, mapping);
+    if (template !== null) return template;
   }
   if (t.isStringLiteral(node)) {
     return node.value;
   }
   const numeric = tryNumericLiteral(node);
   return numeric === null ? null : String(numeric);
+}
+
+/**
+ * Resolve a template literal whose every interpolation is itself a literal.
+ *
+ * Interpolated custom property names are wrapped, because a token inside a larger value has to read
+ * as `var(--angle)`, i.e. `` `conic-gradient(from ${Tokens.Angle}, red)` `` →
+ * `conic-gradient(from var(--angle), red)`. A template with a runtime expression stays unresolved and
+ * becomes a `_var` tuple like any other runtime value.
+ */
+function tryResolveTemplateLiteral(node: t.Expression, mapping: TrussMapping): string | null {
+  if (!t.isTemplateLiteral(node)) return null;
+  let result = node.quasis[0].value.cooked ?? node.quasis[0].value.raw;
+  for (let i = 0; i < node.expressions.length; i++) {
+    const expression = node.expressions[i];
+    if (!t.isExpression(expression)) return null;
+    const resolved = tryResolveValueLiteral(expression, mapping);
+    if (resolved === null) return null;
+    const quasi = node.quasis[i + 1];
+    result += maybeCssVar(resolved) + (quasi.value.cooked ?? quasi.value.raw);
+  }
+  return result;
 }
 
 /** I.e. `12` → 12 and `-12` → -12; null for anything but a (negated) numeric literal. */
@@ -69,6 +97,27 @@ function tryResolveTokensMember(node: t.Expression, mapping: TrussMapping): stri
     throw new UnsupportedPatternError(`Unknown token "${memberName}" - add it to config.tokens`);
   }
   return tokenMap[memberName];
+}
+
+/** Resolve `Keyframes.Member` / `Keyframes["Member"]` to an animation name, i.e. `Keyframes.Spin` → `spin`. */
+function tryResolveKeyframesMember(node: t.Expression, mapping: TrussMapping): string | null {
+  if (!t.isMemberExpression(node) || !t.isIdentifier(node.object, { name: "Keyframes" })) return null;
+  const memberName = memberPropertyName(node);
+  if (memberName === null) return null;
+
+  const keyframesMap = mapping.keyframes;
+  if (!keyframesMap) {
+    throw new UnsupportedPatternError(`Keyframes.* requires config.keyframes`);
+  }
+  // The enum member is PascalCase, i.e. `Keyframes.Spin`, while the configured name is the CSS one.
+  const name = Object.keys(keyframesMap).find((configured) => pascalCase(configured) === memberName);
+  if (name === undefined) {
+    throw new UnknownKeyframesError(
+      memberName,
+      Object.keys(keyframesMap).map((configured) => pascalCase(configured)),
+    );
+  }
+  return name;
 }
 
 // ── Argument and object-literal validation ────────────────────────────

--- a/packages/truss/src/plugin/style-entries.ts
+++ b/packages/truss/src/plugin/style-entries.ts
@@ -188,11 +188,6 @@ function whenPrefix(whenPseudo: WhenCondition): string {
   return `wh_${rel}_${pseudoPrefix}_${markerPart}`;
 }
 
-/** I.e. `"backgroundColor"` → `"background-color"`, `"WebkitTransform"` → `"-webkit-transform"`. */
-export function camelToKebab(s: string): string {
-  return s.replace(/^(Webkit|Moz|Ms|O)/, (m) => `-${m.toLowerCase()}`).replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
-}
-
 /** Collapse anything that is not a letter or digit into single underscores, i.e. `"0 0 0 1px blue"` → `"0_0_0_1px_blue"`. */
 export function sanitizeClassNameToken(value: string): string {
   return value

--- a/packages/truss/src/plugin/test-css.test.ts
+++ b/packages/truss/src/plugin/test-css.test.ts
@@ -5,9 +5,14 @@ import { createTestCssPayload, splitArbitraryCss } from "./test-css";
 
 describe("createTestCssPayload", () => {
   test("omits empty arrays and caller metadata", () => {
-    expect(createTestCssPayload({ rules: [], properties: [], arbitraryCssBlocks: [] })).toEqual({});
+    expect(createTestCssPayload({ rules: [], properties: [], keyframes: [], arbitraryCssBlocks: [] })).toEqual({});
     expect(
-      createTestCssPayload({ rules: [], properties: [], arbitraryCssBlocks: [{ cssText: "/* only */" }] }),
+      createTestCssPayload({
+        rules: [],
+        properties: [],
+        keyframes: [],
+        arbitraryCssBlocks: [{ cssText: "/* only */" }],
+      }),
     ).toEqual({});
   });
 
@@ -27,6 +32,7 @@ describe("createTestCssPayload", () => {
         },
       ],
       properties: [{ varName: "--width", cssText: '@property --width { syntax: "*"; inherits: false; }' }],
+      keyframes: [],
       arbitraryCssBlocks: [],
     });
     const restored: TestCssPayload = JSON.parse(JSON.stringify(payload));
@@ -62,6 +68,7 @@ describe("createTestCssPayload", () => {
       createTestCssPayload({
         rules: [],
         properties: [],
+        keyframes: [],
         arbitraryCssBlocks: [{ cssText: "/* first */ .a { color: red; }" }, { cssText: ".a { color: red; }" }],
       }),
     ).toEqual({ arbitraryRules: [".a { color: red; }", ".a { color: red; }"] });
@@ -104,7 +111,9 @@ describe("splitArbitraryCss", () => {
     "preserves recovered EOF rule text: %s",
     (cssText) => {
       expect(splitArbitraryCss(cssText)).toEqual([cssText]);
-      expect(createTestCssPayload({ rules: [], properties: [], arbitraryCssBlocks: [{ cssText }] })).toEqual({
+      expect(
+        createTestCssPayload({ rules: [], properties: [], keyframes: [], arbitraryCssBlocks: [{ cssText }] }),
+      ).toEqual({
         arbitraryRules: [cssText],
       });
     },
@@ -113,7 +122,12 @@ describe("splitArbitraryCss", () => {
   test("ignores unterminated top-level comments", () => {
     expect(splitArbitraryCss("/* unterminated")).toEqual([]);
     expect(
-      createTestCssPayload({ rules: [], properties: [], arbitraryCssBlocks: [{ cssText: "/* unterminated" }] }),
+      createTestCssPayload({
+        rules: [],
+        properties: [],
+        keyframes: [],
+        arbitraryCssBlocks: [{ cssText: "/* unterminated" }],
+      }),
     ).toEqual({});
     expect(splitArbitraryCss(".a { color: red; } /* unterminated")).toEqual([".a { color: red; }"]);
   });

--- a/packages/truss/src/plugin/test-css.ts
+++ b/packages/truss/src/plugin/test-css.ts
@@ -13,6 +13,7 @@ export function createTestCssPayload(css: ParsedTrussCss): TestCssPayload {
     });
   }
   if (css.properties.length > 0) payload.properties = css.properties;
+  if (css.keyframes.length > 0) payload.keyframes = css.keyframes;
   const arbitraryRules = css.arbitraryCssBlocks.flatMap((block) => splitArbitraryCss(block.cssText));
   if (arbitraryRules.length > 0) payload.arbitraryRules = arbitraryRules;
   return payload;

--- a/packages/truss/src/plugin/transform-css.test.ts
+++ b/packages/truss/src/plugin/transform-css.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { join, dirname } from "path";
 import { tmpdir } from "os";
 import { transformCssTs } from "./transform-css";
-import { camelToKebab } from "./style-entries";
+import { camelToKebab } from "../utils";
 import { loadMapping, trussPlugin } from "./index";
 import { resolve } from "path";
 

--- a/packages/truss/src/plugin/transform-css.ts
+++ b/packages/truss/src/plugin/transform-css.ts
@@ -3,7 +3,7 @@ import { type DiagnosticOptions, type TrussMapping } from "./types";
 import { resolveFullChain } from "./resolve-chain";
 import { extractDollarChain, findCssImportBinding, unwrapExpression } from "./ast-utils";
 import { collectStaticStringBindings, resolveStaticString } from "./css-ts-utils";
-import { camelToKebab } from "./style-entries";
+import { camelToKebab } from "../utils";
 import { parseModule } from "./babel-utils";
 import { Diagnostic } from "./diagnostic";
 

--- a/packages/truss/src/plugin/transform-session.ts
+++ b/packages/truss/src/plugin/transform-session.ts
@@ -1,4 +1,5 @@
 import { resolve } from "path";
+import { applyReferencedKeyframes, applyRegisteredProperties } from "./at-rule-refs";
 import { generateCssData, type AtomicRule } from "./emit-css";
 import { transformCssTs } from "./transform-css";
 import { transformTruss, type TransformResult, type TransformTrussOptions } from "./transform";
@@ -101,7 +102,11 @@ export function createTrussTransformSession(options: TrussTransformSessionOption
       .join("\n\n");
     if (allArbitrary.length > 0) appCss.arbitraryCssBlocks.push({ cssText: allArbitrary });
     const libs = loadLibraries();
-    const body = serializeTrussCss(libs.length === 0 ? appCss : mergeTrussCssData([...libs, appCss]), annotate);
+    const merged = libs.length === 0 ? appCss : mergeTrussCssData([...libs, appCss]);
+    // After the merge, so a keyframe sees every animation in the stylesheet, libraries included.
+    applyReferencedKeyframes(merged, mapping);
+    applyRegisteredProperties(merged, mapping);
+    const body = serializeTrussCss(merged, annotate);
     if (body.length === 0) return "";
     return `${rootSpacingPreludeCss(mapping.increment)}\n${body}`;
   }
@@ -110,9 +115,16 @@ export function createTrussTransformSession(options: TrussTransformSessionOption
     return cssRegistry.size > 0 || arbitraryCssRegistry.size > 0 || libraryPaths.length > 0;
   }
 
-  /** Collect only libraries; application modules deliver their own CSS in tests. */
+  /**
+   * Collect only libraries; application modules deliver their own CSS in tests.
+   *
+   * Registered `@property` blocks ride along here rather than in each module, because registration
+   * is stylesheet-wide state that does not prune with any one rule.
+   */
   function collectTestCss(): TestCssPayload {
-    return createTestCssPayload(mergeTrussCssData(loadLibraries()));
+    const css = mergeTrussCssData(loadLibraries());
+    applyRegisteredProperties(css, ensureMapping());
+    return createTestCssPayload(css);
   }
 
   /** Read the transformed arbitrary CSS for one canonical source file. */

--- a/packages/truss/src/plugin/transform.test.ts
+++ b/packages/truss/src/plugin/transform.test.ts
@@ -284,7 +284,170 @@ describe("transform", () => {
       .anim_pulse_2s_ease_in_out_infinite {
         animation: pulse 2s ease-in-out infinite;
       }
+      @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }
     `,
+    );
+  });
+
+  test("names a configured keyframe through the Keyframes enum", () => {
+    // Given an animation whose name comes from the generated Keyframes enum
+    const source = `
+      import { Css, Keyframes } from "./Css";
+      const s = Css.animationName(Keyframes.Spin).$;
+      `;
+    // When we transform the file
+    const transform = expectTrussTransform(source);
+    // Then the member resolves to the configured name, and its block travels with the rule
+    transform.toHaveTrussOutput(
+      `
+      import { Keyframes } from "./Css";
+      const s = { animationName: "animn_spin" };
+      `,
+      `
+      .animn_spin { animation-name: spin; }
+      @keyframes spin { to { transform: rotate(360deg); } }
+      `,
+    );
+  });
+
+  test("interpolates a Keyframes member into an animation shorthand", () => {
+    // Given the shorthand built as a template literal around the enum member
+    const source = `
+      import { Css, Keyframes } from "./Css";
+      const s = Css.animation(\`\${Keyframes.Spin} 0.8s linear infinite\`).$;
+      `;
+    // When we transform the file
+    const transform = expectTrussTransform(source);
+    // Then the whole value resolves at build time, so it is a static class rather than a runtime var
+    transform.toHaveTrussOutput(
+      `
+      import { Keyframes } from "./Css";
+      const s = { animation: "anim_spin_0_8s_linear_infinite" };
+      `,
+      `
+      .anim_spin_0_8s_linear_infinite { animation: spin 0.8s linear infinite; }
+      @keyframes spin { to { transform: rotate(360deg); } }
+      `,
+    );
+  });
+
+  test("interpolates a token into a larger value as var()", () => {
+    // Given a token used inside a function rather than as the whole value
+    const source = `
+      import { Css, Tokens } from "./Css";
+      const s = Css.add("backgroundImage", \`conic-gradient(from \${Tokens.Angle}, red, blue)\`).$;
+      `;
+    // When we transform the file
+    const transform = expectTrussTransform(source);
+    // Then the interpolation is wrapped, since a bare `--angle` is not a value
+    transform.toHaveTrussOutput(
+      `
+      import { Tokens } from "./Css";
+      const s = { backgroundImage: "bgi_conic_gradient_from_var_angle_red_blue" };
+      `,
+      `
+      .bgi_conic_gradient_from_var_angle_red_blue { background-image: conic-gradient(from var(--angle), red, blue); }
+      `,
+    );
+  });
+
+  test("rejects an animation name that config.keyframes does not declare", () => {
+    // Given a misspelling of the configured `spin` keyframe
+    const source = `
+      import { Css } from "./Css";
+      const s = Css.animation("spinn 1s linear infinite").$;
+      `;
+    // When we transform the file
+    const transform = expectTrussTransform(source);
+    // Then the build reports the unknown name with the nearest configured one
+    transform.toHaveTrussOutput(
+      `
+      console.error("[truss] Unsupported pattern: Unknown keyframes \\"spinn\\" - add it to config.keyframes. Did you mean \\"spin\\"? (test.tsx:2)");
+      const s = {};
+      `,
+      ``,
+    );
+  });
+
+  test("rejects a Keyframes member that config.keyframes does not declare", () => {
+    // Given a misspelling of the `Spin` enum member
+    const source = `
+      import { Css, Keyframes } from "./Css";
+      const s = Css.animationName(Keyframes.Spinn).$;
+      `;
+    // When we transform the file
+    const transform = expectTrussTransform(source);
+    // Then the member is reported the same way a mistyped token is
+    transform.toHaveTrussOutput(
+      `
+      import { Keyframes } from "./Css";
+      console.error("[truss] Unsupported pattern: Unknown keyframes \\"Spinn\\" - add it to config.keyframes. Did you mean \\"Spin\\"? (test.tsx:2)");
+      const s = {};
+      `,
+      ``,
+    );
+  });
+
+  test("accepts a keyframe name another stylesheet defines and writes no block", () => {
+    // Given `aiStarLoader`, which truss-config declares as null because a global stylesheet owns it
+    const source = `
+      import { Css } from "./Css";
+      const s = Css.animationName("aiStarLoader").$;
+      `;
+    // When we transform the file
+    const transform = expectTrussTransform(source);
+    // Then the name passes the check, and Truss emits only the rule
+    transform.toHaveTrussOutput(
+      `
+      const s = { animationName: "animn_aiStarLoader" };
+      `,
+      `
+      .animn_aiStarLoader { animation-name: aiStarLoader; }
+      `,
+    );
+  });
+
+  test("keeps every keyframe when an animation value is only known at runtime", () => {
+    // Given an animation whose value is a runtime expression, so no name is visible to the build
+    const source = `
+      import { Css } from "./Css";
+      function f(motion: string) { return Css.animation(motion).$; }
+      `;
+    // When we transform the file
+    const transform = expectTrussTransform(source);
+    // Then no block is pruned, since the browser may ask for any of them
+    transform.toHaveTrussOutput(
+      `
+      import { maybeCssVar } from "@homebound/truss/runtime";
+      function f(motion: string) { return { animation: ["animation_var", { "--animation": maybeCssVar(motion) }] }; }
+      `,
+      `
+      .animation_var { animation: var(--animation); }
+      @property --animation { syntax: "*"; inherits: false; }
+      @keyframes spin { to { transform: rotate(360deg); } }
+      @keyframes sweep { to { --angle: 360deg; } }
+      @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }
+      `,
+    );
+  });
+
+  test("animating a registered property emits the keyframe that sets it", () => {
+    // Given the `sweep` keyframe, whose only declaration is the registered `--angle` token
+    const source = `
+      import { Css } from "./Css";
+      const s = Css.animation("sweep 2s linear infinite").$;
+      `;
+    // When we transform the file
+    const transform = expectTrussTransform(source);
+    // Then the keyframe body carries the custom property the browser interpolates
+    transform.toHaveTrussOutput(
+      `
+      const s = { animation: "anim_sweep_2s_linear_infinite" };
+      `,
+      `
+      .anim_sweep_2s_linear_infinite { animation: sweep 2s linear infinite; }
+      @keyframes sweep { to { --angle: 360deg; } }
+      `,
     );
   });
 

--- a/packages/truss/src/plugin/transform.ts
+++ b/packages/truss/src/plugin/transform.ts
@@ -20,6 +20,7 @@ import {
   upsertNamedImports,
   type NamedImport,
 } from "./ast-utils";
+import { applyReferencedKeyframes } from "./at-rule-refs";
 import { collectAtomicRules, generateCssData, type AtomicRule } from "./emit-css";
 import { serializeTrussCss } from "./truss-css";
 import { createTestCssPayload } from "./test-css";
@@ -138,6 +139,8 @@ export function transformTruss(
   const chains = sites.map((s) => s.resolvedChain);
   const { rules, needsMaybeInc, needsMaybeCssVar } = collectAtomicRules(chains, mapping);
   const cssData = generateCssData(rules);
+  // Each test module carries the keyframes its own rules name; production merges them once.
+  applyReferencedKeyframes(cssData, mapping);
   const cssText = serializeTrussCss(cssData);
 
   // Step 4: Reserve local names for injected helpers

--- a/packages/truss/src/plugin/truss-css.test.ts
+++ b/packages/truss/src/plugin/truss-css.test.ts
@@ -18,6 +18,7 @@ test("serialization omits only generated annotations when requested", () => {
         cssText: '@property --color { syntax: "<color>"; inherits: false; initial-value: red; }',
       },
     ],
+    keyframes: [{ name: "spin", cssText: "@keyframes spin { to { transform: rotate(360deg); } }" }],
     arbitraryCssBlocks: [{ cssText: '/* user comment */\n.label::after { content: "/* @truss literal */"; }' }],
   };
 
@@ -28,6 +29,8 @@ test("serialization omits only generated annotations when requested", () => {
       css.rules[0].cssText,
       "/* @truss @property */",
       css.properties[0].cssText,
+      "/* @truss @keyframes */",
+      css.keyframes[0].cssText,
       "/* @truss arbitrary:start */",
       css.arbitraryCssBlocks[0].cssText,
       "/* @truss arbitrary:end */",
@@ -37,10 +40,12 @@ test("serialization omits only generated annotations when requested", () => {
 
   // When serialized for an application, then CSS bodies and user comments remain unchanged
   expect(serializeTrussCss(css, false)).toBe(
-    [css.rules[0].cssText, css.properties[0].cssText, css.arbitraryCssBlocks[0].cssText].join("\n"),
+    [css.rules[0].cssText, css.properties[0].cssText, css.keyframes[0].cssText, css.arbitraryCssBlocks[0].cssText].join(
+      "\n",
+    ),
   );
 });
 
 test.each([true, false])("empty CSS stays empty with annotate=%s", (annotate) => {
-  expect(serializeTrussCss({ rules: [], properties: [], arbitraryCssBlocks: [] }, annotate)).toBe("");
+  expect(serializeTrussCss({ rules: [], properties: [], keyframes: [], arbitraryCssBlocks: [] }, annotate)).toBe("");
 });

--- a/packages/truss/src/plugin/truss-css.ts
+++ b/packages/truss/src/plugin/truss-css.ts
@@ -1,10 +1,19 @@
-import type { ParsedArbitraryCssBlock, ParsedCssRule, ParsedPropertyDeclaration, ParsedTrussCss } from "../truss-css";
+import type {
+  ParsedArbitraryCssBlock,
+  ParsedCssRule,
+  ParsedKeyframesBlock,
+  ParsedPropertyDeclaration,
+  ParsedTrussCss,
+} from "../truss-css";
 
 /** Regex matching `/* @truss p:<priority> c:<className> *\/` annotations. */
 const RULE_ANNOTATION_RE = /^\/\* @truss p:([\d.]+) c:(\S+) \*\/$/;
 
 /** Regex matching `/* @truss @property *\/` annotations. */
 const PROPERTY_ANNOTATION_RE = /^\/\* @truss @property \*\/$/;
+
+/** Regex matching `/* @truss @keyframes *\/` annotations. */
+const KEYFRAMES_ANNOTATION_RE = /^\/\* @truss @keyframes \*\/$/;
 
 /** Regex matching the start of an annotated arbitrary CSS block. */
 const ARBITRARY_START_RE = /^\/\* @truss arbitrary:start \*\/$/;
@@ -15,18 +24,22 @@ const ARBITRARY_END_RE = /^\/\* @truss arbitrary:end \*\/$/;
 /** Regex to extract the variable name from `@property --foo { ... }`. */
 const PROPERTY_VAR_RE = /^@property\s+(--\S+)/;
 
+/** Regex to extract the animation name from `@keyframes spin { ... }`. */
+const KEYFRAMES_NAME_RE = /^@keyframes\s+([^\s{]+)/;
+
 /**
- * Parse an annotated truss.css file into rules, @property declarations,
+ * Parse an annotated truss.css file into rules, @property declarations, @keyframes blocks,
  * and arbitrary CSS blocks.
  *
  * The file must contain `/* @truss p:<priority> c:<className> *\/` comments
- * before each CSS rule, and `/* @truss @property *\/` before each @property declaration.
- * Unannotated lines are ignored.
+ * before each CSS rule, `/* @truss @property *\/` before each @property declaration, and
+ * `/* @truss @keyframes *\/` before each @keyframes block. Unannotated lines are ignored.
  */
 export function parseTrussCss(cssText: string): ParsedTrussCss {
   const lines = cssText.split("\n");
   const rules: ParsedCssRule[] = [];
   const properties: ParsedPropertyDeclaration[] = [];
+  const keyframes: ParsedKeyframesBlock[] = [];
   const arbitraryCssBlocks: ParsedArbitraryCssBlock[] = [];
 
   let i = 0;
@@ -63,6 +76,17 @@ export function parseTrussCss(cssText: string): ParsedTrussCss {
       continue;
     }
 
+    // Check for @keyframes annotation
+    if (KEYFRAMES_ANNOTATION_RE.test(line)) {
+      const keyframesLine = takeAnnotatedLine();
+      const nameMatch = keyframesLine === null ? null : KEYFRAMES_NAME_RE.exec(keyframesLine);
+      if (keyframesLine !== null && nameMatch) {
+        keyframes.push({ cssText: keyframesLine, name: nameMatch[1] });
+      }
+      i++;
+      continue;
+    }
+
     if (ARBITRARY_START_RE.test(line)) {
       i++;
       const blockLines: string[] = [];
@@ -83,7 +107,7 @@ export function parseTrussCss(cssText: string): ParsedTrussCss {
     i++;
   }
 
-  return { rules, properties, arbitraryCssBlocks };
+  return { rules, properties, keyframes, arbitraryCssBlocks };
 }
 
 /** Serialize structured CSS without changing rule order or removing duplicate declarations. */
@@ -96,6 +120,10 @@ export function serializeTrussCss(css: ParsedTrussCss, annotate = true): string 
   for (const prop of css.properties) {
     if (annotate) lines.push(`/* @truss @property */`);
     lines.push(prop.cssText);
+  }
+  for (const block of css.keyframes) {
+    if (annotate) lines.push(`/* @truss @keyframes */`);
+    lines.push(block.cssText);
   }
   for (const block of css.arbitraryCssBlocks) {
     lines.push(annotate ? annotateArbitraryCssBlock(block.cssText) : block.cssText.trim());

--- a/packages/truss/src/plugin/types.ts
+++ b/packages/truss/src/plugin/types.ts
@@ -19,6 +19,10 @@ export interface TrussMapping {
   typography?: string[];
   /** Token member name → CSS variable (from `config.tokens`), for `setVar` key resolution. */
   tokens?: Record<string, string>;
+  /** CSS variable → its `@property` block, for the tokens `config.tokens` registers with a `syntax`. */
+  properties?: Record<string, string>;
+  /** Keyframe name → its `@keyframes` block (from `config.keyframes`). */
+  keyframes?: Record<string, string>;
   abbreviations: Record<string, TrussMappingEntry>;
 }
 

--- a/packages/truss/src/plugin/unknown-abbreviation.ts
+++ b/packages/truss/src/plugin/unknown-abbreviation.ts
@@ -3,18 +3,18 @@ import { UnsupportedPatternError } from "./chain-nodes";
 /** An entry name that is absent from the configured abbreviation mapping. */
 export class UnknownAbbreviationError extends UnsupportedPatternError {
   constructor(abbreviation: string, candidates: string[]) {
-    const suggestion = closestAbbreviation(abbreviation, candidates);
+    const suggestion = closestName(abbreviation, candidates);
     super(`Unknown abbreviation "${abbreviation}"${suggestion ? `. Did you mean "${suggestion}"?` : ""}`);
   }
 }
 
 /**
- * Find the nearest mapping key within two insertions, deletions, or substitutions.
+ * Find the nearest candidate within two insertions, deletions, or substitutions.
  * Each row stores exact Levenshtein distances for prefixes of one candidate.
- * I.e. abbreviation "acent" and candidate "accent" finish with distance 1.
- * Equal distances keep the first mapping key; unrelated names yield no suggestion.
+ * I.e. name "acent" and candidate "accent" finish with distance 1.
+ * Equal distances keep the first candidate; unrelated names yield no suggestion.
  */
-function closestAbbreviation(abbreviation: string, candidates: string[]): string | undefined {
+export function closestName(abbreviation: string, candidates: string[]): string | undefined {
   let closest: string | undefined;
   let bestDistance = 3;
   for (const candidate of candidates) {

--- a/packages/truss/src/runtime-css.ts
+++ b/packages/truss/src/runtime-css.ts
@@ -4,7 +4,7 @@ import type { TestCssPayload } from "./test-css";
 interface InstalledRule {
   id: string;
   cssText: string;
-  /** Prelude, atomic rules, property declarations, then arbitrary CSS. */
+  /** Prelude, atomic rules, at-rule definitions (@property / @keyframes), then arbitrary CSS. */
   section: 0 | 1 | 2 | 3;
   key: RuleSortKey | null;
   order: number;
@@ -42,7 +42,11 @@ let trussStyleElement: TrussStyleElement | null = null;
 export function __injectTrussCSS(payload: TestCssPayload): void {
   if (
     typeof document === "undefined" ||
-    (!payload.rules?.length && !payload.properties?.length && !payload.arbitraryRules?.length && !payload.prelude)
+    (!payload.rules?.length &&
+      !payload.properties?.length &&
+      !payload.keyframes?.length &&
+      !payload.arbitraryRules?.length &&
+      !payload.prelude)
   )
     return;
   if (payload.arbitraryRules?.length && !payload.source) {
@@ -81,6 +85,10 @@ export function __injectTrussCSS(payload: TestCssPayload): void {
       changed =
         installRule(state, { ...base, id: `property:${property.varName}`, section: 2, cssText: property.cssText }) ||
         changed;
+    }
+    for (const block of payload.keyframes ?? []) {
+      changed =
+        installRule(state, { ...base, id: `keyframes:${block.name}`, section: 2, cssText: block.cssText }) || changed;
     }
     for (const [position, cssText] of (payload.arbitraryRules ?? []).entries()) {
       changed =

--- a/packages/truss/src/runtime.test.ts
+++ b/packages/truss/src/runtime.test.ts
@@ -546,6 +546,29 @@ describe("__injectTrussCSS", () => {
     expect(sheetRules(sheet)).toEqual([".df { display: flex; }", ":root { --gap: 8px; }"]);
   });
 
+  test("installs keyframes once per name, after atomic rules and before arbitrary CSS", () => {
+    // Given an atomic rule, a keyframe block, and an arbitrary block from a .css.ts
+    const atomic = atomicPayload(3000, "df", ".df { display: flex; }");
+    const keyframes: TestCssPayload = {
+      keyframes: [{ name: "spin", cssText: "@keyframes spin { to { transform: rotate(360deg); } }" }],
+    };
+    const arbitrary: TestCssPayload = { source: "/target.css.ts", arbitraryRules: [".target { color: red; }"] };
+
+    // When each payload is injected, and the keyframe payload arrives a second time
+    __injectTrussCSS(atomic);
+    const sheet = trussStyle().sheet!;
+    __injectTrussCSS(keyframes);
+    __injectTrussCSS(arbitrary);
+    const insert = vi.spyOn(sheet, "insertRule");
+    // And that repeat is a fresh object, as a second module evaluating the same import would deliver
+    __injectTrussCSS(JSON.parse(JSON.stringify(keyframes)));
+
+    // Then the name is deduplicated rather than reinserted
+    expect(insert.mock.calls).toEqual([]);
+    // And the block sits between the atomic rule and the arbitrary one, matching the production order
+    expect(sheetRules(sheet)).toEqual(productionRules([atomic, keyframes, arbitrary]));
+  });
+
   test("retains the prelude from an empty bootstrap before all later rules", () => {
     const prelude = ":root { --truss-ready: 1; }";
     __injectTrussCSS({ prelude });
@@ -671,6 +694,7 @@ function productionRules(sources: TestCssPayload[]): string[] {
       sources.map((source) => ({
         rules: source.rules ?? [],
         properties: source.properties ?? [],
+        keyframes: source.keyframes ?? [],
         arbitraryCssBlocks: source.arbitraryRules?.length ? [{ cssText: source.arbitraryRules.join("\n") }] : [],
       })),
     ),

--- a/packages/truss/src/test-css.ts
+++ b/packages/truss/src/test-css.ts
@@ -1,4 +1,4 @@
-import type { ParsedCssRule, ParsedPropertyDeclaration } from "./truss-css";
+import type { ParsedCssRule, ParsedKeyframesBlock, ParsedPropertyDeclaration } from "./truss-css";
 
 /** An atomic rule ready for CSSOM insertion, with query metadata supplied by the plugin. */
 export interface TestCssRule extends ParsedCssRule {
@@ -9,6 +9,7 @@ export interface TestCssRule extends ParsedCssRule {
 export interface TestCssPayload {
   rules?: TestCssRule[];
   properties?: ParsedPropertyDeclaration[];
+  keyframes?: ParsedKeyframesBlock[];
   /** Complete top-level rules, split by the plugin with nested at-rules left intact. */
   arbitraryRules?: string[];
   /** Canonical application source path, or the combined library source; required for arbitrary rules. */

--- a/packages/truss/src/truss-css.ts
+++ b/packages/truss/src/truss-css.ts
@@ -12,6 +12,13 @@ export interface ParsedPropertyDeclaration {
   varName: string;
 }
 
+/** A parsed @keyframes block extracted from an annotated truss.css file. */
+export interface ParsedKeyframesBlock {
+  cssText: string;
+  /** The animation name, i.e. `spin`. */
+  name: string;
+}
+
 /** A parsed arbitrary CSS block extracted from an annotated truss.css file. */
 export interface ParsedArbitraryCssBlock {
   cssText: string;
@@ -21,5 +28,6 @@ export interface ParsedArbitraryCssBlock {
 export interface ParsedTrussCss {
   rules: ParsedCssRule[];
   properties: ParsedPropertyDeclaration[];
+  keyframes: ParsedKeyframesBlock[];
   arbitraryCssBlocks: ParsedArbitraryCssBlock[];
 }

--- a/packages/truss/src/utils.ts
+++ b/packages/truss/src/utils.ts
@@ -6,3 +6,8 @@ export function lowerCaseFirst(s: string): string {
 export function quote(s: string): string {
   return JSON.stringify(s);
 }
+
+/** I.e. `"backgroundColor"` → `"background-color"`, `"WebkitTransform"` → `"-webkit-transform"`. */
+export function camelToKebab(s: string): string {
+  return s.replace(/^(Webkit|Moz|Ms|O)/, (m) => `-${m.toLowerCase()}`).replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
+}


### PR DESCRIPTION
Adds `truss-config.ts` support for the two at-rules a design system reaches for. Both previously only worked as raw CSS in a `.css.ts`, where nothing checked an animation name and nothing knew a token was meant to be typed or animatable.

## Registering a token with `@property`

A token can now be an object instead of a string, which also emits an `@property` block for it:

```ts
tokens: {
  ThemePrimary: "--theme-primary",                                       // named only
  Angle: { var: "--angle", syntax: "<angle>", inherits: false, initialValue: "0deg" },
},
```

The string form is unchanged, so this is backwards compatible.

Registering is what tells the browser to type-check the value, fall back to `initialValue`, and — the reason most design systems want it — interpolate the variable. An unregistered custom property is an opaque token stream that no transition or keyframe can animate.

This hangs off `tokens` instead of a separate `properties: { "--angle": … }` map so that each variable is named in one place. Two maps keyed differently, one by member name and one by variable name, would drift.

Using a registered token is no different from using any other: `Css.setVar({ [Tokens.Angle]: "45deg" })` to write it, `Tokens.Angle` as a whole value to read it. No per-token methods are generated — `Palette` sets the precedent with `Palette.Primary` rather than a `Css.setPrimary(…)`.

`initialValue` is required for every `syntax` except `"*"`. The browser drops the whole rule without one, so codegen throws rather than emitting something inert.

## Keyframes

```ts
keyframes: {
  spin: { to: { transform: "rotate(360deg)" } },
  sweep: { to: { "--angle": "360deg" } },              // animating a registered property
  shimmer: "from { background-position: 200% 0; }",    // raw body escape hatch
  aiStarLoader: null,                                  // defined by another stylesheet
},
```

Each entry maps a keyframe selector to its declarations, which csstype validates like any other. Custom properties are allowed too, since animating a registered property is written as a keyframe that sets it.

Codegen emits a `Keyframes` enum. A template literal whose interpolations all resolve now compiles statically, so ``Css.animation(`${Keyframes.Spin} 0.8s linear infinite`)`` becomes a static class rather than a runtime variable.

Once any keyframes are configured, an unknown animation name fails the build with a did-you-mean, the same way a mistyped abbreviation does. That is only safe because every name lives in config, which is what the other two forms are for: a string is a raw body, for a timeline the typed form cannot express, and `null` declares a name that another stylesheet owns. Two existing tests animated names defined outside Truss, which is what surfaced the need for `null`.

Interpolating a token into a larger value also wraps correctly now: ``Css.add("backgroundImage", `conic-gradient(from ${Tokens.Angle}, red, blue)`)`` → `conic-gradient(from var(--angle), red, blue)`.

## Keyframes prune, registrations do not

A keyframe block is written only while some `animation` / `animation-name` value still names it, so an animation you stop using stops shipping. A `.css.ts` already got that for free by being imported or not, but a config entry has no file to delete, so without the check a shared config would ship every animation it declares to every app that consumes it.

`@property` blocks are emitted unconditionally — not because the usage is invisible, since `Css.bc(Tokens.Angle)` resolves during chain resolution. It is that `maybeCssVar` exists so a `--token` can flow through a runtime value, so any non-px runtime argument might be a token, and the conservative fallback would keep everything anyway. That fallback fires for a lot of real apps. The saving would be one line per unused token, weighed against a dropped registration silently stopping an animation.

Registrations are also stylesheet-wide rather than per-rule, so they are applied once to the merged stylesheet rather than to each module's payload.

## Notes

- Both at-rules travel through the existing `ParsedTrussCss` plumbing, so library-plus-app merging works unchanged. A registered block replaces the automatic `syntax: "*"` block at its position, so the typed form wins regardless of merge order.
- `config.keyframes` is web-only; the React Native target emits no `Keyframes` enum.
- The first commit is a pure refactor (`camelToKebab` to `utils`, sharing the did-you-mean helper) and passes the suite on its own.
- `packages/app/truss-config.ts` gains a registered token and four keyframes as fixtures, so `Css.ts` / `Css.json` are regenerated.

Full workspace green: 450 truss, 89 app, 25 tachyons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
