### PR TITLE
feat: Add a Css method for each keyframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1080,18 +1080,29 @@ keyframes: {
 
 Each entry is a keyframe selector (`from`, `to`, `50%`, `0%, 100%`), which csstype validates like any other declaration — plus custom properties, since animating a registered property is written as a keyframe that sets it. A **string** is a raw body, for a timeline the typed form cannot express. **`null`** declares a name some other stylesheet owns (a global CSS file, a third-party package): Truss accepts the name and writes nothing.
 
-The generated `Css.ts` file will have an **`export enum Keyframes { … }`** with a PascalCase member per name:
+Each keyframe also gets its own utility method, which puts the name in front of the rest of the `animation` shorthand:
+
+```tsx
+<div css={Css.spin("0.8s linear infinite").$} />
+```
+
+The method is named after the keyframe, camelCased, i.e. `fade-in` becomes `Css.fadeIn(...)`. When that name is already an abbreviation, an alias, or a `CssBuilder` method, the method is named `animate` plus the keyframe, i.e. a keyframe named `float` becomes `Css.animateFloat(...)`, so the `Css.float(...)` property method keeps its name. If both names are taken, generation fails and asks you to rename the keyframe.
+
+The generated `Css.ts` file also has an **`export enum Keyframes { … }`** with a PascalCase member per name, for the animations one method cannot write, i.e. two animations on one element:
 
 ```tsx
 <div css={Css.animationName(Keyframes.Spin).animationDuration("0.8s").$} />
 <div css={Css.animation(`${Keyframes.Spin} 0.8s linear infinite`).$} />
+<div css={Css.animation(`${Keyframes.Spin} 0.8s linear infinite, ${Keyframes.Pulse} 2s ease-in-out infinite`).$} />
 ```
+
+`Css.spin("0.8s linear infinite")` and ``Css.animation(`${Keyframes.Spin} 0.8s linear infinite`)`` resolve to the same declaration, and so share one atomic class.
 
 Once keyframes are configured, Truss checks every `animation` / `animation-name` usage at build-time and fails the build on a name you have not declared, the same way a mistyped abbreviation does — `Unknown keyframes "spinn" - add it to config.keyframes. Did you mean "spin"?`.
 
 A keyframe declaration is written only when used, so unused animations are pruned — the same effect as declaring them in a `.css.ts` file that is never actually imported.
 
-The disclaimer is that values built at runtime, i.e. `Css.animation(motion)`, leave no name in the CSS, so a) they are not checked, and b) they trigger every configured keyframe to emit, just in case the browser ends up asking for one.
+The disclaimer is that values built at runtime, i.e. `Css.animation(motion)`, leave no name in the CSS, so a) they are not checked, and b) they trigger every configured keyframe to emit, just in case the browser ends up asking for one. This holds for `Css.spin(timing)` too: the name is written into the runtime value, so the animation still runs, but the CSS only says `animation: var(--animation)`, so every keyframe is kept.
 
 ### Per-Project Utility Methods
 

--- a/packages/app/src/Css.json
+++ b/packages/app/src/Css.json
@@ -4,7 +4,7 @@
   "typography": ["f24","f18","f16","f14","f12","f10"],
   "tokens": {"ThemeAccent":"--theme-accent","Angle":"--angle"},
   "properties": {"--angle":"@property --angle { syntax: \"<angle>\"; inherits: false; initial-value: 0deg; }"},
-  "keyframes": {"spin":"@keyframes spin { to { transform: rotate(360deg); } }","sweep":"@keyframes sweep { to { --angle: 360deg; } }","pulse":"@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }","aiStarLoader":""},
+  "keyframes": {"spin":"@keyframes spin { to { transform: rotate(360deg); } }","sweep":"@keyframes sweep { to { --angle: 360deg; } }","pulse":"@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }","aiStarLoader":"","fade-in":"@keyframes fade-in { from { opacity: 0; } }","float":"@keyframes float { to { transform: translateY(-4px); } }"},
   "abbreviations": {
     "animation": {"kind":"variable","props":["animation"],"incremented":false},
     "animationDelay": {"kind":"variable","props":["animationDelay"],"incremented":false},
@@ -564,6 +564,12 @@
     "zInitial": {"kind":"static","defs":{"zIndex":"initial"}},
     "zUnset": {"kind":"static","defs":{"zIndex":"unset"}},
     "z": {"kind":"variable","props":["zIndex"],"incremented":false},
-    "bodyText": {"kind":"alias","chain":["f14","black"]}
+    "bodyText": {"kind":"alias","chain":["f14","black"]},
+    "spin": {"kind":"keyframe","name":"spin"},
+    "sweep": {"kind":"keyframe","name":"sweep"},
+    "pulse": {"kind":"keyframe","name":"pulse"},
+    "aiStarLoader": {"kind":"keyframe","name":"aiStarLoader"},
+    "fadeIn": {"kind":"keyframe","name":"fade-in"},
+    "animateFloat": {"kind":"keyframe","name":"float"}
   }
 }

--- a/packages/app/src/Css.ts
+++ b/packages/app/src/Css.ts
@@ -61,6 +61,8 @@ export enum Keyframes {
   Sweep = "sweep",
   Pulse = "pulse",
   AiStarLoader = "aiStarLoader",
+  FadeIn = "fade-in",
+  Float = "float",
 }
 
 // Augment React types so all JSX elements accept the `css` prop:
@@ -2470,6 +2472,32 @@ class CssBuilder<T extends Properties, S extends StyleKind = "buildtime"> {
   // aliases
   get bodyText() {
     return this.f14.black;
+  }
+
+  // keyframes
+  /** Sets `animation: spin value`. */
+  spin(value: string) {
+    return this.add("animation", `spin ${value}`);
+  }
+  /** Sets `animation: sweep value`. */
+  sweep(value: string) {
+    return this.add("animation", `sweep ${value}`);
+  }
+  /** Sets `animation: pulse value`. */
+  pulse(value: string) {
+    return this.add("animation", `pulse ${value}`);
+  }
+  /** Sets `animation: aiStarLoader value`. */
+  aiStarLoader(value: string) {
+    return this.add("animation", `aiStarLoader ${value}`);
+  }
+  /** Sets `animation: fade-in value`. */
+  fadeIn(value: string) {
+    return this.add("animation", `fade-in ${value}`);
+  }
+  /** Sets `animation: float value`. */
+  animateFloat(value: string) {
+    return this.add("animation", `float ${value}`);
   }
 
   get $(): T & { readonly __kind: S } {

--- a/packages/app/truss-config.ts
+++ b/packages/app/truss-config.ts
@@ -46,6 +46,10 @@ export default defineConfig({
     pulse: { "0%, 100%": { opacity: 1 }, "50%": { opacity: 0.45 } },
     // Defined by a global stylesheet, not by Truss; declared so animations may still name it.
     aiStarLoader: null,
+    // A kebab-case name, so its method is `Css.fadeIn(...)`.
+    "fade-in": { from: { opacity: 0 } },
+    // A name the tachyons `float` method already owns, so its method is `Css.animateFloat(...)`.
+    float: { to: { transform: "translateY(-4px)" } },
   },
   target: "web",
 });

--- a/packages/truss/src/generate.test.ts
+++ b/packages/truss/src/generate.test.ts
@@ -83,6 +83,30 @@ describe("generate", () => {
     }
   });
 
+  it("throws for a keyframe whose method name is taken twice over", async () => {
+    // Given a keyframe named `float`, which the tachyons `float` method already owns
+    const dir = mkdtempSync(join(tmpdir(), "truss-generate-"));
+    const config: Config = {
+      outputPath: join(dir, "Css.ts"),
+      palette: {},
+      fonts: {},
+      increment: 8,
+      numberOfIncrements: 1,
+      // And an alias that owns the `animateFloat` name the keyframe would fall back to
+      aliases: { animateFloat: ["df"] },
+      keyframes: { float: { to: { transform: "translateY(-4px)" } } },
+    };
+
+    try {
+      await expect(generate(config)).rejects.toThrow(
+        'Keyframes "float" cannot have a Css method: "float" and "animateFloat" are both already taken. ' +
+          "Rename the keyframe.",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("throws for a registered token whose syntax has no initial value", async () => {
     // Given a token registered with a real syntax but no initialValue, which the browser would reject
     const dir = mkdtempSync(join(tmpdir(), "truss-generate-"));

--- a/packages/truss/src/generate.ts
+++ b/packages/truss/src/generate.ts
@@ -3,7 +3,14 @@ import { promises as fs } from "fs";
 import { code, Code, def, imp } from "ts-poet";
 import { makeBreakpoints } from "src/breakpoints";
 import { Config, SectionName, Sections, UtilityMethod } from "src/config";
-import { newAliasesMethods, startWebCollection, stopWebCollection, WebEntry } from "src/methods";
+import {
+  collectedAbbreviations,
+  newAliasesMethods,
+  startWebCollection,
+  stopWebCollection,
+  WebEntry,
+} from "src/methods";
+import { newKeyframesMethods } from "src/keyframe-methods";
 import { defaultSections } from "src/sections/tachyons";
 import { quote } from "src/utils";
 import { pascalCase } from "change-case";
@@ -59,7 +66,7 @@ export async function generate(config: Config): Promise<void> {
   const { outputPath } = config;
   const target: string = config.target ?? "web";
   if (target === "web") {
-    const { sections, entries } = collectWebGenerationData(config);
+    const { sections, entries } = generateSections(config);
     // For web target: generate a web-friendly CssBuilder (for types/IDE) + a mapping JSON
     const cssOutput = generateWebCssBuilder(config, sections).toString();
     await fs.writeFile(outputPath, cssOutput);
@@ -80,7 +87,7 @@ export async function generate(config: Config): Promise<void> {
 
 function generateReactNativeBuilder(config: Config): Code {
   const { fonts, increment, extras, typeAliases, breakpoints = {}, palette, tokens } = config;
-  const sections = generateSections(config);
+  const { sections } = generateSections(config);
 
   const lines = Object.entries(sections)
     .map(([name, value]) => [`// ${name}`, ...value, ""])
@@ -370,30 +377,32 @@ function generateMethods(config: Config, methodFns: Sections): Record<SectionNam
   return Object.fromEntries(Object.entries(methodFns).map(([name, fn]) => [name, fn(config)]));
 }
 
-/** Returns all utility sections configured for this project. */
-function generateSections(config: Config): Record<string, UtilityMethod[]> {
+/**
+ * Returns all utility sections configured for this project, with the `WebEntry` metadata the web
+ * mapping is built from.
+ *
+ * Keyframe methods come last, so a keyframe only falls back to its `animate<Name>` spelling when a
+ * utility method, a custom section, or an alias already owns the plain name.
+ */
+function generateSections(config: Config): { sections: Record<string, UtilityMethod[]>; entries: WebEntry[] } {
   const { aliases, defaultMethods = "tachyons", sections: customSections } = config;
-  return {
-    ...(defaultMethods === "tachyons"
-      ? generateMethods(config, defaultSections)
-      : defaultMethods === "tachyons-rn"
-        ? generateMethods(config, reactNativeSections)
-        : {}),
-    ...(customSections ? generateMethods(config, customSections) : {}),
-    ...(aliases && { aliases: newAliasesMethods(aliases) }),
-  };
-}
-
-/** Runs section generation once with collection enabled for web outputs. */
-function collectWebGenerationData(config: Config): {
-  sections: Record<string, UtilityMethod[]>;
-  entries: WebEntry[];
-} {
   startWebCollection();
   try {
-    const sections = generateSections(config);
-    const entries = stopWebCollection();
-    return { sections, entries };
+    const sections: Record<string, UtilityMethod[]> = {
+      ...(defaultMethods === "tachyons"
+        ? generateMethods(config, defaultSections)
+        : defaultMethods === "tachyons-rn"
+          ? generateMethods(config, reactNativeSections)
+          : {}),
+      ...(customSections ? generateMethods(config, customSections) : {}),
+      ...(aliases && { aliases: newAliasesMethods(aliases) }),
+    };
+    // `@keyframes` are a web-only feature, like the `Keyframes` enum itself.
+    if (config.target !== "react-native") {
+      const keyframes = newKeyframesMethods(config, collectedAbbreviations());
+      if (keyframes.length > 0) sections.keyframes = keyframes;
+    }
+    return { sections, entries: stopWebCollection() };
   } catch (error) {
     stopWebCollection();
     throw error;
@@ -798,7 +807,8 @@ export type TrussMappingEntry =
   | { kind: "static"; defs: Record<string, unknown> }
   | { kind: "variable"; props: string[]; incremented: boolean; extraDefs?: Record<string, unknown> }
   | { kind: "delegate"; target: string }
-  | { kind: "alias"; chain: string[] };
+  | { kind: "alias"; chain: string[] }
+  | { kind: "keyframe"; name: string };
 
 /**
  * Generates the truss mapping JSON that the Vite plugin uses to resolve
@@ -842,6 +852,12 @@ function generateTrussMapping(config: Config, entries: WebEntry[]): TrussMapping
         abbreviations[entry.abbr] = {
           kind: "alias",
           chain: entry.aliasTargets || [],
+        };
+        break;
+      case "keyframe":
+        abbreviations[entry.abbr] = {
+          kind: "keyframe",
+          name: entry.keyframeName || entry.abbr,
         };
         break;
     }

--- a/packages/truss/src/keyframe-methods.ts
+++ b/packages/truss/src/keyframe-methods.ts
@@ -1,0 +1,81 @@
+import { camelCase, pascalCase } from "change-case";
+import { makeBreakpoints } from "src/breakpoints";
+import { type Config, type UtilityMethod } from "src/config";
+import { newKeyframeMethod } from "src/methods";
+import { TRUSS_PSEUDO_METHODS } from "src/pseudo-selectors";
+
+/**
+ * A `Css.<keyframe>(value)` method for every `config.keyframes` entry, i.e.
+ * `Css.sweep("1.6s linear infinite")` instead of ``Css.animation(`${Keyframes.Sweep} 1.6s linear infinite`)``.
+ *
+ * The method only puts the name in front of the value, so the rest of the animation shorthand is
+ * written as usual, and two animations still go through `Css.animation`, which takes the whole value.
+ *
+ * `taken` is every abbreviation the other sections already generated; see `keyframeAbbreviation`.
+ */
+export function newKeyframesMethods(config: Config, taken: Set<string>): UtilityMethod[] {
+  const names = Object.keys(config.keyframes ?? {});
+  if (names.length === 0) return [];
+  const used = new Set([...taken, ...reservedMethodNames(config)]);
+  return names.map((name) => {
+    const abbr = keyframeAbbreviation(name, used);
+    used.add(abbr);
+    return newKeyframeMethod(abbr, name);
+  });
+}
+
+/**
+ * The method name for a keyframe: its camelCase name, or `animate<Name>` when that name is taken.
+ *
+ * I.e. `sweep` → `sweep` and `fade-in` → `fadeIn`, but a keyframe named `pre` → `animatePre`,
+ * because `Css.pre` already sets `white-space: pre`. Keyframe names are the project's own, so the
+ * fallback keeps a new keyframe from quietly replacing a utility method or an alias.
+ *
+ * Both names being taken needs a rename, since there is no third name to fall back on.
+ */
+function keyframeAbbreviation(name: string, used: Set<string>): string {
+  const camel = camelCase(name);
+  if (!used.has(camel)) return camel;
+  const prefixed = `animate${pascalCase(name)}`;
+  if (!used.has(prefixed)) return prefixed;
+  throw new Error(
+    `Keyframes "${name}" cannot have a Css method: "${camel}" and "${prefixed}" are both already taken. ` +
+      `Rename the keyframe.`,
+  );
+}
+
+/**
+ * The `CssBuilder` members a keyframe method must not shadow: the chain builtins, the pseudo-class
+ * getters, and the breakpoint getters, i.e. `ifSm`.
+ */
+function reservedMethodNames(config: Config): string[] {
+  return [
+    ...BUILDER_METHODS,
+    ...Object.keys(TRUSS_PSEUDO_METHODS),
+    ...Object.keys(makeBreakpoints(config.breakpoints ?? {})).map((name) => `if${pascalCase(name)}`),
+  ];
+}
+
+/** The non-abbreviation members of the generated `CssBuilder`. */
+const BUILDER_METHODS = [
+  "$",
+  "add",
+  "className",
+  "element",
+  "else",
+  "end",
+  "if",
+  "ifContainer",
+  "ifPrint",
+  "marker",
+  "markerOf",
+  "newCss",
+  "newMarker",
+  "props",
+  "raw",
+  "setVar",
+  "style",
+  "typography",
+  "when",
+  "with",
+];

--- a/packages/truss/src/methods.ts
+++ b/packages/truss/src/methods.ts
@@ -10,7 +10,7 @@ export type Prop = keyof Properties;
 // reuse the existing section definitions without modifying any section files.
 
 export interface WebEntry {
-  kind: "static" | "param" | "increment-param" | "px-delegate" | "alias" | "cssvar";
+  kind: "static" | "param" | "increment-param" | "px-delegate" | "alias" | "cssvar" | "keyframe";
   abbr: string;
   /** For static: the CSS properties object, e.g. { display: "flex" } */
   defs?: Record<string, unknown>;
@@ -22,6 +22,8 @@ export interface WebEntry {
   extraDefs?: Record<string, unknown>;
   /** For aliases: the list of chained abbreviations */
   aliasTargets?: string[];
+  /** For keyframes: the `@keyframes` name the method puts in front of its value */
+  keyframeName?: string;
 }
 
 let _webCollector: WebEntry[] | null = null;
@@ -40,6 +42,11 @@ export function stopWebCollection(): WebEntry[] {
 
 function collect(entry: WebEntry): void {
   if (_webCollector) _webCollector.push(entry);
+}
+
+/** The abbreviations collected so far, for the sections that must not re-use an existing name. */
+export function collectedAbbreviations(): Set<string> {
+  return new Set((_webCollector ?? []).map((entry) => entry.abbr));
 }
 
 /**
@@ -115,6 +122,17 @@ export function newMethodsForProp<P extends Prop>(
     ...(baseName !== null ? [newParamMethod(baseName, prop, valueMethodExtraProperties)] : []),
     ...(baseName !== null && includePx ? [newPxMethod(baseName, prop)] : []),
   ];
+}
+
+/**
+ * Given a keyframe abbreviation (i.e. `sweep`) and its `@keyframes` name, returns the TypeScript
+ * code for a `sweep` utility method that puts the name in front of the animation shorthand.
+ *
+ * I.e. `Css.sweep("1.6s linear infinite").$` sets `animation: sweep 1.6s linear infinite`.
+ */
+export function newKeyframeMethod(abbr: UtilityName, name: string): UtilityMethod {
+  collect({ kind: "keyframe", abbr, keyframeName: name });
+  return `/** Sets \`animation: ${name} value\`. */\n ${abbr}(value: string) { return this.add("animation", \`${name} \${value}\`); }`;
 }
 
 /**

--- a/packages/truss/src/plugin/emit-style-hash.ts
+++ b/packages/truss/src/plugin/emit-style-hash.ts
@@ -88,7 +88,8 @@ export function styleHashProperties(
 /**
  * The runtime value stored in a variable tuple's vars object.
  *
- * I.e. an evaluated `Tokens.gap` → `"var(--gap)"`; `mt(x)` → `maybeCssVar(__maybeInc(x))`; `mtPx(x)` → `` `${x}px` ``.
+ * I.e. an evaluated `Tokens.gap` → `"var(--gap)"`; `mt(x)` → `maybeCssVar(__maybeInc(x))`; `mtPx(x)` → `` `${x}px` ``;
+ * `sweep(x)` → `` `sweep ${maybeCssVar(x)}` ``.
  */
 function variableValueExpression(
   dyn: StyleEntry,
@@ -112,6 +113,16 @@ function variableValueExpression(
   }
   if (maybeCssVarHelperName && variableValueNeedsMaybeCssVar(dyn)) {
     valueExpr = t.callExpression(t.identifier(maybeCssVarHelperName), [valueExpr]);
+  }
+  if (dyn.valuePrefix) {
+    // I.e. a keyframe method wraps with `` `sweep ${x}` `` so the value still names its keyframe.
+    valueExpr = t.templateLiteral(
+      [
+        t.templateElement({ raw: dyn.valuePrefix, cooked: dyn.valuePrefix }, false),
+        t.templateElement({ raw: "", cooked: "" }, true),
+      ],
+      [valueExpr],
+    );
   }
   return valueExpr;
 }

--- a/packages/truss/src/plugin/resolve-calls.ts
+++ b/packages/truss/src/plugin/resolve-calls.ts
@@ -44,6 +44,9 @@ export function resolveCallNode(
   if (entry.kind === "delegate") {
     return [resolveDelegateCall(node.name, entry, node, mapping, context)];
   }
+  if (entry.kind === "keyframe") {
+    return [resolveKeyframeCall(node.name, entry, node, mapping, context)];
+  }
   throw new UnsupportedPatternError(`Abbreviation "${node.name}" is ${entry.kind}, cannot be called as a function`);
 }
 
@@ -63,6 +66,36 @@ function resolveVariableCall(
     extraDefs: entry.extraDefs,
     argAst: arg,
     literalValue: tryEvaluatePropertyLiteral(arg, mapping, entry.incremented),
+    mapping,
+    context,
+  });
+}
+
+/**
+ * Resolve a keyframe call like `sweep("1.6s linear infinite")`.
+ *
+ * The method is sugar for `animation`, so the segment uses the `animation` abbreviation and only
+ * puts the keyframe name in front of the value. A literal value then resolves to exactly the CSS
+ * the spelled-out call makes, i.e. `Css.sweep("1.6s linear infinite")` and
+ * ``Css.animation(`${Keyframes.Sweep} 1.6s linear infinite`)`` share one atomic rule.
+ */
+function resolveKeyframeCall(
+  abbr: string,
+  entry: Extract<TrussMappingEntry, { kind: "keyframe" }>,
+  node: CallChainNode,
+  mapping: TrussMapping,
+  context: ResolvedConditionContext,
+): ResolvedSegment {
+  const arg = singleArg(node, abbr);
+  const literalValue = tryEvaluatePropertyLiteral(arg, mapping, false);
+  return resolveLiteralOrVariableSegment({
+    abbr: "animation",
+    props: ["animation"],
+    incremented: false,
+    // A runtime value keeps the name as a prefix, i.e. `Css.sweep(x)` sets `` `sweep ${x}` ``.
+    valuePrefix: `${entry.name} `,
+    argAst: arg,
+    literalValue: literalValue === null ? null : `${entry.name} ${literalValue}`,
     mapping,
     context,
   });
@@ -110,13 +143,26 @@ function resolveLiteralOrVariableSegment(params: {
   props: string[];
   incremented: boolean;
   appendPx?: boolean;
+  /** Text the runtime value keeps in front of it, i.e. `"sweep "` for a keyframe method. */
+  valuePrefix?: string;
   extraDefs?: Record<string, unknown>;
   argAst: t.Expression;
   literalValue: string | null;
   mapping: TrussMapping;
   context: ResolvedConditionContext;
 }): ResolvedSegment {
-  const { abbr, props, incremented, appendPx = false, extraDefs, argAst, literalValue, mapping, context } = params;
+  const {
+    abbr,
+    props,
+    incremented,
+    appendPx = false,
+    valuePrefix,
+    extraDefs,
+    argAst,
+    literalValue,
+    mapping,
+    context,
+  } = params;
 
   if (literalValue !== null) validateAnimationValue(props, literalValue, mapping);
 
@@ -131,6 +177,7 @@ function resolveLiteralOrVariableSegment(params: {
     props,
     incremented,
     appendPx,
+    valuePrefix,
     extraDefs,
     argNode: literalValue === null ? argAst : undefined,
     argResolved: literalValue ?? undefined,

--- a/packages/truss/src/plugin/resolve-entry.ts
+++ b/packages/truss/src/plugin/resolve-entry.ts
@@ -57,6 +57,7 @@ export function resolveEntry(
     }
     case "variable":
     case "delegate":
+    case "keyframe":
       throw new UnsupportedPatternError(`Abbreviation "${abbr}" requires arguments — use ${abbr}() not .${abbr}`);
     default:
       throw new UnsupportedPatternError(`Unhandled entry kind for "${abbr}"`);

--- a/packages/truss/src/plugin/style-entries.ts
+++ b/packages/truss/src/plugin/style-entries.ts
@@ -24,6 +24,8 @@ export interface StyleEntry {
   argResolved?: string;
   incremented?: boolean;
   appendPx?: boolean;
+  /** I.e. `"sweep "` for `Css.sweep(x)`, so the runtime animation value still names its keyframe. */
+  valuePrefix?: string;
 }
 
 // ── Marker class helpers ──────────────────────────────────────────────
@@ -104,6 +106,7 @@ function variableStyleEntries(
       argResolved: seg.argResolved,
       incremented: seg.incremented,
       appendPx: seg.appendPx,
+      valuePrefix: seg.valuePrefix,
     };
   });
 

--- a/packages/truss/src/plugin/transform.test.ts
+++ b/packages/truss/src/plugin/transform.test.ts
@@ -289,6 +289,81 @@ describe("transform", () => {
     );
   });
 
+  test("names a keyframe through its own method", () => {
+    // Given the `pulse` keyframe animated through the method its config entry generates
+    const source = `
+      import { Css } from "./Css";
+      const s = Css.pulse("2s ease-in-out infinite").$;
+      `;
+    // When we transform the file
+    const transform = expectTrussTransform(source);
+    // Then it resolves to the rule the spelled-out `Css.animation("pulse 2s ease-in-out infinite")` makes,
+    // so the two spellings share one class rather than writing the same declaration twice
+    transform.toHaveTrussOutput(
+      `
+      const s = { animation: "anim_pulse_2s_ease_in_out_infinite" };
+      `,
+      `
+      .anim_pulse_2s_ease_in_out_infinite { animation: pulse 2s ease-in-out infinite; }
+      @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }
+      `,
+    );
+  });
+
+  test("keeps the keyframe name in front of a runtime animation value", () => {
+    // Given a keyframe method whose value is a runtime expression, i.e. only the duration varies
+    const source = `
+      import { Css } from "./Css";
+      function f(timing: string) { return Css.pulse(timing).$; }
+      `;
+    // When we transform the file
+    const transform = expectTrussTransform(source);
+    // Then the name is written into the custom property, since the value alone would not name it
+    transform.toHaveTrussOutput(
+      `
+      import { maybeCssVar } from "@homebound/truss/runtime";
+      function f(timing: string) { return { animation: ["animation_var", { "--animation": \`pulse \${maybeCssVar(timing)}\` }] }; }
+      `,
+      `
+      .animation_var { animation: var(--animation); }
+      @property --animation { syntax: "*"; inherits: false; }
+      @keyframes spin { to { transform: rotate(360deg); } }
+      @keyframes sweep { to { --angle: 360deg; } }
+      @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }
+      @keyframes fade-in { from { opacity: 0; } }
+      @keyframes float { to { transform: translateY(-4px); } }
+      `,
+    );
+  });
+
+  test("names a keyframe whose method name is not its own", () => {
+    // Given the kebab-case `fade-in` keyframe, whose method name has to be camelCased
+    // And the `float` keyframe, whose plain name the tachyons `float` method already owns
+    const source = `
+      import { Css } from "./Css";
+      const a = Css.fadeIn("1s ease").$;
+      const b = Css.animateFloat("2s ease-in-out infinite").$;
+      const c = Css.float("left").$;
+      `;
+    // When we transform the file
+    const transform = expectTrussTransform(source);
+    // Then each method writes the keyframe name as configured, and `float` still sets the property
+    transform.toHaveTrussOutput(
+      `
+      const a = { animation: "anim_fade_in_1s_ease" };
+      const b = { animation: "anim_float_2s_ease_in_out_infinite" };
+      const c = { float: "fl_left" };
+      `,
+      `
+      .anim_fade_in_1s_ease { animation: fade-in 1s ease; }
+      .anim_float_2s_ease_in_out_infinite { animation: float 2s ease-in-out infinite; }
+      .fl_left { float: left; }
+      @keyframes fade-in { from { opacity: 0; } }
+      @keyframes float { to { transform: translateY(-4px); } }
+      `,
+    );
+  });
+
   test("names a configured keyframe through the Keyframes enum", () => {
     // Given an animation whose name comes from the generated Keyframes enum
     const source = `
@@ -427,6 +502,8 @@ describe("transform", () => {
       @keyframes spin { to { transform: rotate(360deg); } }
       @keyframes sweep { to { --angle: 360deg; } }
       @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }
+      @keyframes fade-in { from { opacity: 0; } }
+      @keyframes float { to { transform: translateY(-4px); } }
       `,
     );
   });

--- a/packages/truss/src/plugin/types.ts
+++ b/packages/truss/src/plugin/types.ts
@@ -55,7 +55,9 @@ export type TrussMappingEntry =
   /** I.e. `{ "kind": "delegate", "target": "mt" }` for `Css.mtPx(v).$`. */
   | { kind: "delegate"; target: string }
   /** I.e. `{ "kind": "alias", "chain": ["f14", "black"] }` for `Css.bodyText.$`. */
-  | { kind: "alias"; chain: string[] };
+  | { kind: "alias"; chain: string[] }
+  /** I.e. `{ "kind": "keyframe", "name": "sweep" }` for `Css.sweep("1.6s linear infinite").$`. */
+  | { kind: "keyframe"; name: string };
 
 /** Fields shared by the segments that resolve to atomic CSS declarations. */
 interface CssSegmentBase {
@@ -91,6 +93,8 @@ export interface VariableSegment extends CssSegmentBase {
   incremented: boolean;
   /** For Px delegates: whether the runtime value must append `px`. */
   appendPx: boolean;
+  /** For keyframe methods: the animation name put in front of the runtime value, i.e. `"sweep "`. */
+  valuePrefix?: string;
   /** Additional static defs applied alongside the variable value. */
   extraDefs?: Record<string, unknown>;
   argNode?: t.Expression;


### PR DESCRIPTION
Keyframes currently have to be animated through the shorthand, i.e. ``Css.animation(`${Keyframes.Sweep} 1.6s linear infinite`)``. Each `config.keyframes` entry now also generates its own method:

```tsx
<div css={Css.sweep("1.6s linear infinite").$} />
```

### How it works

- `keyframe-methods.ts` generates one method per keyframe, last in the section order so it can see every other abbreviation. The name is the camelCase keyframe, i.e. `fade-in` → `Css.fadeIn(...)`, falling back to `animate<Name>` when an abbreviation, an alias, a pseudo/breakpoint getter, or a `CssBuilder` method already owns it, i.e. a keyframe named `float` → `Css.animateFloat(...)`, so `Css.float(...)` keeps its name. Generation fails when both names are taken.
- The method is sugar for `animation`: the generated body is `` sweep(value) { return this.add("animation", `sweep ${value}`) } ``, so the untransformed `RuntimeCss` path works too, and the mapping carries `{"sweep": {"kind": "keyframe", "name": "sweep"}}`.
- `resolveKeyframeCall` resolves under the `animation` abbreviation with the name prefixed onto the value, so `Css.pulse("2s ease-in-out infinite")` and the spelled-out `Css.animation(...)` produce the same class rather than two copies of the declaration.
- A runtime value carries the name in a new `valuePrefix`, wrapped exactly like the `appendPx` delegate does: `` {"--animation": `pulse ${maybeCssVar(timing)}`} ``.
- Keyframe pruning is unchanged: a literal value still prunes exactly, and a runtime one still keeps every block.

The `Keyframes` enum stays for the values one method cannot write, i.e. two comma-separated animations.

### Testing

- Transform tests for the literal case (shared atomic rule), the runtime case (prefixed custom property), and the two naming rules, the last through two new keyframes in the demo app's `truss-config.ts`.
- A generate test for the error when both method names are taken.
- 454 truss + 89 app tests pass; both packages typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)