### PR TITLE
feat: Link the stylesheet with `import "virtual:truss.css"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ For web usage, use the `truss` command to generate the `Css.ts` (and `Css.json` 
   - `wget https://raw.githubusercontent.com/homebound-team/truss/main/packages/template-tachyons/truss-config.ts`
 - Run `npm run truss`
   - Re-run `npm run truss` anytime you change `truss-config.ts`
-- Start using `Css.mt1.etc.$` in your project and wire `trussPlugin(...)` in Vite (see setup below)
+- Start using `Css.mt1.etc.$` in your project, wire `trussPlugin(...)` in Vite, and add `import "virtual:truss.css";` to your entry module (see setup below)
 
 We recommend checking the `src/Css.ts` file into your repository, with the rationale:
 
@@ -330,6 +330,37 @@ Notes:
 - `mapping` is required and should point to the single `Css.json` you want to compile against.
 - `libraries` lists paths to pre-compiled `truss.css` files that will be merged with the app's own generated CSS. Rules are deduplicated by class name and sorted by priority to produce a correct unified stylesheet.
 
+### Linking the Stylesheet
+
+Import Truss's stylesheet once, in your entry module:
+
+```tsx
+// src/main.tsx, or app/root.tsx for a server-rendered app
+import "virtual:truss.css";
+```
+
+Vite then treats Truss's CSS like any other stylesheet: it serves it in dev, bundles and hashes it in production, and a framework such as React Router lists it in the route manifest. This is the same one line for a Vite SPA and for an app that renders its own document (React Router, Remix, TanStack Start) -- there is no `<link>` tag to write and no dev-only script.
+
+- In dev the import serves the rules collected so far, and Truss pushes later ones over Vite's own CSS HMR.
+- In production the import is filled in after the last module is transformed, and the stylesheet is renamed so its hash covers the rules it ends up with.
+- A library build (Vite's `build.lib`) has no entry module of its own, so it keeps emitting a standalone `assets/truss-<hash>.css` for consuming apps to merge through `libraries`.
+
+#### Upgrading from the `index.html` link
+
+Truss used to write the `<link>` tag into `index.html` itself. If your `index.html` still has that tag, delete it and add the import above -- the plugin fails the build while the stale tag is there, since it now points at nothing:
+
+```
+[truss] index.html still links Truss's stylesheet. Delete that <link> tag and add
+`import "virtual:truss.css";` to your entry module instead.
+```
+
+If you delete the tag but forget the import, the build warns rather than silently shipping an unstyled app:
+
+```
+[truss] No module imported "virtual:truss.css", so this build ships no Truss stylesheet.
+Add `import "virtual:truss.css";` to your entry module.
+```
+
 ### CSS Annotations
 
 Truss metadata comments in emitted CSS, such as `/* @truss p:3000 c:accent */`, let consuming applications sort and deduplicate rules from library stylesheets.
@@ -349,11 +380,11 @@ Truss ships two build plugins. Both transform `Css.*.$` expressions into plain o
 | ------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------- |
 | **Build tool**            | Vite                                                                              | esbuild / tsup                                                |
 | **Use case**              | Applications and Vitest test suites                                               | Library packages compiled with tsup or plain esbuild          |
-| **Dev server HMR**        | Yes -- serves CSS via a virtual endpoint and pushes updates over WebSocket        | No -- esbuild has no dev server                               |
-| **Content-hashed output** | Yes -- production builds emit `assets/truss-<hash>.css` for long-term caching     | No -- writes a fixed `truss.css` to the output directory      |
+| **Dev server HMR**        | Yes -- serves CSS through `virtual:truss.css` and updates it over Vite's CSS HMR  | No -- esbuild has no dev server                               |
+| **Content-hashed output** | Yes -- the bundled stylesheet is renamed to hash the rules it carries             | No -- writes a fixed `truss.css` to the output directory      |
 | **Library CSS merging**   | Yes -- `libraries` option merges pre-compiled library CSS into the app stylesheet | No -- libraries are merged by the consuming app's Vite plugin |
 | **Test CSS injection**    | Yes -- auto-injects CSS into jsdom for Vitest                                     | No                                                            |
-| **HTML injection**        | Yes -- injects `<link>` / `<script>` tags into `index.html`                       | No -- not applicable for library builds                       |
+| **Stylesheet linking**    | Yes -- `import "virtual:truss.css"` in the entry module, for SPAs and SSR alike   | No -- not applicable for library builds                       |
 
 **When to use which:**
 

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Truss v2 Demo</title>
-    <link rel="stylesheet" href="/virtual:truss.css" />
   </head>
   <body>
     <div id="root"></div>

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -1,3 +1,4 @@
+import "virtual:truss.css";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./App";

--- a/packages/truss/src/plugin/index.test.ts
+++ b/packages/truss/src/plugin/index.test.ts
@@ -41,23 +41,16 @@ describe("trussPlugin", () => {
     // And an application module using the flex rule
     runTransform(plugin, 'import { Css } from "./Css"; const s = Css.df.$;', join(root, "src", "App.tsx"));
 
-    // When the stylesheet is served or emitted
+    // When the stylesheet is served, bundled or emitted
     let css = "";
     let fileName = "";
     if (scenario.command === "serve") {
       css = getVirtualCss(plugin);
     } else {
-      invokeHook(
-        plugin.generateBundle,
-        {
-          emitFile(asset: { source: string; fileName: string }) {
-            css = asset.source;
-            fileName = asset.fileName;
-          },
-        },
-        {},
-        {},
-      );
+      // A library writes its own file; an application fills the stylesheet the bundler made.
+      const built = scenario.lib ? getEmittedCss(plugin) : getBuiltCss(plugin);
+      css = built.css;
+      fileName = built.fileName;
     }
 
     // Then only library and dev outputs carry merge annotations
@@ -68,7 +61,8 @@ describe("trussPlugin", () => {
     );
     if (scenario.command === "build") {
       // And the asset name hashes the exact final stylesheet
-      expect(fileName).toBe(`assets/truss-${createHash("sha256").update(css).digest("hex").slice(0, 8)}.css`);
+      const hash = createHash("sha256").update(css).digest("hex").slice(0, 8);
+      expect(fileName).toBe(scenario.lib ? `assets/truss-${hash}.css` : `assets/index-${hash}.css`);
     }
   });
 
@@ -85,34 +79,15 @@ describe("trussPlugin", () => {
     invokeHook(library.buildStart, {});
     runTransform(library, 'import { Css } from "./Css"; const s = Css.df.$;', join(root, "src", "Lib.tsx"));
     runTransform(library, 'export const css = { body: "/* keep */ margin: 0;" };', join(root, "src", "Lib.css.ts"));
-    invokeHook(
-      library.generateBundle,
-      {
-        emitFile(asset: { source: string }) {
-          writeFileSync(join(root, "library.css"), asset.source);
-        },
-      },
-      {},
-      {},
-    );
+    writeFileSync(join(root, "library.css"), getEmittedCss(library).css);
     // And an application using the library stylesheet and an overlapping atomic rule
     const app = trussPlugin({ mapping: "./src/Css.json", libraries: ["./library.css"] });
     invokeHook(app.configResolved, {}, { root, command: "build", mode: "production" });
     invokeHook(app.buildStart, {});
     runTransform(app, 'import { Css } from "./Css"; const s = Css.df.black.$;', join(root, "src", "App.tsx"));
 
-    // When the application emits its final stylesheet
-    let css = "";
-    invokeHook(
-      app.generateBundle,
-      {
-        emitFile(asset: { source: string }) {
-          css = asset.source;
-        },
-      },
-      {},
-      {},
-    );
+    // When the application builds its final stylesheet
+    const { css } = getBuiltCss(app);
 
     // Then library rules survive, atomic rules are sorted and deduplicated, and user comments remain
     expect(css).toBe(
@@ -158,7 +133,7 @@ describe("trussPlugin", () => {
     invokeHook(plugin.configResolved, {}, { root, command: "build", mode: "production" });
     invokeHook(plugin.buildStart, {});
     const virtualId = invokeHook(plugin.resolveId, {}, "./Button.css.ts?truss-css", join(root, "src", "App.tsx"));
-    expect(virtualId).toBe("\0truss-css:" + id.slice(0, -3));
+    expect(virtualId).toBe("\0truss-css:" + id);
 
     // When Vite loads then transforms the CSS, then both hooks reject the spread
     expect(() => invokeHook(plugin.load, {}, virtualId)).toThrow("spread elements in css.ts export");
@@ -604,17 +579,7 @@ describe("trussPlugin", () => {
       join(root, "src", "Z.css.ts"),
     );
     // When the bundle is generated
-    let css = "";
-    invokeHook(
-      plugin.generateBundle,
-      {
-        emitFile(asset: { source: string }) {
-          css = asset.source;
-        },
-      },
-      {},
-      {},
-    );
+    const { css } = getBuiltCss(plugin);
     // Then the arbitrary block follows codepoint source order
     expect(css).toBe(
       [
@@ -634,22 +599,22 @@ describe("trussPlugin", () => {
     // Given a mapping with a flex rule
     const root = createTempRoot();
     writeMapping(join(root, "src", "Css.json"), { df: { kind: "static", defs: { display: "flex" } } });
-    // And a dev server with controlled update timing and a captured CSS endpoint
+    // And a dev server with controlled update timing
     vi.useFakeTimers();
     const plugin = trussPlugin({ mapping: "./src/Css.json" });
     invokeHook(plugin.configResolved, {}, { root, command: "serve", mode: "development" });
     invokeHook(plugin.buildStart, {});
-    const send = vi.fn();
-    const use = vi.fn();
-    const server = { middlewares: { use }, ws: { send }, httpServer: { on() {} } };
+    const { server, reloads } = fakeDevServer();
     invokeHook(plugin.configureServer, {}, server);
+    // And a browser that has already loaded the stylesheet
+    getVirtualCss(plugin);
 
     // When Vite reports a file change before transforming it
     invokeHook(plugin.handleHotUpdate, {}, { server });
     vi.runAllTimers();
 
-    // Then no stale stylesheet update is sent and no poller is running
-    expect(send.mock.calls).toEqual([]);
+    // Then no stale stylesheet reload is requested and no poller is running
+    expect(reloads.mock.calls).toEqual([]);
     expect(vi.getTimerCount()).toBe(0);
 
     // When an application module and a .css.ts module add CSS in the same turn
@@ -660,46 +625,43 @@ describe("trussPlugin", () => {
     runTransform(plugin, appCode, appId);
     runTransform(plugin, cssCode, cssId);
 
-    // Then notification is deferred and both changes share one timer
-    expect(send.mock.calls).toEqual([]);
+    // Then the reload is deferred and both changes share one timer
+    expect(reloads.mock.calls.length).toBe(0);
     expect(vi.getTimerCount()).toBe(1);
     vi.runAllTimers();
-    expect(send.mock.calls).toEqual([[{ type: "custom", event: "truss:css-update" }]]);
-    // And the endpoint already serves both completed transforms
-    const end = vi.fn();
-    use.mock.calls[0][0]({ url: "/virtual:truss.css" }, { setHeader() {}, end }, () => {});
-    expect(end.mock.calls).toEqual([
+    // And exactly one stylesheet reload covers both transforms
+    expect(reloads.mock.calls.length).toBe(1);
+    // And the stylesheet already carries both completed transforms
+    expect(getVirtualCss(plugin)).toBe(
       [
-        [
-          ":root { --t-spacing: 8px; }",
-          "/* @truss p:3000 c:df */",
-          ".df { display: flex; }",
-          "/* @truss arbitrary:start */",
-          "body {",
-          "  color: red;",
-          "}",
-          "/* @truss arbitrary:end */",
-        ].join("\n"),
-      ],
-    ]);
+        ":root { --t-spacing: 8px; }",
+        "/* @truss p:3000 c:df */",
+        ".df { display: flex; }",
+        "/* @truss arbitrary:start */",
+        "body {",
+        "  color: red;",
+        "}",
+        "/* @truss arbitrary:end */",
+      ].join("\n"),
+    );
 
     // When Vite retransforms unchanged CSS or a module without styles
-    send.mockClear();
+    reloads.mockClear();
     runTransform(plugin, appCode, appId);
     runTransform(plugin, cssCode, cssId);
     runTransform(plugin, "export const value = 1;", join(root, "src", "other.ts"));
     vi.runAllTimers();
 
-    // Then no stylesheet is requested
-    expect(send.mock.calls).toEqual([]);
+    // Then no stylesheet reload is requested
+    expect(reloads.mock.calls).toEqual([]);
     expect(vi.getTimerCount()).toBe(0);
 
     // When a later .css.ts edit replaces its rules
     runTransform(plugin, 'export const css = { body: "color: blue;" };', cssId);
     vi.runAllTimers();
 
-    // Then the edit gets one new notification without an initial file-change event
-    expect(send.mock.calls).toEqual([[{ type: "custom", event: "truss:css-update" }]]);
+    // Then the edit gets one new reload without an initial file-change event
+    expect(reloads.mock.calls.length).toBe(1);
   });
 
   test.each(["close", "buildStart"])("dev cancels pending CSS updates on %s", (event) => {
@@ -711,127 +673,184 @@ describe("trussPlugin", () => {
     const plugin = trussPlugin({ mapping: "./src/Css.json" });
     invokeHook(plugin.configResolved, {}, { root, command: "serve", mode: "development" });
     invokeHook(plugin.buildStart, {});
-    const send = vi.fn();
-    const on = vi.fn();
-    invokeHook(plugin.configureServer, {}, { middlewares: { use() {} }, ws: { send }, httpServer: { on } });
+    const { server, reloads, close } = fakeDevServer();
+    invokeHook(plugin.configureServer, {}, server);
+    getVirtualCss(plugin);
     runTransform(plugin, 'import { Css } from "./Css"; const s = Css.df.$;', join(root, "src", "App.tsx"));
     expect(vi.getTimerCount()).toBe(1);
 
     // When the server closes or the build state resets before notification
     if (event === "close") {
-      expect(on.mock.calls[0][0]).toBe("close");
-      on.mock.calls[0][1]();
+      close();
     } else {
       invokeHook(plugin.buildStart, {});
     }
 
-    // Then the pending timer is removed and no update is sent
+    // Then the pending timer is removed and no reload is requested
     expect(vi.getTimerCount()).toBe(0);
     vi.runAllTimers();
-    expect(send.mock.calls).toEqual([]);
+    expect(reloads.mock.calls).toEqual([]);
   });
 
-  test("dev runtime fetches initially and only subscribes to CSS changes", async () => {
-    // Given the dev runtime and a browser with an existing Truss style element
-    const plugin = trussPlugin({ mapping: "./src/Css.json" });
-    const id = invokeHook(plugin.resolveId, {}, "virtual:truss:runtime", undefined);
-    const code = invokeHook(plugin.load, {}, id) as string;
-    const style = { textContent: "" };
-    const document = { getElementById: () => style };
-    const fetch = vi.fn().mockResolvedValue({ text: async () => ".df { display: flex; }" });
-    const on = vi.fn();
-
-    // When the browser evaluates the runtime
-    new Function("document", "fetch", "hot", code.replaceAll("import.meta.hot", "hot"))(document, fetch, { on });
-
-    // Then it fetches once on startup and does not subscribe to Vite JS updates
-    expect(fetch.mock.calls).toEqual([["/virtual:truss.css"]]);
-    expect(on.mock.calls.map((call) => call[0])).toEqual(["truss:css-update"]);
-    await vi.waitFor(() => expect(style.textContent).toBe(".df { display: flex; }"));
-
-    // When the server reports changed CSS
-    fetch.mockClear();
-    fetch.mockResolvedValue({ text: async () => ".df { display: grid; }" });
-    on.mock.calls[0][1]();
-
-    // Then the browser fetches and applies the stylesheet once
-    expect(fetch.mock.calls).toEqual([["/virtual:truss.css"]]);
-    await vi.waitFor(() => expect(style.textContent).toBe(".df { display: grid; }"));
-  });
-
-  test("dev html injects the runtime without a stylesheet link", () => {
+  test.each(["serve", "build"])("%s rejects an index.html that still links the stylesheet", (command) => {
+    // Given a mapping with a flex rule
     const root = createTempRoot();
-    writeMapping(join(root, "src", "Css.json"), {
-      df: { kind: "static", defs: { display: "flex" } },
-    });
+    writeMapping(join(root, "src", "Css.json"), { df: { kind: "static", defs: { display: "flex" } } });
+    const plugin = trussPlugin({ mapping: "./src/Css.json" });
+    invokeHook(plugin.configResolved, {} as any, { root, command, mode: "development" } as any);
+    // And an index.html carrying the link Truss used to write for itself
+    const html = '<html><head>\n    <link rel="stylesheet" href="/virtual:truss.css" />\n  </head><body></body></html>';
 
+    // When the HTML is transformed, then the stale link is called out with the one-line fix
+    expect(() => invokeHook(plugin.transformIndexHtml, {} as any, html)).toThrow(
+      'index.html still links Truss\'s stylesheet. Delete that <link> tag and add `import "virtual:truss.css";`',
+    );
+  });
+
+  test.each([
+    '<link rel="stylesheet" href="__TRUSS_CSS_HASH__">',
+    '<link rel="stylesheet" href="/assets/truss-abcd1234.css">',
+  ])("rejects a build output that already carries %s", (link) => {
+    // Given a plugin building an application
+    const root = createTempRoot();
+    writeMapping(join(root, "src", "Css.json"), { df: { kind: "static", defs: { display: "flex" } } });
+    const plugin = trussPlugin({ mapping: "./src/Css.json" });
+    invokeHook(plugin.configResolved, {} as any, { root, command: "build", mode: "production" } as any);
+    // And HTML from a tool that reran an older build, i.e. Storybook keeping its patched output
+
+    // When the HTML is transformed, then the leftover link is rejected the same way
+    expect(() =>
+      invokeHook(plugin.transformIndexHtml, {} as any, `<html><head>${link}</head><body></body></html>`),
+    ).toThrow("index.html still links Truss's stylesheet");
+  });
+
+  test("leaves an index.html without a Truss link alone", () => {
+    // Given a plugin serving an app whose HTML links only its own stylesheet
+    const root = createTempRoot();
+    writeMapping(join(root, "src", "Css.json"), { df: { kind: "static", defs: { display: "flex" } } });
     const plugin = trussPlugin({ mapping: "./src/Css.json" });
     invokeHook(plugin.configResolved, {} as any, { root, command: "serve", mode: "development" } as any);
+    const html = '<html><head><link rel="stylesheet" href="/reset.css"></head><body></body></html>';
 
-    const html = invokeHook(plugin.transformIndexHtml, {} as any, "<html><head></head><body></body></html>") as any;
-    expect(html).toBe(
-      '<html><head>    <script type="module" src="/virtual:truss:runtime"></script>\n  </head><body></body></html>',
-    );
+    // When the HTML is transformed, then nothing is added or removed
+    expect(invokeHook(plugin.transformIndexHtml, {} as any, html)).toBe(html);
   });
 
-  test("production html injects a placeholder stylesheet link for truss.css", () => {
+  test("an application build without the import warns instead of shipping unstyled", () => {
+    // Given a mapping with a flex rule
     const root = createTempRoot();
-    writeMapping(join(root, "src", "Css.json"), {
-      df: { kind: "static", defs: { display: "flex" } },
-    });
-
+    writeMapping(join(root, "src", "Css.json"), { df: { kind: "static", defs: { display: "flex" } } });
     const plugin = trussPlugin({ mapping: "./src/Css.json" });
     invokeHook(plugin.configResolved, {} as any, { root, command: "build", mode: "production" } as any);
+    invokeHook(plugin.buildStart, {} as any);
+    // And an application module using the flex rule, but no module importing the stylesheet
+    runTransform(plugin, 'import { Css } from "./Css"; const s = Css.df.$;', join(root, "src", "App.tsx"));
 
-    const html = invokeHook(plugin.transformIndexHtml, {} as any, "<html><head></head><body></body></html>") as any;
-    // The placeholder is replaced with the content-hashed filename in writeBundle
-    expect(html).toBe(
-      '<html><head>    <link rel="stylesheet" href="__TRUSS_CSS_HASH__">\n  </head><body></body></html>',
-    );
+    // When the bundle is generated
+    const warn = vi.fn();
+    const emitFile = vi.fn();
+    invokeHook(plugin.generateBundle, { warn, emitFile }, {}, {});
+
+    // Then the missing import is reported
+    expect(warn.mock.calls).toEqual([
+      [
+        '[truss] No module imported "virtual:truss.css", so this build ships no Truss stylesheet. ' +
+          'Add `import "virtual:truss.css";` to your entry module.',
+      ],
+    ]);
+    // And no stylesheet is emitted for a document that would not link it
+    expect(emitFile.mock.calls).toEqual([]);
   });
 
-  test("production html strips dev-only virtual:truss.css link", () => {
+  test("dev serves the collected stylesheet through the virtual:truss.css import", () => {
+    // Given a mapping with a flex rule
     const root = createTempRoot();
-    writeMapping(join(root, "src", "Css.json"), {
-      df: { kind: "static", defs: { display: "flex" } },
-    });
-
+    writeMapping(join(root, "src", "Css.json"), { df: { kind: "static", defs: { display: "flex" } } });
     const plugin = trussPlugin({ mapping: "./src/Css.json" });
-    invokeHook(plugin.configResolved, {} as any, { root, command: "build", mode: "production" } as any);
+    invokeHook(plugin.configResolved, {} as any, { root, command: "serve", mode: "development" } as any);
+    invokeHook(plugin.buildStart, {} as any);
+    // And an application module using the flex rule
+    runTransform(plugin, 'import { Css } from "./Css"; const s = Css.df.$;', join(root, "src", "App.tsx"));
 
-    const html = invokeHook(
-      plugin.transformIndexHtml,
-      {} as any,
-      '<html><head>\n    <link rel="stylesheet" href="/virtual:truss.css" />\n  </head><body></body></html>',
-    ) as any;
-    expect(html).toBe(
-      '<html><head>\n      <link rel="stylesheet" href="__TRUSS_CSS_HASH__">\n  </head><body></body></html>',
-    );
+    // When a server-rendered root module imports the stylesheet
+    const resolvedId = invokeHook(plugin.resolveId, {} as unknown, "virtual:truss.css", join(root, "src", "root.tsx"));
+    const css = invokeHook(plugin.load, {} as unknown, resolvedId);
+
+    // Then the module is the real stylesheet, not a placeholder or a fetch script
+    expect(resolvedId).toBe("\0virtual:truss.css");
+    expect(css).toBe(":root { --t-spacing: 8px; }\n/* @truss p:3000 c:df */\n.df { display: flex; }");
   });
 
-  test("production html is idempotent across multiple builds (e.g. Storybook)", () => {
+  test("production fills the bundled stylesheet that imported virtual:truss.css", () => {
+    // Given a mapping with a flex rule
     const root = createTempRoot();
-    writeMapping(join(root, "src", "Css.json"), {
-      df: { kind: "static", defs: { display: "flex" } },
-    });
-
+    writeMapping(join(root, "src", "Css.json"), { df: { kind: "static", defs: { display: "flex" } } });
     const plugin = trussPlugin({ mapping: "./src/Css.json" });
     invokeHook(plugin.configResolved, {} as any, { root, command: "build", mode: "production" } as any);
+    invokeHook(plugin.buildStart, {} as any);
+    // And a server-rendered root module that imports the stylesheet
+    const resolvedId = invokeHook(plugin.resolveId, {} as unknown, "virtual:truss.css", join(root, "src", "root.tsx"));
+    const placeholder = invokeHook(plugin.load, {} as unknown, resolvedId) as string;
+    // And an application module using the flex rule
+    runTransform(plugin, 'import { Css } from "./Css"; const s = Css.df.$;', join(root, "src", "App.tsx"));
+    // And a bundle where the framework hashed that placeholder into the root route's stylesheet,
+    // alongside an unrelated stylesheet that must stay untouched
+    // And a manifest naming the route stylesheet, the way React Router's client build does
+    const bundle: Record<string, any> = {
+      "assets/root-Ab12cd34.css": { type: "asset", fileName: "assets/root-Ab12cd34.css", source: placeholder },
+      "assets/reset-Ef56gh78.css": { type: "asset", fileName: "assets/reset-Ef56gh78.css", source: "* { margin: 0; }" },
+      ".vite/manifest.json": {
+        type: "asset",
+        fileName: ".vite/manifest.json",
+        source: '{ "css": ["assets/root-Ab12cd34.css"] }',
+      },
+    };
 
-    // Simulate a second build pass receiving HTML that already has a patched truss link
-    const alreadyPatched = [
-      "<html><head>",
-      '    <link rel="stylesheet" href="/assets/truss-abcd1234.css">',
-      "  </head><body></body></html>",
-    ].join("\n");
-    const html = invokeHook(plugin.transformIndexHtml, {} as any, alreadyPatched) as any;
-    // The old hashed link should be stripped and replaced with a single placeholder
-    expect(html).toBe(
-      '<html><head>\n      <link rel="stylesheet" href="__TRUSS_CSS_HASH__">\n  </head><body></body></html>',
+    // When the bundle is generated
+    const emitted: string[] = [];
+    invokeHook(plugin.generateBundle, { emitFile: (a: any) => emitted.push(a.fileName) }, {}, bundle);
+
+    // Then the route stylesheet carries every rule
+    const css = ":root { --t-spacing: 8px; }\n.df { display: flex; }";
+    const fileName = `assets/root-${createHash("sha256").update(css).digest("hex").slice(0, 8)}.css`;
+    expect(bundle["assets/root-Ab12cd34.css"].source).toBe(css);
+    // And it is written under a name whose hash tracks the rules, not the placeholder
+    expect(bundle["assets/root-Ab12cd34.css"].fileName).toBe(fileName);
+    // And the manifest points at the new name
+    expect(bundle[".vite/manifest.json"].source).toBe(`{ "css": ["${fileName}"] }`);
+    // And the unrelated stylesheet is unchanged
+    expect(bundle["assets/reset-Ef56gh78.css"].source).toBe("* { margin: 0; }");
+    // And no second stylesheet is emitted for the document to link
+    expect(emitted).toEqual([]);
+  });
+
+  test("a .css.ts side-effect import compiles to an empty module, not a stylesheet", () => {
+    // Given a .css.ts file with an arbitrary selector
+    const root = createTempRoot();
+    writeMapping(join(root, "src", "Css.json"), { df: { kind: "static", defs: { display: "flex" } } });
+    const cssTsPath = join(root, "src", "App.css.ts");
+    mkdirSync(dirname(cssTsPath), { recursive: true });
+    writeFileSync(cssTsPath, 'import { Css } from "./Css";\nexport const css = { ".card": Css.df.$ };\n', "utf8");
+    const plugin = trussPlugin({ mapping: "./src/Css.json" });
+    runConfigHooks(plugin, root);
+
+    // When the `?truss-css` side effect is resolved and loaded
+    const resolvedId = invokeHook(plugin.resolveId, {} as unknown, "./App.css.ts?truss-css", cssTsPath);
+    const moduleCode = invokeHook(plugin.load, {} as unknown, resolvedId);
+
+    // Then it is JavaScript, so Vite writes no per-route stylesheet for it
+    expect(moduleCode).toBe(`/* [truss] ${cssTsPath} — included via truss.css */\nexport {};`);
+    // And the rules still reach the collected stylesheet
+    expect(getVirtualCss(plugin)).toBe(
+      [
+        ":root { --t-spacing: 8px; }",
+        "/* @truss arbitrary:start */",
+        ".card {",
+        "  display: flex;",
+        "}",
+        "/* @truss arbitrary:end */",
+      ].join("\n"),
     );
-    // Only one truss CSS link should exist (the placeholder)
-    const linkCount = (html.match(/<link[^>]*TRUSS_CSS_HASH/g) || []).length;
-    expect(linkCount).toBe(1);
   });
 
   test("dev virtual CSS orders static base rules before variable rules for the same property", () => {
@@ -1290,36 +1309,57 @@ function runTransform(
   return result as { code: string; map: any };
 }
 
-/** Simulate the dev virtual CSS endpoint by invoking configureServer and calling the middleware. */
+/** Read the dev stylesheet the way an app's `import "virtual:truss.css"` does. */
 function getVirtualCss(plugin: ReturnType<typeof trussPlugin>): string {
+  const resolvedId = invokeHook(plugin.resolveId, {} as unknown, "virtual:truss.css", undefined);
+  expect(resolvedId).toBe("\0virtual:truss.css");
+  return invokeHook(plugin.load, {} as unknown, resolvedId) as string;
+}
+
+/**
+ * Run an application build the way a framework does: the entry imports `virtual:truss.css`, the
+ * bundler hashes that placeholder into a stylesheet, and generateBundle fills the rules in.
+ *
+ * Returns the asset as written, so `fileName` is the name the document ends up linking.
+ */
+function getBuiltCss(plugin: ReturnType<typeof trussPlugin>): { css: string; fileName: string } {
+  const resolvedId = invokeHook(plugin.resolveId, {} as unknown, "virtual:truss.css", undefined);
+  const placeholder = invokeHook(plugin.load, {} as unknown, resolvedId) as string;
+  const asset = { type: "asset", fileName: "assets/index-Ab12cd34.css", source: placeholder };
+  invokeHook(plugin.generateBundle, { warn() {} }, {}, { "assets/index-Ab12cd34.css": asset });
+  return { css: String(asset.source), fileName: asset.fileName };
+}
+
+/** Run a library build, which emits a standalone stylesheet for consuming apps to merge. */
+function getEmittedCss(plugin: ReturnType<typeof trussPlugin>): { css: string; fileName: string } {
   let css = "";
-  const middlewares: Array<(req: unknown, res: unknown, next: unknown) => void> = [];
-  const fakeServer = {
-    middlewares: {
-      use(fn: (req: unknown, res: unknown, next: unknown) => void) {
-        middlewares.push(fn);
+  let fileName = "";
+  invokeHook(
+    plugin.generateBundle,
+    {
+      warn() {},
+      emitFile(asset: { source: string; fileName: string }) {
+        css = asset.source;
+        fileName = asset.fileName;
       },
     },
-    httpServer: { on() {} },
+    {},
+    {},
+  );
+  return { css, fileName };
+}
+
+/** A dev server that records the stylesheet reloads the plugin asks Vite for. */
+function fakeDevServer(): { server: any; reloads: ReturnType<typeof vi.fn>; close: () => void } {
+  const reloads = vi.fn();
+  const on = vi.fn();
+  const stylesheet = { id: "\0virtual:truss.css" };
+  const client = {
+    moduleGraph: { getModuleById: (id: string) => (id === stylesheet.id ? stylesheet : undefined) },
+    reloadModule: reloads,
   };
-
-  // Register the middleware
-  invokeHook(plugin.configureServer, {} as unknown, fakeServer);
-
-  // Call each middleware with a matching request
-  const fakeReq = { url: "/virtual:truss.css" };
-  const fakeRes = {
-    setHeader() {},
-    end(content: string) {
-      css = content;
-    },
-  };
-
-  for (const mw of middlewares) {
-    mw(fakeReq, fakeRes, () => {});
-  }
-
-  return css;
+  const server = { environments: { client }, ws: { send() {} }, httpServer: { on } };
+  return { server, reloads, close: () => on.mock.calls[0][1]() };
 }
 
 function getTestCssModule(plugin: ReturnType<typeof trussPlugin>): string {

--- a/packages/truss/src/plugin/index.ts
+++ b/packages/truss/src/plugin/index.ts
@@ -1,5 +1,5 @@
-import { readFileSync, writeFileSync, existsSync, readdirSync } from "fs";
-import { resolve, dirname, isAbsolute, join } from "path";
+import { readFileSync, existsSync } from "fs";
+import { resolve, dirname, isAbsolute } from "path";
 import { createHash } from "crypto";
 import { type PluginContext } from "rollup";
 import { rewriteCssTsImports } from "./rewrite-css-ts-imports";
@@ -35,10 +35,11 @@ export interface TrussVitePlugin {
   load?: (this: DiagnosticContext, id: string) => string | null;
   transform?: (this: DiagnosticContext, code: string, id: string) => { code: string; map: any } | null;
   configureServer?: (server: any) => void;
-  transformIndexHtml?: (html: string) => string;
+  transformIndexHtml?: ((html: string) => string) | { order?: "pre" | "post"; handler: (html: string) => string };
   handleHotUpdate?: (ctx: any) => void;
-  generateBundle?: (options: any, bundle: any) => void;
-  writeBundle?: (options: any, bundle: any) => void;
+  generateBundle?:
+    | ((options: any, bundle: any) => void)
+    | { order?: "pre" | "post"; handler: (this: PluginContext, options: any, bundle: any) => void };
 }
 
 /** Prefix for virtual CSS module IDs generated from .css.ts files. */
@@ -48,20 +49,29 @@ const CSS_TS_QUERY = "?truss-css";
 const RUNTIME_MODULE = "@homebound/truss/runtime";
 const INJECT_CSS_HELPER = "__injectTrussCSS";
 
-/** Placeholder injected into HTML during build; replaced with the hashed CSS filename in generateBundle. */
-const TRUSS_CSS_PLACEHOLDER = "__TRUSS_CSS_HASH__";
+/**
+ * The app's stylesheet. `import "virtual:truss.css"` in the entry module lets the framework
+ * link and bundle Truss's CSS the same as any other stylesheet, which works for a Vite SPA and
+ * for an app that renders its own document, i.e. React Router, Remix, TanStack Start.
+ */
+const VIRTUAL_STYLESHEET_ID = "virtual:truss.css";
+const RESOLVED_VIRTUAL_STYLESHEET_ID = "\0" + VIRTUAL_STYLESHEET_ID;
+/**
+ * Stand-in rule that `virtual:truss.css` loads during a build. Vite bundles and hashes the
+ * stylesheet before the last module is transformed, so the real rules are not known yet; a
+ * post-ordered `generateBundle` swaps this rule for `collectCss()` once they are.
+ */
+const STYLESHEET_PLACEHOLDER = ".__truss_placeholder__ { --truss-placeholder: 0; }";
+const STYLESHEET_PLACEHOLDER_RE = /\.__truss_placeholder__\s*\{[^}]*\}/;
 
-/** Virtual module IDs for dev HMR. */
-const VIRTUAL_CSS_ENDPOINT = "/virtual:truss.css";
-const VIRTUAL_RUNTIME_ID = "virtual:truss:runtime";
-const RESOLVED_VIRTUAL_RUNTIME_ID = "\0" + VIRTUAL_RUNTIME_ID;
-// Test-only bootstrap that injects merged library CSS and the spacing prelude
-// as a virtual module side effect instead of an HTTP
-// fetch. In dev, the browser reaches /virtual:truss.css via transformIndexHtml
-// -> virtual:truss:runtime -> fetch("/virtual:truss.css") -> configureServer.
-// Vitest/jsdom does not boot from index.html or run that browser fetch/HMR path;
-// it imports modules directly into the test environment, so CSS has to enter via
-// a module side effect instead.
+/** Any `index.html` tag left over from the stylesheet link Truss used to write itself. */
+const LEGACY_CSS_LINK_RE =
+  /<link[^>]*href=["'][^"']*(?:virtual:truss\.css|__TRUSS_CSS_HASH__|\/assets\/truss-[0-9a-f]+\.css)["'][^>]*\/?>/;
+
+// Test-only bootstrap that injects merged library CSS and the spacing prelude as a virtual
+// module side effect. Vitest/jsdom does not import `virtual:truss.css` or run browser CSS
+// HMR; it imports modules directly into the test environment, so CSS has to enter via a
+// module side effect instead.
 const VIRTUAL_TEST_CSS_ID = "virtual:truss:test-css";
 const RESOLVED_VIRTUAL_TEST_CSS_ID = "\0" + VIRTUAL_TEST_CSS_ID;
 
@@ -81,11 +91,13 @@ export function trussPlugin(opts: TrussPluginOptions): TrussVitePlugin {
   let debug = false;
   let isTest = false;
   let isBuild = false;
+  let isLib = false;
   let annotate = true;
   let devSocket: { send: (payload: unknown) => void } | undefined;
+  let devServer: any;
+  /** True once a module imported `virtual:truss.css`, i.e. the app links its stylesheet itself. */
+  let stylesheetImported = false;
   const libraryPaths = opts.libraries ?? [];
-  /** The hashed CSS filename emitted during generateBundle, used by writeBundle to patch HTML. */
-  let emittedCssFileName: string | null = null;
 
   let cssUpdateTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -109,7 +121,7 @@ export function trussPlugin(opts: TrussPluginOptions): TrussVitePlugin {
       // Notify after transforms finish, batching registry changes in this event-loop turn.
       cssUpdateTimer = setTimeout(() => {
         cssUpdateTimer = undefined;
-        devSocket?.send({ type: "custom", event: "truss:css-update" });
+        reloadVirtualStylesheet();
       }, 0);
     },
   });
@@ -123,13 +135,15 @@ export function trussPlugin(opts: TrussPluginOptions): TrussVitePlugin {
       debug = config.command === "serve" || config.mode === "development" || config.mode === "test";
       isTest = config.mode === "test";
       isBuild = config.command === "build";
-      annotate = !isBuild || Boolean(config.build?.lib);
+      isLib = Boolean(config.build?.lib);
+      annotate = !isBuild || isLib;
     },
 
     buildStart() {
       session.ensureMapping();
       // Reset registries and library cache at start of each build
       session.reset();
+      stylesheetImported = false;
       clearTimeout(cssUpdateTimer);
       cssUpdateTimer = undefined;
     },
@@ -141,50 +155,47 @@ export function trussPlugin(opts: TrussPluginOptions): TrussVitePlugin {
       // server and does not use browser CSS updates.
       if (isTest) return;
       devSocket = server.ws;
-
-      // Serve the current collected CSS at the virtual endpoint
-      server.middlewares.use((req: any, res: any, next: any) => {
-        if (req.url !== VIRTUAL_CSS_ENDPOINT) return next();
-        const css = session.collectCss(annotate);
-        res.setHeader("Content-Type", "text/css");
-        res.setHeader("Cache-Control", "no-store");
-        res.end(css);
-      });
+      devServer = server;
 
       // Cancel pending CSS updates when the server closes.
       server.httpServer?.on("close", () => {
         clearTimeout(cssUpdateTimer);
         cssUpdateTimer = undefined;
         devSocket = undefined;
+        devServer = undefined;
       });
     },
 
-    transformIndexHtml(html: string) {
-      if (isBuild) {
-        // Strip any existing truss CSS references so the hook is idempotent when
-        // a tool (e.g. Storybook) runs multiple Vite builds with the same plugin.
-        // I.e. removes /virtual:truss.css, __TRUSS_CSS_HASH__, and /assets/truss-<hash>.css
-        const stripped = html
-          .replace(/\s*<link[^>]*href=["'][^"']*virtual:truss\.css["'][^>]*\/?>/g, "")
-          .replace(/\s*<link[^>]*href=["'][^"']*__TRUSS_CSS_HASH__["'][^>]*\/?>/g, "")
-          .replace(/\s*<link[^>]*href=["'][^"']*\/assets\/truss-[0-9a-f]+\.css["'][^>]*\/?>/g, "");
-        // Inject a stylesheet link with a placeholder; writeBundle replaces it
-        // with the content-hashed filename for long-term caching.
-        const link = `<link rel="stylesheet" href="${TRUSS_CSS_PLACEHOLDER}">`;
-        return stripped.replace("</head>", `    ${link}\n  </head>`);
-      }
-      // Inject the virtual runtime script for dev mode; it owns style updates.
-      const tag = `<script type="module" src="/${VIRTUAL_RUNTIME_ID}"></script>`;
-      return html.replace("</head>", `    ${tag}\n  </head>`);
+    /**
+     * Reject an `index.html` that still links Truss's stylesheet.
+     *
+     * Truss used to write that tag itself; the app imports `virtual:truss.css` now. A leftover
+     * tag no longer names a stylesheet — in dev the URL falls through to Vite's HTML fallback,
+     * so the page silently loads `index.html` as CSS — hence failing rather than warning.
+     *
+     * Ordered pre, so the raw HTML is checked before Vite's own HTML plugin rewrites its links.
+     */
+    transformIndexHtml: {
+      order: "pre",
+      handler(html: string) {
+        if (LEGACY_CSS_LINK_RE.test(html)) {
+          throw new Error(
+            "[truss] index.html still links Truss's stylesheet. Delete that <link> tag and add " +
+              '`import "virtual:truss.css";` to your entry module instead.',
+          );
+        }
+        return html;
+      },
     },
 
     // -- Virtual module resolution --
 
     resolveId(source: string, importer: string | undefined) {
-      // Handle the dev HMR runtime virtual module
-      if (source === VIRTUAL_RUNTIME_ID || source === "/" + VIRTUAL_RUNTIME_ID) {
-        return RESOLVED_VIRTUAL_RUNTIME_ID;
+      if (source === VIRTUAL_STYLESHEET_ID) {
+        stylesheetImported = true;
+        return RESOLVED_VIRTUAL_STYLESHEET_ID;
       }
+
       if (source === VIRTUAL_TEST_CSS_ID || source === "/" + VIRTUAL_TEST_CSS_ID) {
         return RESOLVED_VIRTUAL_TEST_CSS_ID;
       }
@@ -200,40 +211,19 @@ export function trussPlugin(opts: TrussPluginOptions): TrussVitePlugin {
       // Compile test side effects without evaluating build-only CssBuilder expressions.
       if (isTest) return VIRTUAL_TEST_CSS_PREFIX + absolutePath;
 
-      // Return a virtual CSS module ID that maps back to the source .css.ts file.
-      // Strip the trailing `.ts` so the ID ends in `.css` — this tells Vite to
-      // route the loaded content through its CSS pipeline.
-      return VIRTUAL_CSS_PREFIX + absolutePath.slice(0, -3);
+      // Return a virtual module ID that maps back to the source .css.ts file. Its rules go
+      // into collectCss(), so the module itself stays JavaScript and Vite writes no stylesheet
+      // for it — a CSS module here becomes a near-empty per-route asset the document must link.
+      return VIRTUAL_CSS_PREFIX + absolutePath;
     },
 
     load(id: string) {
-      // Serve the dev HMR runtime script
-      if (id === RESOLVED_VIRTUAL_RUNTIME_ID) {
-        return `
-// Truss dev HMR runtime — keeps styles up to date without page reload
-(() => {
-  let style = document.getElementById("__truss_virtual__");
-  if (!style) {
-    style = document.createElement("style");
-    style.id = "__truss_virtual__";
-    document.head.appendChild(style);
-  }
-
-  function fetchCss() {
-    fetch("${VIRTUAL_CSS_ENDPOINT}")
-      .then((r) => r.text())
-      .then((css) => { style.textContent = css; })
-      .catch(() => {});
-  }
-
-  fetchCss();
-
-  if (import.meta.hot) {
-    import.meta.hot.on("truss:css-update", fetchCss);
-  }
-})();
-`;
+      // Dev serves the rules collected so far and pushes the rest over Vite's CSS HMR;
+      // a build gets a placeholder that generateBundle fills in.
+      if (id === RESOLVED_VIRTUAL_STYLESHEET_ID) {
+        return isBuild ? STYLESHEET_PLACEHOLDER : session.collectCss(annotate);
       }
+
       if (id === RESOLVED_VIRTUAL_TEST_CSS_ID) {
         // Vitest/jsdom has no dev server stylesheet fetch, so inject libraries
         // once; application modules deliver CSS when they evaluate.
@@ -278,23 +268,22 @@ __injectTrussCSS(${JSON.stringify(payload)});
       // Handle .css.ts virtual modules
       if (!id.startsWith(VIRTUAL_CSS_PREFIX)) return null;
 
-      // Re-add `.ts` to recover the original source file path
-      const sourcePath = id.slice(VIRTUAL_CSS_PREFIX.length) + ".ts";
+      const sourcePath = id.slice(VIRTUAL_CSS_PREFIX.length);
       const sourceCode = readFileSync(sourcePath, "utf8");
 
       // Populate the arbitrary CSS registry on first load; subsequent updates
       // happen in the transform hook when Vite re-transforms the changed file.
       session.updateArbitraryCssRegistry(sourcePath, sourceCode, diagnostics(this));
 
-      // Return an empty stylesheet to Vite's CSS pipeline — the real CSS is now
-      // served via collectCss() (dev: /virtual:truss.css, build: truss-<hash>.css)
-      // so we avoid duplicating it in Vite's own CSS bundle.
-      return `/* [truss] ${sourcePath} — included via truss.css */`;
+      // Return an empty module — the real CSS is served via collectCss(), either through
+      // the app's own `virtual:truss.css` import or, without one, the dev endpoint and the
+      // emitted truss-<hash>.css. So we avoid duplicating it in Vite's own CSS bundle.
+      return `/* [truss] ${sourcePath} — included via truss.css */\nexport {};`;
     },
 
     transform(code: string, id: string) {
-      // The virtual test module already contains compiled CSS, not source TypeScript.
-      if (id.startsWith(VIRTUAL_TEST_CSS_PREFIX)) return null;
+      // The virtual modules already contain compiled CSS or an empty body, not source TypeScript.
+      if (id.startsWith(VIRTUAL_TEST_CSS_PREFIX) || id.startsWith(VIRTUAL_CSS_PREFIX)) return null;
       // Only process JS/TS/JSX/TSX files outside node_modules
       if (!/\.[cm]?[jt]sx?(\?|$)/.test(id)) return null;
       const fileId = stripQueryAndHash(id);
@@ -346,38 +335,54 @@ __injectTrussCSS(${JSON.stringify(payload)});
 
     // -- Production CSS emission --
 
-    generateBundle(_options: any, _bundle: any) {
-      if (!isBuild) return;
-      const css = session.collectCss(annotate);
-      if (!css) return;
+    // Post, so Vite's own CSS assets are in the bundle and can be patched.
+    generateBundle: {
+      order: "post",
+      handler(_options: any, bundle: any) {
+        if (!isBuild) return;
+        const css = session.collectCss(annotate);
+        if (!css) return;
 
-      // Compute a content hash so the filename is cache-bustable.
-      const hash = createHash("sha256").update(css).digest("hex").slice(0, 8);
-      const fileName = `assets/truss-${hash}.css`;
-      emittedCssFileName = fileName;
-
-      (this as any).emitFile({
-        type: "asset",
-        fileName,
-        source: css,
-      });
-    },
-
-    /** Patch HTML files on disk to replace the CSS placeholder with the hashed filename. */
-    writeBundle(options: any, _bundle: any) {
-      if (!emittedCssFileName) return;
-      const outDir = options.dir || join(projectRoot, "dist");
-      // Find and patch all HTML files in the output directory
-      for (const entry of readdirSync(outDir)) {
-        if (!entry.endsWith(".html")) continue;
-        const htmlPath = join(outDir, entry);
-        const html = readFileSync(htmlPath, "utf8");
-        if (html.includes(TRUSS_CSS_PLACEHOLDER)) {
-          writeFileSync(htmlPath, html.replace(TRUSS_CSS_PLACEHOLDER, `/${emittedCssFileName}`), "utf8");
+        // A library has no entry module of its own to import the stylesheet, so it keeps
+        // writing a standalone file for the consuming app to merge through `libraries`.
+        if (isLib) {
+          const hash = createHash("sha256").update(css).digest("hex").slice(0, 8);
+          (this as any).emitFile({ type: "asset", fileName: `assets/truss-${hash}.css`, source: css });
+          return;
         }
-      }
+
+        if (!stylesheetImported) {
+          (this as any).warn(
+            '[truss] No module imported "virtual:truss.css", so this build ships no Truss stylesheet. ' +
+              'Add `import "virtual:truss.css";` to your entry module.',
+          );
+          return;
+        }
+
+        // The framework has already bundled, hashed and linked a stylesheet holding the
+        // placeholder, so fill that in rather than emit a file nothing links.
+        fillStylesheetPlaceholder(bundle, css);
+      },
     },
   };
+
+  /**
+   * Send new rules to a dev page that imports `virtual:truss.css`.
+   *
+   * Vite transforms modules on demand, so the load hook answers the stylesheet import with only
+   * the rules known at that moment. Reloading the module re-runs load and lets Vite's own CSS
+   * HMR replace the stylesheet, the same as editing a `.css` file would.
+   *
+   * Only the browser's copy is reloaded. Reloading the server copy makes Vite reload the whole
+   * page, which a style change does not need.
+   */
+  function reloadVirtualStylesheet(): void {
+    const client = devServer?.environments?.client ?? devServer;
+    const module = client?.moduleGraph?.getModuleById?.(RESOLVED_VIRTUAL_STYLESHEET_ID);
+    if (!module) return;
+    Promise.resolve(client.reloadModule(module)).catch(() => {});
+  }
+
   /** Reject fatal diagnostics; report the rest in the terminal and dev overlay. */
   function reportDiagnostic(context: DiagnosticContext, error: TransformDiagnostic): void {
     if ((opts.unsupportedPattern ?? (isBuild ? "error" : "warn")) === "error") {
@@ -388,6 +393,55 @@ __injectTrussCSS(${JSON.stringify(payload)});
       type: "error",
       err: { message: error.message, stack: "", id: error.id, loc: error.loc, plugin: "truss" },
     });
+  }
+}
+
+/**
+ * Put the collected stylesheet into whichever bundled CSS asset holds the `virtual:truss.css`
+ * placeholder rule.
+ *
+ * I.e. React Router bundles `import "virtual:truss.css"` into `assets/root-B1c2d3.css`, whose
+ * source starts as `.__truss_placeholder__ { --truss-placeholder: 0; }`; this replaces that rule
+ * with every rule the transforms produced, so the document's existing `<link>` carries them.
+ * The placeholder is matched as a whole rule, so a CSS minifier that reformats it still matches.
+ */
+function fillStylesheetPlaceholder(bundle: Record<string, any>, css: string): void {
+  for (const item of Object.values(bundle)) {
+    if (item.type !== "asset" || !item.fileName.endsWith(".css")) continue;
+    const source = String(item.source);
+    if (!STYLESHEET_PLACEHOLDER_RE.test(source)) continue;
+    item.source = source.replace(STYLESHEET_PLACEHOLDER_RE, css);
+    rehashStylesheet(bundle, item);
+  }
+}
+
+/**
+ * Rename a filled stylesheet so its name hashes the rules it holds.
+ *
+ * The framework hashes the asset while it still holds only the placeholder, so every build would
+ * otherwise reuse one filename and browsers would keep serving the rules they cached from an
+ * earlier deploy. I.e. `assets/root-DrDJUF32.css` becomes `assets/root-9f1c2ab3.css`, and every
+ * manifest, HTML file and chunk in this bundle that names the old file is rewritten. A name with
+ * no hash in it is left alone.
+ */
+function rehashStylesheet(bundle: Record<string, any>, item: any): void {
+  const hashed = /^(.*-)[A-Za-z0-9_-]{8}(\.css)$/.exec(item.fileName);
+  if (!hashed) return;
+  const hash = createHash("sha256").update(String(item.source)).digest("hex").slice(0, 8);
+  const oldFileName: string = item.fileName;
+  const newFileName = `${hashed[1]}${hash}${hashed[2]}`;
+  if (newFileName === oldFileName) return;
+
+  // Rename in place: Rolldown ignores new keys added to the bundle, and writes each entry
+  // under its own `fileName`, so the stale key is harmless.
+  item.fileName = newFileName;
+  for (const other of Object.values(bundle)) {
+    if (other === item) continue;
+    if (other.type === "chunk") {
+      other.code = other.code.split(oldFileName).join(newFileName);
+    } else if (typeof other.source === "string") {
+      other.source = other.source.split(oldFileName).join(newFileName);
+    }
   }
 }
 

--- a/packages/truss/src/plugin/transform-css.test.ts
+++ b/packages/truss/src/plugin/transform-css.test.ts
@@ -508,7 +508,7 @@ describe("trussPlugin .css.ts integration", () => {
     expect(resolved).toBeNull();
   });
 
-  test("load stores CSS in the arbitrary registry and returns a placeholder", () => {
+  test("load stores CSS in the arbitrary registry and returns an empty module", () => {
     const root = createTempRoot();
     writeMapping(join(root, "src", "Css.json"), {
       df: { kind: "static", defs: { display: "flex" } },
@@ -520,10 +520,10 @@ describe("trussPlugin .css.ts integration", () => {
     invokeHook(plugin.configResolved, {} as any, { root });
     invokeHook(plugin.buildStart, {} as any);
 
-    const virtualId = "\0truss-css:" + cssTs.slice(0, -3);
+    const virtualId = "\0truss-css:" + cssTs;
     const result = invokeHook(plugin.load, {} as any, virtualId);
-    // The virtual module returns a placeholder comment — real CSS is in collectCss()
-    expect(result).toBe(`/* [truss] ${cssTs} — included via truss.css */`);
+    // The virtual module returns an empty module — real CSS is in collectCss()
+    expect(result).toBe(`/* [truss] ${cssTs} — included via truss.css */\nexport {};`);
 
     // The CSS should be available via the dev virtual endpoint instead
     const css = getVirtualCss(plugin);
@@ -666,30 +666,10 @@ function n(s: string): string {
   return s.replace(/\s+/g, " ").trim();
 }
 
-/** Simulate the dev virtual CSS endpoint by invoking configureServer and calling the middleware. */
+/** Read the dev stylesheet the way an app's `import "virtual:truss.css"` does. */
 function getVirtualCss(plugin: ReturnType<typeof trussPlugin>): string {
-  let css = "";
-  const middlewares: Array<(req: unknown, res: unknown, next: unknown) => void> = [];
-  const fakeServer = {
-    middlewares: {
-      use(fn: (req: unknown, res: unknown, next: unknown) => void) {
-        middlewares.push(fn);
-      },
-    },
-    httpServer: { on() {} },
-  };
-  invokeHook(plugin.configureServer, {} as unknown, fakeServer);
-  const fakeReq = { url: "/virtual:truss.css" };
-  const fakeRes = {
-    setHeader() {},
-    end(content: string) {
-      css = content;
-    },
-  };
-  for (const mw of middlewares) {
-    mw(fakeReq, fakeRes, () => {});
-  }
-  return css;
+  const resolvedId = invokeHook(plugin.resolveId, {} as unknown, "virtual:truss.css", undefined);
+  return invokeHook(plugin.load, {} as unknown, resolvedId) as string;
 }
 
 function invokeHook(hook: unknown, thisArg: unknown, ...args: unknown[]): unknown {


### PR DESCRIPTION
Apps import their stylesheet now, instead of Truss writing a `<link>` into `index.html`:

```tsx
// src/main.tsx, or app/root.tsx for a server-rendered app
import "virtual:truss.css";
```

That is the same one line for a Vite SPA and for an app that renders its own document (React Router, Remix, TanStack Start), which has no `index.html` to write into. Vite then treats Truss's CSS like any other stylesheet — it serves it in dev, bundles and hashes it in production, and a framework such as React Router lists it in the route manifest.

## What was removed

`transformIndexHtml`'s link and script injection, the `writeBundle` HTML patching on disk, the `__TRUSS_CSS_HASH__` placeholder, the `virtual:truss:runtime` dev script, and the `/virtual:truss.css` middleware endpoint — plus the `truss:css-update` event, which had no listeners left.

Library builds (`build.lib`) still emit a standalone `assets/truss-<hash>.css`, since a library has no entry module of its own and consuming apps merge it through `libraries`.

## Upgrading

Add `import "virtual:truss.css";` to your entry module and delete the old `<link>` tag.

`transformIndexHtml` survives only as a migration check, and it throws:

```
[truss] index.html still links Truss's stylesheet. Delete that <link> tag and add
`import "virtual:truss.css";` to your entry module instead.
```

Failing rather than warning is deliberate: a leftover `/virtual:truss.css` now falls through to Vite's SPA HTML fallback and returns `index.html` with `Content-Type: text/html`, so the page silently loads HTML as a stylesheet.

If the tag is gone but nothing imports the stylesheet, the build warns instead:

```
[truss] No module imported "virtual:truss.css", so this build ships no Truss stylesheet.
Add `import "virtual:truss.css";` to your entry module.
```

That one is a warning, not an error, because a multi-environment build runs `generateBundle` per environment and an SSR environment legitimately has no stylesheet to ship.

## Two things worth reviewing

**`rehashStylesheet`.** The framework hashes the stylesheet while it still holds the build placeholder, so without this the filename never changes when the CSS does and browsers serve stale rules after a deploy. Confirmed on a real app: 28.94 kB → 28.99 kB with the name stuck at `root-DrDJUF32.css`. The fix renames the asset to hash its final contents and rewrites every manifest, chunk and HTML reference in the bundle. It renames in place on `item.fileName`, because Rolldown ignores new keys added to `bundle`.

**`.css.ts` side effects.** `x.css.ts?truss-css` loads as `export {}` rather than a comment-only stylesheet, which was becoming a near-empty per-route CSS file the document had to link. The real `.css.ts` module keeps its named exports.

## Verification

- **SPA** (`packages/app`, migrated here): one `assets/index-<hash>.css` that Vite links itself; dev `<head>` is just `@vite/client` and `main.tsx`.
- **SSR** (React Router app in the css-in-js-arena): one `root-<hash>.css` linked on all six routes, down from a 70-line local plugin plus 14 lines of hand-injected dev script.
- Dev HMR: editing a route logs `hmr update virtual:truss.css` and serves the new rules; the stylesheet grows as modules transform.
- Stale link fails the build; missing import warns.
- 572 tests green, prettier clean, `tsc --build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
